### PR TITLE
fix: 为 Release 产物文件名添加版本号

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -86,12 +86,13 @@ jobs:
         env:
           NODE_ENV: production
           NODE_OPTIONS: --max-old-space-size=4096
+          QCE_VERSION: ${{ github.ref_name }}
       
       - name: "[x] 上传主包构建产物"
         uses: actions/upload-artifact@v4
         with:
           name: NapCat-QCE-${{ matrix.platform }}-${{ matrix.arch }}
-          path: NapCat-QCE-${{ matrix.platform }}-${{ matrix.arch }}.${{ matrix.artifact_ext }}
+          path: NapCat-QCE-${{ matrix.platform }}-${{ matrix.arch }}-${{ github.ref_name }}.${{ matrix.artifact_ext }}
           retention-days: 7
       
 
@@ -172,8 +173,8 @@ jobs:
 
           | 平台 | 状态 | 文件 |
           |------|------|------|
-          | Windows 10/11 x64 | ✅ 完全支持 | \`NapCat-QCE-Windows-x64.zip\` |
-          | Linux x64 | ✅ 应该支持 | \`NapCat-QCE-Linux-x64.tar.gz\` |
+          | Windows 10/11 x64 | ✅ 完全支持 | \`NapCat-QCE-Windows-x64-${VERSION}.zip\` |
+          | Linux x64 | ✅ 应该支持 | \`NapCat-QCE-Linux-x64-${VERSION}.tar.gz\` |
           | macOS | ⚠️ 暂不支持 | 因兼容性问题暂不提供 |
 
           <details>
@@ -240,8 +241,8 @@ jobs:
           echo "包含 NapCat ${{ needs.get-napcat-version.outputs.version }}"
           echo "========================================="
           echo "发布的文件："
-          echo "- ✅ NapCat-QCE-Windows-x64.zip"
-          echo "- ✅ NapCat-QCE-Linux-x64.tar.gz"
+          echo "- ✅ NapCat-QCE-Windows-x64-${{ github.ref_name }}.zip"
+          echo "- ✅ NapCat-QCE-Linux-x64-${{ github.ref_name }}.tar.gz"
           echo "- ⚠️  macOS 因兼容性问题暂不发布"
           echo "========================================="
 

--- a/scripts/quick-pack.py
+++ b/scripts/quick-pack.py
@@ -13,7 +13,20 @@ from pathlib import Path
 from urllib.request import urlretrieve, urlopen
 from datetime import datetime
 
-VERSION = "4.0.0-test"
+def get_qce_version():
+    """Get QCE version from package.json or environment variable"""
+    # Priority: QCE_VERSION env > package.json
+    if os.environ.get('QCE_VERSION'):
+        return os.environ['QCE_VERSION'].lstrip('v')
+    
+    try:
+        with open('plugins/qq-chat-exporter/package.json', 'r', encoding='utf-8') as f:
+            pkg = json.load(f)
+            return pkg.get('version', 'unknown')
+    except:
+        return 'unknown'
+
+VERSION = get_qce_version()
 
 def get_platform_info():
     """Detect current platform"""
@@ -99,9 +112,18 @@ def main():
     
     # Detect platform
     os_name, arch, archive_ext = get_platform_info()
+    
+    # Get QCE version for output filename
+    qce_version = VERSION
+    print(f"[*] QCE Version: {qce_version}")
+    
+    # Directory name (without version for internal use)
     pack_dir = f"NapCat-QCE-{os_name}-{arch}"
+    # Output filename (with version)
+    output_basename = f"NapCat-QCE-{os_name}-{arch}-v{qce_version}"
+    
     print(f"[*] Platform: {os_name} {arch}")
-    print(f"[*] Package: {pack_dir}")
+    print(f"[*] Package: {output_basename}")
     print()
     
     # Get NapCat version
@@ -566,9 +588,9 @@ QCE 版本: {VERSION}
     print("[x] Created")
     print()
     
-    # Create main archive
+    # Create main archive (with version in filename)
     print("[11/11] Creating main archive...")
-    output_file = f"{pack_dir}{archive_ext}"
+    output_file = f"{output_basename}{archive_ext}"
     create_archive(pack_dir, output_file, archive_ext)
     print()
     


### PR DESCRIPTION
## Summary

为 Release 产物文件名添加版本号，使下载的文件更易于识别和管理。

## Changes

### scripts/quick-pack.py
- 新增 `get_qce_version()` 函数，从 `QCE_VERSION` 环境变量或 `package.json` 读取版本
- 输出文件名格式改为：`NapCat-QCE-{platform}-{arch}-v{version}.{ext}`
- 例如：`NapCat-QCE-Windows-x64-v5.0.14.zip`

### .github/workflows/release-plugin.yml
- 构建时传递 `QCE_VERSION` 环境变量（值为 Git tag）
- 更新 artifact 上传路径匹配新文件名格式
- 更新 release notes 模板中的文件名显示

## Before vs After

| Before | After |
|--------|-------|
| `NapCat-QCE-Windows-x64.zip` | `NapCat-QCE-Windows-x64-v5.0.14.zip` |
| `NapCat-QCE-Linux-x64.tar.gz` | `NapCat-QCE-Linux-x64-v5.0.14.tar.gz` |
