### PR TITLE
feat: 改进 PR/dev 构建产物命名

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -31,32 +31,52 @@ jobs:
     runs-on: ${{ matrix.os }}
     
     steps:
-      - name: "[1/4] Checkout repository"
+      - name: "[1/5] Checkout repository"
         uses: actions/checkout@v4
       
-      - name: "[2/4] Setup Node.js & pnpm"
+      - name: "[2/5] Setup Node.js & pnpm"
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
       
-      - name: "[3/4] Setup pnpm"
+      - name: "[3/5] Setup pnpm"
         uses: pnpm/action-setup@v4
         with:
           version: 8
       
-      - name: "[4/4] Build complete package"
+      - name: "[4/5] Generate build version"
+        id: version
+        run: |
+          # 从 package.json 读取基础版本
+          BASE_VERSION=$(node -p "require('./plugins/qq-chat-exporter/package.json').version")
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            # PR 构建: v5.0.12-pr123-abc1234
+            VERSION="${BASE_VERSION}-pr${{ github.event.pull_request.number }}-${SHORT_SHA}"
+          else
+            # Push 构建: v5.0.12-dev-abc1234
+            VERSION="${BASE_VERSION}-dev-${SHORT_SHA}"
+          fi
+          
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Generated version: ${VERSION}"
+        shell: bash
+      
+      - name: "[5/5] Build complete package"
         run: python${{ matrix.platform == 'Windows' && '' || '3' }} scripts/quick-pack.py
         env:
           NODE_ENV: production
           NODE_OPTIONS: --max-old-space-size=4096
+          QCE_VERSION: ${{ steps.version.outputs.version }}
       
       - name: "Upload build artifact"
         uses: actions/upload-artifact@v4
         with:
-          name: NapCat-QCE-${{ matrix.platform }}-${{ matrix.arch }}
+          name: NapCat-QCE-${{ matrix.platform }}-${{ matrix.arch }}-${{ steps.version.outputs.version }}
           path: NapCat-QCE-${{ matrix.platform }}-${{ matrix.arch }}*
           retention-days: 7
       
       - name: "Build complete"
-        run: echo "${{ matrix.platform }}-${{ matrix.arch }} build completed"
+        run: echo "${{ matrix.platform }}-${{ matrix.arch }} build completed (version: ${{ steps.version.outputs.version }})"
 


### PR DESCRIPTION
让 PR 和普通 push 构建的产物包含更多信息：

**命名格式：**
- PR 构建：\NapCat-QCE-Windows-x64-v5.0.12-pr123-abc1234\
- Push 构建：\NapCat-QCE-Windows-x64-v5.0.12-dev-abc1234\

**包含信息：**
- 基础版本号（从 package.json 读取）
- 构建类型（pr/dev）
- PR 编号（仅 PR 构建）
- Commit SHA 前 7 位

这样可以轻松识别每个构建产物的来源和版本。