### PR TITLE
feat: 群/好友头像导出支持

### DIFF
--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -2540,9 +2540,17 @@ export class QQChatExporterApiServer {
             task = this.exportTasks.get(taskId);
             const chatName = task?.sessionName || peer.peerUid;
             const selfInfo = this.core.selfInfo;
+            
+            // 获取聊天头像 URL
+            const isGroup = peer.chatType === ChatType.Group || peer.chatType === 2;
+            const chatAvatar = isGroup 
+                ? `https://p.qlogo.cn/gh/${peer.peerUid}/${peer.peerUid}/640/`
+                : `https://q1.qlogo.cn/g?b=qq&nk=${peer.peerUid}&s=640`;
+            
             const chatInfo = {
                 name: chatName,
-                type: (peer.chatType === ChatType.Group || peer.chatType === 2 ? 'group' : 'private') as 'group' | 'private',
+                type: (isGroup ? 'group' : 'private') as 'group' | 'private',
+                avatar: chatAvatar,
                 selfUid: selfInfo?.uid,
                 selfUin: selfInfo?.uin,
                 selfName: selfInfo?.nick


### PR DESCRIPTION
## 功能描述

为 JSON 导出添加群/好友头像支持：

- 在 chatInfo 中添加 avatar 字段，包含群/好友头像 URL
- 群头像格式：https://p.qlogo.cn/gh/{groupCode}/{groupCode}/640/
- 好友头像格式：https://q1.qlogo.cn/g?b=qq&nk={uin}&s=640
- 如果启用了 embedAvatarsAsBase64 选项，会自动将头像下载并转换为 base64 格式

## 修改文件

- ApiServer.ts: 添加 avatar 字段到 chatInfo
- JsonExporter.ts: 添加 formatChatInfoAsync 和 downloadUrlAsBase64 方法支持 base64 转换

## 测试

- [ ] JSON 导出包含群头像 URL
- [ ] JSON 导出包含好友头像 URL
- [ ] 启用 base64 选项时，头像正确转换为 base64