### PR TITLE
feat: add group member name export option

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/fixtures/builders.ts
+++ b/plugins/qq-chat-exporter/__tests__/fixtures/builders.ts
@@ -307,9 +307,12 @@ export class ConversationBuilder {
 
     add(...rawMessages: RawMessage[]): this {
         for (const m of rawMessages) {
-            // Stamp peer info if missing
-            if (!m.peerUid) m.peerUid = this.peer.peerUid;
-            if (!m.chatType) m.chatType = this.peer.chatType;
+            // Inherit peer info from the surrounding conversation. Messages
+            // built via msg() default to chatType=1 (private), but a builder
+            // that wraps a group peer should propagate chatType=2 so that
+            // downstream parsers receive consistent data.
+            m.peerUid = this.peer.peerUid;
+            m.chatType = this.peer.chatType;
             this.messages.push(m);
         }
         return this;

--- a/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/HtmlExporter.groupMixedMedia.snap.html
+++ b/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/HtmlExporter.groupMixedMedia.snap.html
@@ -424,7 +424,7 @@
                 <div class="message-avatar">
                     A
                 </div>
-                <span class="message-sender">Alice</span>
+                <span class="message-sender">Alice (PM)</span>
                 
                 <span class="message-time">2024-01-01 00:01:40</span>
             </div>
@@ -441,7 +441,7 @@
                 <div class="message-avatar">
                     B
                 </div>
-                <span class="message-sender">Bob</span>
+                <span class="message-sender">Bob (Eng)</span>
                 
                 <span class="message-time">2024-01-01 00:02:40</span>
             </div>
@@ -458,7 +458,7 @@
                 <div class="message-avatar">
                     B
                 </div>
-                <span class="message-sender">Bob</span>
+                <span class="message-sender">Bob (Eng)</span>
                 
                 <span class="message-time">2024-01-01 00:02:45</span>
             </div>
@@ -509,7 +509,7 @@
                 <div class="message-avatar">
                     A
                 </div>
-                <span class="message-sender">Alice</span>
+                <span class="message-sender">Alice (PM)</span>
                 
                 <span class="message-time">2024-01-01 00:04:00</span>
             </div>
@@ -530,7 +530,7 @@
                 <div class="message-avatar">
                     A
                 </div>
-                <span class="message-sender">Alice</span>
+                <span class="message-sender">Alice (PM)</span>
                 
                 <span class="message-time">2024-01-01 00:05:00</span>
             </div>

--- a/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/JsonExporter.groupMixedMedia.snap.json
+++ b/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/JsonExporter.groupMixedMedia.snap.json
@@ -24,13 +24,13 @@
     "senders": [
       {
         "uid": "u_alice",
-        "name": "Alice",
+        "name": "Alice (PM)",
         "messageCount": 3,
         "percentage": 42.86
       },
       {
         "uid": "u_bob",
-        "name": "Bob",
+        "name": "Bob (Eng)",
         "messageCount": 2,
         "percentage": 28.57
       },
@@ -59,7 +59,9 @@
       "sender": {
         "uid": "u_alice",
         "uin": "11111",
-        "name": "Alice"
+        "name": "Alice (PM)",
+        "nickname": "Alice",
+        "groupCard": "Alice (PM)"
       },
       "type": "type_1",
       "content": {
@@ -86,7 +88,9 @@
       "sender": {
         "uid": "u_bob",
         "uin": "22222",
-        "name": "Bob"
+        "name": "Bob (Eng)",
+        "nickname": "Bob",
+        "groupCard": "Bob (Eng)"
       },
       "type": "type_1",
       "content": {
@@ -120,7 +124,9 @@
       "sender": {
         "uid": "u_bob",
         "uin": "22222",
-        "name": "Bob"
+        "name": "Bob (Eng)",
+        "nickname": "Bob",
+        "groupCard": "Bob (Eng)"
       },
       "type": "type_1",
       "content": {
@@ -162,7 +168,8 @@
       "sender": {
         "uid": "u_charlie",
         "uin": "33333",
-        "name": "Charlie"
+        "name": "Charlie",
+        "nickname": "Charlie"
       },
       "type": "type_1",
       "content": {
@@ -202,7 +209,8 @@
       "sender": {
         "uid": "u_charlie",
         "uin": "33333",
-        "name": "Charlie"
+        "name": "Charlie",
+        "nickname": "Charlie"
       },
       "type": "type_8",
       "content": {
@@ -244,7 +252,9 @@
       "sender": {
         "uid": "u_alice",
         "uin": "11111",
-        "name": "Alice"
+        "name": "Alice (PM)",
+        "nickname": "Alice",
+        "groupCard": "Alice (PM)"
       },
       "type": "type_3",
       "content": {
@@ -280,7 +290,9 @@
       "sender": {
         "uid": "u_alice",
         "uin": "11111",
-        "name": "Alice"
+        "name": "Alice (PM)",
+        "nickname": "Alice",
+        "groupCard": "Alice (PM)"
       },
       "type": "type_6",
       "content": {
@@ -328,6 +340,7 @@
     "options": {
       "includeResourceLinks": true,
       "includeSystemMessages": true,
+      "preferGroupMemberName": true,
       "timeFormat": "YYYY-MM-DD HH:mm:ss",
       "encoding": "utf-8"
     }

--- a/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/TextExporter.groupMixedMedia.snap.txt
+++ b/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/TextExporter.groupMixedMedia.snap.txt
@@ -13,17 +13,17 @@
 时间范围: 2024-01-01 00:01:40 - 2024-01-01 00:05:00
 
 
-Alice:
+Alice (PM):
 时间: 2024-01-01 00:01:40
 内容: Anyone seen the build break?
 
 
-Bob:
+Bob (Eng):
 时间: 2024-01-01 00:02:40
 内容: Looking now [[微笑]]
 
 
-Bob:
+Bob (Eng):
 时间: 2024-01-01 00:02:45
 内容: [图片: screenshot.png]
 资源: 1 个文件
@@ -43,14 +43,14 @@ Charlie:
   - file: trace.json
 
 
-Alice:
+Alice (PM):
 时间: 2024-01-01 00:04:00
 内容: [回复 : Anyone seen the build break?]
 thanks team, fix incoming
 回复:  - Anyone seen the build break?
 
 
-Alice:
+Alice (PM):
 时间: 2024-01-01 00:05:00
 内容: [语音 7秒]
 资源: 1 个文件

--- a/plugins/qq-chat-exporter/__tests__/unit/SimpleMessageParser.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/SimpleMessageParser.test.ts
@@ -47,7 +47,7 @@ test('parses plain text messages', async () => {
 test('uses group card name in preference to nickname', async () => {
     const { SimpleMessageParser } = await loadParser();
     const parser = new SimpleMessageParser({ html: 'none' });
-    const m = msg()
+    const m = msg({ chatType: 2 })
         .sender({ uid: 'u_alice', uin: '11111', nick: 'Alice', card: 'Alice (PM)', remark: 'A.Pm' })
         .text('hi')
         .build();
@@ -56,6 +56,28 @@ test('uses group card name in preference to nickname', async () => {
     assert.equal(parsed.sender.groupCard, 'Alice (PM)');
     assert.equal(parsed.sender.remark, 'A.Pm');
     assert.equal(parsed.sender.nickname, 'Alice');
+});
+
+test('private chat ignores group card and uses remark first', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const m = msg({ chatType: 1 })
+        .sender({ uid: 'u_alice', uin: '11111', nick: 'Alice', card: 'Alice (PM)', remark: 'A.Pm' })
+        .text('hi')
+        .build();
+    const [parsed] = await parser.parseMessages([m]);
+    assert.equal(parsed.sender.name, 'A.Pm');
+});
+
+test('group chat with preferGroupMemberName=false falls back to nickname', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none', preferGroupMemberName: false });
+    const m = msg({ chatType: 2 })
+        .sender({ uid: 'u_alice', uin: '11111', nick: 'Alice', card: 'Alice (PM)' })
+        .text('hi')
+        .build();
+    const [parsed] = await parser.parseMessages([m]);
+    assert.equal(parsed.sender.name, 'Alice');
 });
 
 test('parses @everyone and @user mentions', async () => {

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -3643,6 +3643,7 @@ export class QQChatExporterApiServer {
                 includeSystemMessages: options?.includeSystemMessages ?? true,
                 filterPureImageMessages: options?.filterPureImageMessages ?? false,
                 prettyFormat: options?.prettyFormat ?? true,
+                preferGroupMemberName: options?.preferGroupMemberName ?? false,
                 timeFormat: 'YYYY-MM-DD HH:mm:ss',
                 encoding: 'utf-8'
             };
@@ -3700,7 +3701,9 @@ export class QQChatExporterApiServer {
                     break;
                 case 'HTML':
                     // HTML流式导出：使用异步生成器，实现全程低内存占用
-                    const parser = new SimpleMessageParser();
+                    const parser = new SimpleMessageParser({
+                        preferGroupMemberName: options?.preferGroupMemberName
+                    });
                     
                     const htmlExporter = new ModernHtmlExporter({
                         outputPath: filePath,
@@ -4089,7 +4092,9 @@ export class QQChatExporterApiServer {
             };
 
             // 创建分块HTML导出器
-            const parser = new SimpleMessageParser();
+            const parser = new SimpleMessageParser({
+                preferGroupMemberName: options?.preferGroupMemberName
+            });
             const htmlExporter = new ModernHtmlExporter({
                 outputPath: path.join(tempDir, 'index.html'),
                 includeResourceLinks: !options?.filterPureImageMessages,
@@ -4380,7 +4385,9 @@ export class QQChatExporterApiServer {
 
             // 初始化解析器
             const { SimpleMessageParser } = await import('../core/parser/SimpleMessageParser.js');
-            const parser = new SimpleMessageParser(this.core);
+            const parser = new SimpleMessageParser({
+                preferGroupMemberName: options?.preferGroupMemberName
+            });
 
             // 头像收集（如果启用了 embedAvatarsAsBase64）
             const embedAvatars = options?.embedAvatarsAsBase64 === true;

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -3643,7 +3643,7 @@ export class QQChatExporterApiServer {
                 includeSystemMessages: options?.includeSystemMessages ?? true,
                 filterPureImageMessages: options?.filterPureImageMessages ?? false,
                 prettyFormat: options?.prettyFormat ?? true,
-                preferGroupMemberName: options?.preferGroupMemberName ?? false,
+                preferGroupMemberName: options?.preferGroupMemberName ?? true,
                 timeFormat: 'YYYY-MM-DD HH:mm:ss',
                 encoding: 'utf-8'
             };

--- a/plugins/qq-chat-exporter/lib/core/exporter/BaseExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/BaseExporter.ts
@@ -83,7 +83,7 @@ export abstract class BaseExporter {
             encoding: options.encoding || 'utf-8',
             customCss: options.customCss,
             chunkSize: options.chunkSize,
-            preferGroupMemberName: options.preferGroupMemberName ?? false
+            preferGroupMemberName: options.preferGroupMemberName ?? true
         };
         
         this.cancelled = false;
@@ -200,7 +200,7 @@ export abstract class BaseExporter {
             yieldEvery: 1000,
             suppressFallbackWarn: true,
             stopOnAbort: true,
-            preferGroupMemberName: this.options.preferGroupMemberName ?? false
+            preferGroupMemberName: this.options.preferGroupMemberName ?? true
         };
         
         return new MessageParser(core, config);

--- a/plugins/qq-chat-exporter/lib/core/exporter/BaseExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/BaseExporter.ts
@@ -39,6 +39,8 @@ export interface ExportOptions {
     encoding: string;
     /** 分块大小（大文件分块输出） */
     chunkSize?: number;
+    /** 群聊导出时是否优先使用群成员名称 */
+    preferGroupMemberName?: boolean;
 }
 
 /**
@@ -80,7 +82,8 @@ export abstract class BaseExporter {
             prettyFormat: options.prettyFormat ?? true,
             encoding: options.encoding || 'utf-8',
             customCss: options.customCss,
-            chunkSize: options.chunkSize
+            chunkSize: options.chunkSize,
+            preferGroupMemberName: options.preferGroupMemberName ?? false
         };
         
         this.cancelled = false;
@@ -196,7 +199,8 @@ export abstract class BaseExporter {
             progressEvery: 100,
             yieldEvery: 1000,
             suppressFallbackWarn: true,
-            stopOnAbort: true
+            stopOnAbort: true,
+            preferGroupMemberName: this.options.preferGroupMemberName ?? false
         };
         
         return new MessageParser(core, config);

--- a/plugins/qq-chat-exporter/lib/core/exporter/ExcelExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ExcelExporter.ts
@@ -390,7 +390,9 @@ export class ExcelExporter extends BaseExporter {
      * 使用SimpleMessageParser作为fallback解析器
      */
     private async useFallbackParser(messages: RawMessage[]): Promise<CleanMessage[]> {
-        const simpleParser = new SimpleMessageParser();
+        const simpleParser = new SimpleMessageParser({
+            preferGroupMemberName: this.options.preferGroupMemberName
+        });
         return await simpleParser.parseMessages(messages);
     }
 

--- a/plugins/qq-chat-exporter/lib/core/exporter/JsonExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/JsonExporter.ts
@@ -902,7 +902,9 @@ export class JsonExporter extends BaseExporter {
      * 使用SimpleMessageParser作为fallback解析器
      */
     private async useFallbackParser(messages: RawMessage[]): Promise<CleanMessage[]> {
-        const simpleParser = new SimpleMessageParser();
+        const simpleParser = new SimpleMessageParser({
+            preferGroupMemberName: this.options.preferGroupMemberName
+        });
         return await simpleParser.parseMessages(messages);
     }
 
@@ -1265,6 +1267,7 @@ export class JsonExporter extends BaseExporter {
             options: {
                 includeResourceLinks: this.options.includeResourceLinks,
                 includeSystemMessages: this.options.includeSystemMessages,
+                preferGroupMemberName: this.options.preferGroupMemberName ?? false,
                 timeFormat: this.options.timeFormat,
                 encoding: this.options.encoding
             }

--- a/plugins/qq-chat-exporter/lib/core/exporter/JsonExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/JsonExporter.ts
@@ -1267,7 +1267,7 @@ export class JsonExporter extends BaseExporter {
             options: {
                 includeResourceLinks: this.options.includeResourceLinks,
                 includeSystemMessages: this.options.includeSystemMessages,
-                preferGroupMemberName: this.options.preferGroupMemberName ?? false,
+                preferGroupMemberName: this.options.preferGroupMemberName ?? true,
                 timeFormat: this.options.timeFormat,
                 encoding: this.options.encoding
             }

--- a/plugins/qq-chat-exporter/lib/core/exporter/TextExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/TextExporter.ts
@@ -134,7 +134,9 @@ export class TextExporter extends BaseExporter {
      * 使用SimpleMessageParser作为fallback解析器
      */
     private async useFallbackParser(messages: RawMessage[]): Promise<ParsedMessage[]> {
-        const simpleParser = new SimpleMessageParser();
+        const simpleParser = new SimpleMessageParser({
+            preferGroupMemberName: this.options.preferGroupMemberName
+        });
         const cleanMessages = await simpleParser.parseMessages(messages);
         
         // 将CleanMessage转换为ParsedMessage格式

--- a/plugins/qq-chat-exporter/lib/core/parser/MessageParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/MessageParser.ts
@@ -344,6 +344,7 @@ export interface ParsedMessage {
 export interface MessageParserConfig {
   includeResourceLinks: boolean;
   includeSystemMessages: boolean;
+  preferGroupMemberName?: boolean;
   parseMarketFace: boolean;
   parseCardMessages: boolean;
   parseMultiForward: boolean;
@@ -381,6 +382,7 @@ export interface MessageParserConfig {
 const DEFAULT_PARSER_CONFIG: MessageParserConfig = {
   includeResourceLinks: true,
   includeSystemMessages: true,
+  preferGroupMemberName: false,
   parseMarketFace: true,
   parseCardMessages: true,
   parseMultiForward: true,
@@ -697,6 +699,8 @@ export class MessageParser {
       content.html = this.generateHtmlFromOB11(ob11Msg.message);
     }
 
+    const senderInfo = this.getSenderDisplayInfo(rawMsg);
+
     return {
       messageId: rawMsg.msgId,
       messageSeq: rawMsg.msgSeq,
@@ -705,14 +709,10 @@ export class MessageParser {
       sender: {
         uid: rawMsg.senderUid,
         uin: rawMsg.senderUin,
-        name: (rawMsg.sendMemberName && rawMsg.sendMemberName.trim()) ||
-              (rawMsg.sendRemarkName && rawMsg.sendRemarkName.trim()) ||
-              (rawMsg.sendNickName && rawMsg.sendNickName.trim()) ||
-              (rawMsg.senderUin && String(rawMsg.senderUin)) ||
-              undefined,
-        nickname: (rawMsg.sendNickName && rawMsg.sendNickName.trim()) || undefined,
-        groupCard: (rawMsg.sendMemberName && rawMsg.sendMemberName.trim()) || undefined,
-        remark: (rawMsg.sendRemarkName && rawMsg.sendRemarkName.trim()) || undefined,
+        name: senderInfo.name,
+        nickname: senderInfo.nickname,
+        groupCard: senderInfo.groupCard,
+        remark: senderInfo.remark,
         avatar: undefined,
         role: undefined
       },
@@ -1512,13 +1512,15 @@ export class MessageParser {
       }
     }
 
+    const senderInfo = this.getSenderDisplayInfo(message, userInfo);
+
     return {
       uid,
       uin: message.senderUin || userInfo?.uin,
-      name: (message.sendNickName && message.sendNickName.trim()) || 
-            userInfo?.nick || 
-            (message.senderUin && String(message.senderUin)) ||
-            undefined,
+      name: senderInfo.name,
+      nickname: senderInfo.nickname,
+      groupCard: senderInfo.groupCard,
+      remark: senderInfo.remark,
       avatar: userInfo?.avatarUrl,
       role: undefined
     };
@@ -1546,6 +1548,40 @@ export class MessageParser {
 
   private isTempMessage(message: RawMessage): boolean {
     return message.chatType === 100;
+  }
+
+  private normalizeDisplayText(value: unknown): string | undefined {
+    if (value === null || value === undefined) return undefined;
+    const text = String(value).trim();
+    return text || undefined;
+  }
+
+  private getSenderDisplayInfo(message: RawMessage, userInfo?: any): {
+    name: string | undefined;
+    nickname: string | undefined;
+    groupCard: string | undefined;
+    remark: string | undefined;
+  } {
+    const groupCard = this.normalizeDisplayText(message.sendMemberName);
+    const remark = this.normalizeDisplayText(message.sendRemarkName);
+    const nickname = this.normalizeDisplayText(message.sendNickName) || this.normalizeDisplayText(userInfo?.nick);
+    const fallbackUin = this.normalizeDisplayText(message.senderUin ?? userInfo?.uin);
+    const fallbackUid = this.normalizeDisplayText(message.senderUid || message.peerUid);
+    const isGroupChat = message.chatType === 2;
+    const preferGroupMemberName = isGroupChat && this.config.preferGroupMemberName === true;
+
+    const name = (
+      isGroupChat
+        ? (preferGroupMemberName ? groupCard || remark || nickname : nickname)
+        : remark || nickname
+    ) || fallbackUin || fallbackUid;
+
+    return {
+      name,
+      nickname,
+      groupCard,
+      remark
+    };
   }
 
   private extractReplyContent(replyElement: any, messageRef?: RawMessage): string {
@@ -1644,6 +1680,8 @@ export class MessageParser {
       }
     }
 
+    const senderInfo = this.getSenderDisplayInfo(message);
+
     return {
       messageId: message.msgId,
       messageSeq: message.msgSeq,
@@ -1652,14 +1690,10 @@ export class MessageParser {
       sender: {
         uid: message.senderUid || '0',
         uin: message.senderUin || '0',
-        name: (message.sendMemberName && message.sendMemberName.trim()) ||
-              (message.sendRemarkName && message.sendRemarkName.trim()) || 
-              (message.sendNickName && message.sendNickName.trim()) || 
-              (message.senderUin && String(message.senderUin)) ||
-              '未知用户',
-        nickname: (message.sendNickName && message.sendNickName.trim()) || undefined,
-        groupCard: (message.sendMemberName && message.sendMemberName.trim()) || undefined,
-        remark: (message.sendRemarkName && message.sendRemarkName.trim()) || undefined
+        name: senderInfo.name || '未知用户',
+        nickname: senderInfo.nickname,
+        groupCard: senderInfo.groupCard,
+        remark: senderInfo.remark
       },
       receiver: {
         uid: message.peerUid,
@@ -1689,15 +1723,19 @@ export class MessageParser {
   }
 
   private createErrorMessage(originalMessage: RawMessage, error: any): ParsedMessage {
+    const senderInfo = this.getSenderDisplayInfo(originalMessage);
+
     return {
       messageId: originalMessage.msgId,
       messageSeq: originalMessage.msgSeq,
       timestamp: dateFromUnixSeconds(originalMessage.msgTime),
       sender: {
         uid: originalMessage.senderUid || 'unknown',
-        name: (originalMessage.sendNickName && originalMessage.sendNickName.trim()) ||
-              (originalMessage.senderUin && String(originalMessage.senderUin)) ||
-              '未知用户'
+        uin: originalMessage.senderUin || undefined,
+        name: senderInfo.name || '未知用户',
+        nickname: senderInfo.nickname,
+        groupCard: senderInfo.groupCard,
+        remark: senderInfo.remark
       },
       messageType: originalMessage.msgType,
       isSystemMessage: false,

--- a/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
@@ -229,6 +229,7 @@ export interface SimpleParserOptions {
   progressEvery?: number;
   yieldEvery?: number;
   html?: 'full' | 'none';
+  preferGroupMemberName?: boolean;
   onProgress?: (processed: number, total: number) => void;
 }
 
@@ -236,7 +237,8 @@ const DEFAULT_SIMPLE_OPTIONS: Required<Omit<SimpleParserOptions, 'onProgress'>> 
   concurrency: resolveConcurrency(),
   progressEvery: 100,
   yieldEvery: 1000,
-  html: 'full'
+  html: 'full',
+  preferGroupMemberName: true
 };
 
 /* ---------------------------------- 主类 ---------------------------------- */
@@ -369,21 +371,7 @@ export class SimpleMessageParser {
   private async parseMessage(message: RawMessage): Promise<CleanMessage> {
     const tsMs = millisFromUnixSeconds(message.msgTime as any);
     const timestamp = tsMs > 0 ? tsMs : Date.now();
-
-    // 提取所有可用的名称信息
-    const groupCard = message.sendMemberName && message.sendMemberName.trim() || undefined;
-    const remark = message.sendRemarkName && message.sendRemarkName.trim() || undefined;
-    const nickname = message.sendNickName && message.sendNickName.trim() || undefined;
-    
-    // 群名片 > 好友备注 > 昵称 > QQ号 > UID
-    const senderName = (
-      groupCard ||
-      remark ||
-      nickname ||
-      (message.senderUin && String(message.senderUin)) ||
-      (message.senderUid && String(message.senderUid)) ||
-      '未知用户'
-    ).trim();
+    const senderInfo = this.getSenderDisplayInfo(message);
 
     const content = await this.parseMessageContent(message);
 
@@ -396,10 +384,10 @@ export class SimpleMessageParser {
       sender: {
         uid: message.senderUid || '未知',
         uin: message.senderUin,
-        name: senderName,
-        nickname: nickname,
-        groupCard: groupCard,
-        remark: remark
+        name: senderInfo.name,
+        nickname: senderInfo.nickname,
+        groupCard: senderInfo.groupCard,
+        remark: senderInfo.remark
       },
       type: this.getMessageTypeString(message.msgType),
       content,
@@ -980,21 +968,7 @@ export class SimpleMessageParser {
   private createErrorMessage(message: RawMessage, error: any): CleanMessage {
     const tsMs = millisFromUnixSeconds(message.msgTime as any);
     const timestamp = tsMs > 0 ? tsMs : Date.now();
-
-    // 提取所有可用的名称信息
-    const groupCard = message.sendMemberName && message.sendMemberName.trim() || undefined;
-    const remark = message.sendRemarkName && message.sendRemarkName.trim() || undefined;
-    const nickname = message.sendNickName && message.sendNickName.trim() || undefined;
-    
-    // 群名片 > 好友备注 > 昵称 > QQ号 > UID
-    const senderName = (
-      groupCard ||
-      remark ||
-      nickname ||
-      (message.senderUin && String(message.senderUin)) ||
-      (message.senderUid && String(message.senderUid)) ||
-      '未知用户'
-    ).trim();
+    const senderInfo = this.getSenderDisplayInfo(message);
 
     const errMsg = (error && (error.message || error.toString?.())) || 'Unknown';
     return {
@@ -1005,10 +979,10 @@ export class SimpleMessageParser {
       sender: {
         uid: message.senderUid || '未知',
         uin: message.senderUin,
-        name: senderName,
-        nickname: nickname,
-        groupCard: groupCard,
-        remark: remark
+        name: senderInfo.name,
+        nickname: senderInfo.nickname,
+        groupCard: senderInfo.groupCard,
+        remark: senderInfo.remark
       },
       type: 'error',
       content: {
@@ -1020,6 +994,38 @@ export class SimpleMessageParser {
       },
       recalled: false,
       system: false
+    };
+  }
+
+  private getTrimmedText(value: unknown): string | undefined {
+    if (value === null || value === undefined) return undefined;
+    const text = String(value).trim();
+    return text || undefined;
+  }
+
+  private getSenderDisplayInfo(message: RawMessage): {
+    name: string;
+    nickname: string | undefined;
+    groupCard: string | undefined;
+    remark: string | undefined;
+  } {
+    const groupCard = this.getTrimmedText(message.sendMemberName);
+    const remark = this.getTrimmedText(message.sendRemarkName);
+    const nickname = this.getTrimmedText(message.sendNickName);
+    const isGroupChat = message.chatType === 2;
+    const preferGroupMemberName = isGroupChat && this.options.preferGroupMemberName !== false;
+
+    const name = (
+      isGroupChat
+        ? (preferGroupMemberName ? groupCard || remark || nickname : nickname)
+        : remark || nickname
+    ) || this.getTrimmedText(message.senderUin) || this.getTrimmedText(message.senderUid) || '未知用户';
+
+    return {
+      name,
+      nickname,
+      groupCard,
+      remark
     };
   }
 

--- a/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
+++ b/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
@@ -587,7 +587,7 @@ export class ScheduledExportManager {
                         includeSystemMessages: task.options.includeSystemMessages ?? true,
                         filterPureImageMessages: task.options.filterPureImageMessages ?? false,
                         prettyFormat: task.options.prettyFormat ?? true,
-                        preferGroupMemberName: task.options.preferGroupMemberName ?? false,
+                        preferGroupMemberName: task.options.preferGroupMemberName ?? true,
                         timeFormat: 'YYYY-MM-DD HH:mm:ss',
                         encoding: 'utf-8'
                     }, {}, this.core);
@@ -600,7 +600,7 @@ export class ScheduledExportManager {
                         includeResourceLinks: task.options.includeResourceLinks ?? true,
                         includeSystemMessages: task.options.includeSystemMessages ?? true,
                         filterPureImageMessages: task.options.filterPureImageMessages ?? false,
-                        preferGroupMemberName: task.options.preferGroupMemberName ?? false,
+                        preferGroupMemberName: task.options.preferGroupMemberName ?? true,
                         timeFormat: 'YYYY-MM-DD HH:mm:ss',
                         prettyFormat: false,
                         encoding: 'utf-8'

--- a/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
+++ b/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
@@ -149,6 +149,7 @@ export interface ScheduledExportConfig {
         includeSystemMessages?: boolean;
         filterPureImageMessages?: boolean;
         prettyFormat?: boolean;
+        preferGroupMemberName?: boolean;
     };
     /** 备份模式（新增） */
     backupMode?: BackupMode;
@@ -563,7 +564,9 @@ export class ScheduledExportManager {
                 selfName: selfInfo?.nick
             };
 
-            const parser = new SimpleMessageParser();
+            const parser = new SimpleMessageParser({
+                preferGroupMemberName: task.options.preferGroupMemberName
+            });
 
             switch (task.format.toUpperCase()) {
                 case 'HTML':
@@ -584,6 +587,7 @@ export class ScheduledExportManager {
                         includeSystemMessages: task.options.includeSystemMessages ?? true,
                         filterPureImageMessages: task.options.filterPureImageMessages ?? false,
                         prettyFormat: task.options.prettyFormat ?? true,
+                        preferGroupMemberName: task.options.preferGroupMemberName ?? false,
                         timeFormat: 'YYYY-MM-DD HH:mm:ss',
                         encoding: 'utf-8'
                     }, {}, this.core);
@@ -596,6 +600,7 @@ export class ScheduledExportManager {
                         includeResourceLinks: task.options.includeResourceLinks ?? true,
                         includeSystemMessages: task.options.includeSystemMessages ?? true,
                         filterPureImageMessages: task.options.filterPureImageMessages ?? false,
+                        preferGroupMemberName: task.options.preferGroupMemberName ?? false,
                         timeFormat: 'YYYY-MM-DD HH:mm:ss',
                         prettyFormat: false,
                         encoding: 'utf-8'

--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -819,6 +819,7 @@ export default function QCEDashboard() {
           streamingZipMode: config.streamingZipMode,
           exportAsZip: config.exportAsZip,
           embedAvatarsAsBase64: config.embedAvatarsAsBase64,
+          preferGroupMemberName: config.preferGroupMemberName,
           outputDir: config.outputDir,
           keywords: config.keywords,
           excludeUserUins: config.excludeUserUins,

--- a/qce-v4-tool/components/ui/batch-export-dialog.tsx
+++ b/qce-v4-tool/components/ui/batch-export-dialog.tsx
@@ -38,6 +38,7 @@ export interface BatchExportConfig {
   embedAvatarsAsBase64: boolean
   includeSystemMessages: boolean
   filterPureImageMessages: boolean
+  preferGroupMemberName: boolean
   outputDir: string
   keywords: string
   excludeUserUins: string
@@ -71,6 +72,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
   const [embedAvatarsAsBase64, setEmbedAvatarsAsBase64] = useState(false)
   const [includeSystemMessages, setIncludeSystemMessages] = useState(true)
   const [filterPureImageMessages, setFilterPureImageMessages] = useState(false) // HTML默认false
+  const [preferGroupMemberName, setPreferGroupMemberName] = useState(true)
   const [outputDir, setOutputDir] = useState('')
   const [keywords, setKeywords] = useState('')
   const [excludeUserUins, setExcludeUserUins] = useState('')
@@ -98,6 +100,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
       setEmbedAvatarsAsBase64(false)
       setIncludeSystemMessages(true)
       setFilterPureImageMessages(false)
+      setPreferGroupMemberName(true)
       setOutputDir('')
       setKeywords('')
       setExcludeUserUins('')
@@ -184,6 +187,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
       embedAvatarsAsBase64,
       includeSystemMessages,
       filterPureImageMessages,
+      preferGroupMemberName,
       outputDir,
       keywords,
       excludeUserUins,
@@ -411,6 +415,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
                     { id: "streamingZipMode", checked: streamingZipMode, set: setStreamingZipMode, title: "流式导出（超大消息量专用）", desc: format === "HTML" ? "专为50万+消息量设计，全程流式处理防止内存溢出。输出ZIP格式。" : "专为50万+消息量设计，全程流式处理防止内存溢出。输出分块JSONL格式。", visible: format === "HTML" || format === "JSON", highlight: true },
                     { id: "includeSystemMessages", checked: includeSystemMessages, set: setIncludeSystemMessages, title: "包含系统消息", desc: "包含入群通知、撤回提示等系统提示消息", visible: true, highlight: false },
                     { id: "filterPureImageMessages", checked: filterPureImageMessages, set: setFilterPureImageMessages, title: "快速导出（跳过资源下载）", desc: "保留所有消息记录，但不下载图片/视频/音频等资源文件，大幅加快导出速度", visible: true, highlight: false },
+                    { id: "preferGroupMemberName", checked: preferGroupMemberName, set: setPreferGroupMemberName, title: "优先使用群成员名称", desc: "群聊导出时优先使用群名片或群内名称。关闭后会改用 QQ 昵称或 QQ 号。这个选项仅对群聊生效。", visible: true, highlight: false },
                     { id: "exportAsZip", checked: exportAsZip, set: setExportAsZip, title: "导出为ZIP压缩包", desc: "将HTML文件和资源文件打包为ZIP格式（仅HTML格式可用）", visible: format === "HTML" && !streamingZipMode, highlight: false },
                     { id: "useNameInFileName", checked: useNameInFileName, set: setUseNameInFileName, title: "文件名包含聊天名称", desc: "导出文件名中包含聊天对象的名称，方便识别", visible: true, highlight: false },
                     { id: "embedAvatarsAsBase64", checked: embedAvatarsAsBase64, set: setEmbedAvatarsAsBase64, title: "嵌入头像为Base64", desc: "将发送者头像以Base64格式嵌入JSON文件（仅JSON格式可用，会增加文件大小）", visible: format === "JSON", highlight: false }

--- a/qce-v4-tool/components/ui/scheduled-export-wizard.tsx
+++ b/qce-v4-tool/components/ui/scheduled-export-wizard.tsx
@@ -62,6 +62,7 @@ export function ScheduledExportWizard({
     includeResourceLinks: true,
     includeSystemMessages: true,
     filterPureImageMessages: false,
+    preferGroupMemberName: true,
   })
 
   // 选中的目标
@@ -116,6 +117,7 @@ export function ScheduledExportWizard({
         filterPureImageMessages: prefilledData.filterPureImageMessages !== undefined 
           ? prefilledData.filterPureImageMessages 
           : defaultFilter,
+        preferGroupMemberName: prefilledData.preferGroupMemberName !== undefined ? prefilledData.preferGroupMemberName : true,
       })
 
       // 如果有预填充的目标，添加到选中列表
@@ -149,6 +151,7 @@ export function ScheduledExportWizard({
         includeResourceLinks: true,
         includeSystemMessages: true,
         filterPureImageMessages: false,
+        preferGroupMemberName: true,
       })
       setSelectedTargets([])
       setSearchTerm("")
@@ -201,6 +204,7 @@ export function ScheduledExportWizard({
         includeResourceLinks: baseForm.includeResourceLinks,
         includeSystemMessages: baseForm.includeSystemMessages,
         filterPureImageMessages: baseForm.filterPureImageMessages,
+        preferGroupMemberName: baseForm.preferGroupMemberName,
       }
       
       try {
@@ -817,6 +821,13 @@ export function ScheduledExportWizard({
                       set: (v: boolean) => setBaseForm(p => ({ ...p, filterPureImageMessages: v })),
                       title: "快速导出（跳过资源下载）",
                       desc: "保留所有消息记录，但不下载图片/视频/音频等资源文件，大幅加快导出速度"
+                    },
+                    {
+                      id: "preferGroupMemberName",
+                      checked: baseForm.preferGroupMemberName,
+                      set: (v: boolean) => setBaseForm(p => ({ ...p, preferGroupMemberName: v })),
+                      title: "优先使用群成员名称",
+                      desc: "群聊导出时优先使用群名片或群内名称。关闭后会改用 QQ 昵称或 QQ 号。这个选项仅对群聊生效。"
                     }
                   ].map((opt) => (
                     <div

--- a/qce-v4-tool/components/ui/task-wizard.tsx
+++ b/qce-v4-tool/components/ui/task-wizard.tsx
@@ -82,6 +82,7 @@ export function TaskWizard({
     streamingZipMode: false, // 流式ZIP导出模式
     outputDir: "", // Issue #192: 自定义导出路径
     useNameInFileName: false, // Issue #216: 文件名包含聊天名称
+    preferGroupMemberName: true, // Issue #358: 群聊优先使用群成员名称
   })
 
   const { groupSearch, friendSearch } = useSearch()
@@ -122,6 +123,7 @@ export function TaskWizard({
         streamingZipMode: prefilledData.streamingZipMode || false,
         outputDir: prefilledData.outputDir || "",  // Issue #192
         useNameInFileName: prefilledData.useNameInFileName || false,  // Issue #216
+        preferGroupMemberName: prefilledData.preferGroupMemberName !== undefined ? prefilledData.preferGroupMemberName : true,
       })
     }
   }, [prefilledData, isOpen])
@@ -197,6 +199,7 @@ export function TaskWizard({
         streamingZipMode: false,
         outputDir: "", // Issue #192: 重置自定义导出路径
         useNameInFileName: false, // Issue #216: 重置文件名包含聊天名称
+        preferGroupMemberName: true, // Issue #358: 重置群成员名称选项
       })
     }
   }, [isOpen])
@@ -975,6 +978,14 @@ export function TaskWizard({
                 title: "快速导出（跳过资源下载）",
                 desc: "保留所有消息记录，但不下载图片/视频/音频等资源文件，大幅加快导出速度",
                 visible: true
+              },
+              {
+                id: "preferGroupMemberName",
+                checked: form.preferGroupMemberName ?? true,
+                set: (v: boolean) => setForm((p) => ({ ...p, preferGroupMemberName: v })),
+                title: "优先使用群成员名称",
+                desc: "群聊导出时优先使用群名片或群内名称。关闭后会改用 QQ 昵称或 QQ 号。",
+                visible: form.chatType === 2
               },
               {
                 id: "exportAsZip",

--- a/qce-v4-tool/hooks/use-export-tasks.ts
+++ b/qce-v4-tool/hooks/use-export-tasks.ts
@@ -444,6 +444,7 @@ export function useExportTasks(_props?: UseExportTasksProps) {
           prettyFormat: true,
           exportAsZip: form.exportAsZip,
           embedAvatarsAsBase64: form.embedAvatarsAsBase64,
+          preferGroupMemberName: form.preferGroupMemberName ?? true,
           ...(form.outputDir?.trim() && { outputDir: form.outputDir.trim() }),
           ...(form.useNameInFileName && { useNameInFileName: true }),
         },

--- a/qce-v4-tool/hooks/use-scheduled-exports.ts
+++ b/qce-v4-tool/hooks/use-scheduled-exports.ts
@@ -25,6 +25,7 @@ export interface ScheduledExportConfig {
         includeSystemMessages?: boolean;
         filterPureImageMessages?: boolean;
         prettyFormat?: boolean;
+        preferGroupMemberName?: boolean;
     };
     enabled: boolean;
     createdAt?: string;
@@ -101,6 +102,7 @@ export function useScheduledExports() {
                     includeSystemMessages: formData.includeSystemMessages ?? true,
                     filterPureImageMessages: formData.filterPureImageMessages ?? false,
                     prettyFormat: true,
+                    preferGroupMemberName: formData.preferGroupMemberName ?? true,
                 },
                 ...(formData.outputDir?.trim() && { outputDir: formData.outputDir.trim() }),
                 enabled: formData.enabled,

--- a/qce-v4-tool/types/api.ts
+++ b/qce-v4-tool/types/api.ts
@@ -155,6 +155,8 @@ export interface CreateTaskForm {
   outputDir?: string
   /** 在文件名中包含聊天名称（Issue #216） */
   useNameInFileName?: boolean
+  /** 群聊导出时优先使用群成员名称（Issue #358） */
+  preferGroupMemberName?: boolean
 }
 
 export interface CreateTaskRequest {
@@ -184,6 +186,8 @@ export interface CreateTaskRequest {
     outputDir?: string
     /** 在文件名中包含聊天名称（Issue #216） */
     useNameInFileName?: boolean
+    /** 群聊导出时优先使用群成员名称（Issue #358） */
+    preferGroupMemberName?: boolean
   }
 }
 
@@ -271,6 +275,7 @@ export interface ScheduledExport {
     includeSystemMessages?: boolean
     filterPureImageMessages?: boolean
     prettyFormat?: boolean
+    preferGroupMemberName?: boolean
   }
   outputDir?: string
   enabled: boolean
@@ -312,6 +317,7 @@ export interface CreateScheduledExportForm {
   includeResourceLinks?: boolean
   includeSystemMessages?: boolean
   filterPureImageMessages?: boolean
+  preferGroupMemberName?: boolean
 }
 
 export interface ScheduledExportsResponse {


### PR DESCRIPTION
## Summary
- add a selectable `preferGroupMemberName` export option for single export, batch export, and scheduled export
- wire the option through frontend requests, backend export options, and scheduled export config
- make both parser chains respect the option so group exports can switch between group member names and QQ nicknames or QQ numbers

## Testing
- `npx tsc -p plugins/qq-chat-exporter/tsconfig.json --noEmit` (fails because the repo already has unrelated historical type issues, such as missing NapCat declarations)
- `npx tsc -p qce-v4-tool/tsconfig.json --noEmit` (fails because the repo already has unrelated existing UI type errors)

Closes #358