### PR TITLE
fix(ui): remove AnimatePresence to fix Edge DOM errors (#200)

### DIFF
--- a/qce-v4-tool/components/loading-provider.tsx
+++ b/qce-v4-tool/components/loading-provider.tsx
@@ -20,9 +20,11 @@ export function useLoading() {
 
 export function LoadingProvider({ children }: { children: React.ReactNode }) {
   const [isLoading, setIsLoading] = useState(true)
-  const [hasShownInitialLoad, setHasShownInitialLoad] = useState(false)
+  const [isMounted, setIsMounted] = useState(false)
 
   useEffect(() => {
+    setIsMounted(true)
+    
     // Check if this is the first visit
     const hasVisited = localStorage.getItem('qce-has-visited')
     
@@ -34,8 +36,6 @@ export function LoadingProvider({ children }: { children: React.ReactNode }) {
       // Not first time - skip loading
       setIsLoading(false)
     }
-    
-    setHasShownInitialLoad(true)
   }, [])
 
   const setLoading = (loading: boolean) => {
@@ -48,12 +48,10 @@ export function LoadingProvider({ children }: { children: React.ReactNode }) {
 
   return (
     <LoadingContext.Provider value={{ isLoading, setLoading }}>
-      <>
-        {hasShownInitialLoad && (
-          <LoadingScreen isLoading={isLoading} onComplete={handleLoadingComplete} />
-        )}
-        {children}
-      </>
+      {isMounted && (
+        <LoadingScreen isLoading={isLoading} onComplete={handleLoadingComplete} />
+      )}
+      {children}
     </LoadingContext.Provider>
   )
 }


### PR DESCRIPTION
## Summary
Fixes #200, #199, #197 - Edge browser DOM errors (insertBefore/emoveChild)

## Root Cause
Edge browser (v143+) and browser extensions inject DOM nodes during page load. When React's AnimatePresence tries to animate elements in/out, it fails because the expected DOM structure has been modified.

The previous fix (v5.0.4) using suppressHydrationWarning only suppressed warnings but didn't prevent the actual DOM operation failures.

## Solution
- Remove AnimatePresence and motion components from AuthProvider
- Use simple conditional rendering instead of animated transitions
- Add isMounted state to ensure client-side only rendering
- Simplify LoadingProvider to avoid DOM structure issues

## Why This Works
By avoiding AnimatePresence entirely, we eliminate the complex DOM operations (insertBefore, removeChild) that fail when browser extensions modify the DOM. The loading state now uses simple CSS transitions instead.

## Testing
- [x] Build passes
- [x] No TypeScript errors
- [x] Works in Firefox (confirmed by user)
- [x] Should work in Edge (removes problematic code)