### PR TITLE
fix(#189): 使用懒加载自动加载所有好友/群组数据

### DIFF
--- a/qce-v4-tool/components/ui/scheduled-export-wizard.tsx
+++ b/qce-v4-tool/components/ui/scheduled-export-wizard.tsx
@@ -170,10 +170,10 @@ export function ScheduledExportWizard({
   // 初始化搜索数据
   useEffect(() => {
     if (isOpen && groups.length > 0 && groupSearchRef.current.allData.length === 0) {
-      groupSearchRef.current.load(1, 999)
+      groupSearchRef.current.load()
     }
     if (isOpen && friends.length > 0 && friendSearchRef.current.allData.length === 0) {
-      friendSearchRef.current.load(1, 999)
+      friendSearchRef.current.load()
     }
   }, [isOpen, groups.length, friends.length])
 
@@ -391,8 +391,8 @@ export function ScheduledExportWizard({
                       variant="outline"
                       size="sm"
                       onClick={() => {
-                        if (currentChatTypeRef.current === 2) groupSearchRef.current.load(1, 999)
-                        else friendSearchRef.current.load(1, 999)
+                        if (currentChatTypeRef.current === 2) groupSearchRef.current.load()
+                        else friendSearchRef.current.load()
                       }}
                       disabled={(currentChatType === 2 ? groupSearch : friendSearch).loading}
                       className="rounded-full"

--- a/qce-v4-tool/components/ui/task-wizard.tsx
+++ b/qce-v4-tool/components/ui/task-wizard.tsx
@@ -151,10 +151,10 @@ export function TaskWizard({
 
   useEffect(() => {
     if (isOpen && groups.length > 0 && groupSearchRef.current.allData.length === 0) {
-      groupSearchRef.current.load(1, 999)
+      groupSearchRef.current.load()
     }
     if (isOpen && friends.length > 0 && friendSearchRef.current.allData.length === 0) {
-      friendSearchRef.current.load(1, 999)
+      friendSearchRef.current.load()
     }
   }, [isOpen, groups.length, friends.length])
 
@@ -364,8 +364,8 @@ export function TaskWizard({
               variant="outline"
               size="sm"
               onClick={() => {
-                if (currentChatTypeRef.current === 2) groupSearchRef.current.load(1, 999)
-                else friendSearchRef.current.load(1, 999)
+                if (currentChatTypeRef.current === 2) groupSearchRef.current.load()
+                else friendSearchRef.current.load()
               }}
               disabled={s.loading}
               className="rounded-full"


### PR DESCRIPTION
## 问题描述
修复 #189 - 好友只能显示 1000 个，无法选中和搜索 1500+ 好友的问题

## 解决方案
使用懒加载优化（如评论中提到的方案）：

1. 修改 use-search hook：
   - 使用递归懒加载自动获取全部数据
   - 每次请求 200 条数据，自动继续加载直到全部完成
   - 使用 useRef 存储函数引用支持递归调用
   - 加载过程中保持 loading 状态，用户可以看到加载进度

2. 更新前端组件：
   - 移除 task-wizard.tsx 和 scheduled-export-wizard.tsx 中硬编码的 999 限制
   - 使用默认参数调用 load 函数

## 技术细节
- 每批加载 200 条数据，间隔 50ms 继续加载下一批
- 避免一次性请求大量数据导致的性能问题
- 保持现有的前端搜索过滤功能不变

## 测试
- [x] 支持 1500+ 好友的用户正常选择和搜索
- [x] 群组列表同样支持自动加载全部
- [x] 搜索功能正常工作
