### PR TITLE
修复：群聊历史拉取增加“时间范围早停”，避免海量无效 API 请求风险

### DIFF
--- a/NapCatQQ/src/qq-chat-exporter/types/index.ts
+++ b/NapCatQQ/src/qq-chat-exporter/types/index.ts
@@ -156,6 +156,8 @@ export interface BatchFetchResult {
     actualCount: number;
     /** 获取耗时（毫秒） */
     fetchTime: number;
+    /** 批次中最早消息的时间（毫秒） */
+    earliestMsgTime?: number;
 }
 
 /**


### PR DESCRIPTION
在处理超长历史群聊时，现有的批量消息拉取逻辑存在一个性能上的风险：

1.  即使用户设定了精确的时间筛选范围（例如只筛选**最近一个月**的消息）。
2.  代码仍然会不断向后回溯，通过 API 拉取一批又一批消息（每批约 5000 条），直到非常早的历史。
3.  这个过程中，大部分 API 调用拉回的消息，都会在客户端被判定为超出时间范围而丢弃。
4.  这导致了大量不必要的 API 调用（超过 40 万次），极易触发平台限制，造成拉取失败或耗时过长。

**修复：** 我为拉取逻辑增加了一个“**提前停止**”机制，一旦拉取到的消息时间早于筛选的开始时间，且当前批次已为空，系统就会立即停止回溯，从而彻底解决无效 API 调用的问题。

我现在做出了下面2个修改：
- 文件：
  - `BatchMessageFetcher.ts`
    - 在批量拉取的主循环中加入防御性提前停止判断：如果本批次客户端筛选后为空，且批次最早时间早于筛选开始时间，则直接停止继续回溯。 `fetchAllMessagesInTimeRange`
    - 在处理 API 结果时计算批次最早消息时间 earliestMsgTime（统一为毫秒），并在 earliestMsgTime < filter.startTime 时将 hasMore 置为 false，同时清空下一批次标识，触发早停。 `processApiResult`
  - `index.ts`
    - 增加了 BatchFetchResult 的可选字段 earliestMsgTime，用于在批次结果中携带“该批次最早消息时间（毫秒）”。 `BatchFetchResult`
- 时间单位对齐：
  - fetchAllMessagesInTimeRange 的参数 startTime、endTime 在项目调用处使用的是毫秒（例如 ApiServer 中传入的是 startTimeMs/endTimeMs），我在早停逻辑中已将 earliestMsgTime 统一为毫秒再比较，确保判断正确。