### PR TITLE
fix: scheduled export custom output directory not working

### DIFF
--- a/qce-v4-tool/hooks/use-scheduled-exports.ts
+++ b/qce-v4-tool/hooks/use-scheduled-exports.ts
@@ -83,7 +83,6 @@ export function useScheduledExports() {
         try {
             setLoading(true);
             
-            // 将表单数据转换为API配置格式
             const config: ScheduledExportConfig = {
                 name: formData.name,
                 peer: {
@@ -103,6 +102,7 @@ export function useScheduledExports() {
                     filterPureImageMessages: formData.filterPureImageMessages ?? false,
                     prettyFormat: true,
                 },
+                ...(formData.outputDir?.trim() && { outputDir: formData.outputDir.trim() }),
                 enabled: formData.enabled,
             };
             


### PR DESCRIPTION
## Problem

Fix Issue #234: Custom output directory not working for scheduled export tasks.

When users create a scheduled export task with a custom save path, the files are still saved to the default path `%USERPROFILE%\.qq-chat-exporter\scheduled-exports`.

## Root Cause

The `createTask` function in `qce-v4-tool/hooks/use-scheduled-exports.ts` omits the `outputDir` field when building the configuration object, preventing it from being sent to the backend.

### Call Chain Analysis

```
User Input (scheduled-export-wizard.tsx)
  -> outputDir field exists
Form Submit (scheduled-export-wizard.tsx:200)
  -> includes outputDir
Hook Processing (use-scheduled-exports.ts:createTask)
  -> MISSING outputDir field (root cause)
API Request (POST /api/scheduled-exports)
  -> config without outputDir
Backend Receives (ApiServer.ts:2148)
  -> passes config as-is
Scheduler Creates (ScheduledExportManager.ts:createScheduledExport)
  -> task.outputDir = undefined
Task Execution (ScheduledExportManager.ts:537)
  -> outputDir || default path
Result: Uses default path
```

## Solution

Add conditional `outputDir` field passing in the `createTask` function:

```typescript
const config: ScheduledExportConfig = {
    // ... other fields
    ...(formData.outputDir?.trim() && { outputDir: formData.outputDir.trim() }),
    enabled: formData.enabled,
};
```

### Technical Details

1. Conditional spreading: Only adds `outputDir` field when value exists
2. Input sanitization: Uses `trim()` to remove leading/trailing whitespace
3. Type safety: Uses optional chaining to handle undefined/null
4. Backward compatibility: Backend has default value fallback

## Verification

### Type Safety
- `CreateScheduledExportForm` includes `outputDir?: string`
- `ScheduledExport` includes `outputDir?: string`
- Frontend and backend type definitions are consistent

### Edge Cases
- Empty string: Filtered by `trim()`, not passed
- Whitespace only: Filtered by `trim()`, not passed
- undefined/null: Safely handled by optional chaining
- Valid path: Correctly passed and used

### Functionality
- Create task: Custom path is passed
- Update task: Path modification is supported
- Backend: Correctly uses custom or default path

## Impact

- Modified file: `qce-v4-tool/hooks/use-scheduled-exports.ts`
- Affected feature: Custom save path for scheduled exports
- Backward compatibility: Fully compatible
- Risk assessment: Low risk, only adds field passing logic

## Related Issue

Closes #234
