### PR TITLE
feat: 批量导出模式下立即显示全选按钮 (#248)

### DIFF
--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -1445,36 +1445,40 @@ export default function QCEDashboard() {
                         {batchMode ? "退出批量模式" : "批量导出"}
                       </Button>
                     </motion.div>
-                    {batchMode && selectedItems.size > 0 && (
+                    {batchMode && (
                       <>
                         <motion.div whileTap={{ scale: 0.98 }}>
                           <Button 
-                            onClick={handleOpenBatchExportDialog} 
-                            className="rounded-full"
-                          >
-                            导出选中 ({selectedItems.size})
-                          </Button>
-                        </motion.div>
-                        <motion.div whileTap={{ scale: 0.98 }}>
-                          <Button 
                             onClick={handleSelectAll} 
-                            variant="ghost" 
+                            variant="outline" 
                             size="sm" 
                             className="rounded-full"
                           >
                             全选
                           </Button>
                         </motion.div>
-                        <motion.div whileTap={{ scale: 0.98 }}>
-                          <Button 
-                            onClick={handleClearSelection} 
-                            variant="ghost" 
-                            size="sm" 
-                            className="rounded-full"
-                          >
-                            清空
-                          </Button>
-                        </motion.div>
+                        {selectedItems.size > 0 && (
+                          <>
+                            <motion.div whileTap={{ scale: 0.98 }}>
+                              <Button 
+                                onClick={handleClearSelection} 
+                                variant="ghost" 
+                                size="sm" 
+                                className="rounded-full"
+                              >
+                                清空
+                              </Button>
+                            </motion.div>
+                            <motion.div whileTap={{ scale: 0.98 }}>
+                              <Button 
+                                onClick={handleOpenBatchExportDialog} 
+                                className="rounded-full"
+                              >
+                                导出选中 ({selectedItems.size})
+                              </Button>
+                            </motion.div>
+                          </>
+                        )}
                       </>
                     )}
                   </div>


### PR DESCRIPTION
## 概述

修复批量导出模式下"全选"按钮的显示逻辑，解决 #248 中用户反馈的问题。

## 问题

之前的实现中，"全选"按钮只有在用户已经选择了至少一个会话后才会显示。这导致用户需要手动逐个点击才能看到全选按钮，对于好友/群组数量较多的用户非常不便。

## 修复内容

- 进入批量模式后立即显示"全选"按钮
- "清空"和"导出选中"按钮仍然只在有选中项时显示
- 按钮顺序调整为：全选 → 清空 → 导出选中

## 测试

- [x] 进入批量模式后"全选"按钮立即可见
- [x] 点击"全选"后所有群组和好友被选中
- [x] 选中项数量正确显示
- [x] 前端构建通过

Closes #248
