### PR TITLE
test: zero-credential mock harness for plugin and api server

### DIFF
--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -1,0 +1,127 @@
+name: 测试 QCE 插件
+
+on:
+  push:
+    branches: [main, master, dev]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  unit-and-integration:
+    name: ${{ matrix.os }} / Node ${{ matrix.node }} / ${{ matrix.suite }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        node: ['20.x', '22.x']
+        suite: [unit, integration]
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install plugin dependencies
+        working-directory: plugins/qq-chat-exporter
+        run: |
+          # node_modules is committed for runtime; only platform-specific
+          # esbuild binaries need installing per-OS.
+          node __tests__/scripts/ensure-platform-esbuild.mjs
+
+      - name: Run ${{ matrix.suite }} tests
+        working-directory: plugins/qq-chat-exporter
+        run: npm run test:${{ matrix.suite }}
+
+      - name: Upload exporter snapshots on failure
+        if: failure() && matrix.suite == 'integration'
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshots-${{ matrix.os }}-node${{ matrix.node }}
+          path: plugins/qq-chat-exporter/__tests__/integration/__snapshots__/
+          retention-days: 7
+
+  api-e2e:
+    name: API smoke (Playwright)
+    runs-on: ubuntu-latest
+    needs: unit-and-integration
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('qce-v4-tool/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install plugin esbuild binary
+        working-directory: plugins/qq-chat-exporter
+        run: node __tests__/scripts/ensure-platform-esbuild.mjs
+
+      - name: Install frontend deps + Playwright browser
+        working-directory: qce-v4-tool
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm exec playwright install --with-deps chromium
+
+      - name: Start mock API server
+        working-directory: plugins/qq-chat-exporter
+        run: |
+          nohup node __tests__/scripts/mock-server.mjs > /tmp/mock-server.log 2>&1 &
+          # Wait for /health to become reachable
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:40653/health > /dev/null; then
+              echo "[ci] mock server ready"
+              break
+            fi
+            sleep 1
+          done
+          curl -fsS http://localhost:40653/health
+        env:
+          QCE_MOCK_TOKEN: qce_mock_token_for_tests
+
+      - name: Run Playwright API smoke tests
+        working-directory: qce-v4-tool
+        run: pnpm exec playwright test e2e/api-smoke.spec.ts
+        env:
+          E2E_API_URL: http://localhost:40653
+          QCE_MOCK_TOKEN: qce_mock_token_for_tests
+
+      - name: Mock server logs (always)
+        if: always()
+        run: |
+          echo '--- mock-server.log ---'
+          cat /tmp/mock-server.log || true
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: qce-v4-tool/playwright-report/
+          retention-days: 7

--- a/plugins/qq-chat-exporter/.gitignore
+++ b/plugins/qq-chat-exporter/.gitignore
@@ -1,0 +1,10 @@
+# Platform-specific esbuild binaries (installed by __tests__/scripts/ensure-platform-esbuild.mjs)
+node_modules/@esbuild/linux-x64/
+node_modules/@esbuild/linux-arm64/
+node_modules/@esbuild/darwin-x64/
+node_modules/@esbuild/darwin-arm64/
+
+# Test artifacts
+playwright-report/
+test-results/
+

--- a/plugins/qq-chat-exporter/__tests__/README.md
+++ b/plugins/qq-chat-exporter/__tests__/README.md
@@ -1,0 +1,115 @@
+# QCE Test Harness
+
+零登录测试架构。所有测试在不连真实 QQ 的情况下跑完整 pipeline。
+
+## 一句话上手
+
+```bash
+cd plugins/qq-chat-exporter
+npm test                    # 跑全部单测 + 集成测试
+npm run mock:server         # 启动一个不需要登录 QQ 的 API Server（端口 40653）
+```
+
+## 目录结构
+
+```
+__tests__/
+├── helpers/                 # 测试基础设施
+│   ├── MockNapCatCore.ts    # 假 NapCatCore 工厂，按真实 shape 实现 MsgApi/GroupApi/...
+│   ├── installBridge.ts     # 把 MockCore 注入到 globalThis.__NAPCAT_BRIDGE__
+│   ├── snapshot.ts          # 极简 snapshot 实现（无 Jest 依赖）
+│   ├── silenceConsole.ts    # 跑测试时静音生产代码的 console.log
+│   ├── tempDir.ts           # mkdtemp + 自动清理
+│   └── types.ts             # 测试用的 Mock* TypeScript 类型
+├── fixtures/                # 预置场景
+│   ├── builders.ts          # msg().text().image().reply()...build() DSL
+│   └── conversations.ts     # privateTextOnly / groupMixedMedia / privateWithRecall ...
+├── unit/
+│   └── SimpleMessageParser.test.ts   # 9 个 case，覆盖文本/@/图/语音/视频/文件/表情/撤回/回复/转发
+├── integration/
+│   ├── BatchMessageFetcher.test.ts   # 分页 / 时间过滤 / 批次大小
+│   ├── exporters.test.ts             # HTML / JSON / TXT snapshot
+│   └── __snapshots__/                # 生成的 baseline，提交进 git
+├── scripts/
+│   ├── run-tests.mjs                 # 跨平台 npm test 包装器
+│   ├── mock-server.mjs               # Tier 2: 起 ApiServer + MockCore
+│   └── ensure-platform-esbuild.mjs   # 自动安装当前 OS 的 esbuild 二进制
+├── smoke.test.ts                     # bridge 注入/卸载 sanity
+└── tsconfig.json                     # 测试用 tsconfig（关掉 verbatimModuleSyntax）
+```
+
+## 三层架构
+
+### Tier 1 — 单元 / 集成测试（必跑）
+
+```bash
+npm run test:unit         # 解析器单元测试
+npm run test:integration  # Fetcher + 4 种 Exporter
+npm test                  # 全部
+npm run test:update-snapshots  # 改了 exporter 后用这个更新 baseline
+```
+
+无依赖。`node:test` 原生跑，约 1.7 秒。
+
+### Tier 2 — Mock API Server（开发 / 调试用）
+
+```bash
+npm run mock:server
+```
+
+输出：
+
+```
+[QCE Mock] API server listening on http://localhost:40653
+[QCE Mock] Token:    qce_mock_token_for_tests
+[QCE Mock] Scenario: default (5 conversations)
+```
+
+跟生产一模一样的 `QQChatExporterApiServer`，只是 `core` 是假的。
+
+环境变量：
+
+- `QCE_MOCK_TOKEN` — 预置 access token，默认 `qce_mock_token_for_tests`
+- `QCE_MOCK_SCENARIO` — `default` / `private` / `group` / `recall` / `forward` / `volume`
+- `QCE_MOCK_HOME` — sqlite/缓存目录（默认 `mkdtemp`，进程退出时清掉）
+
+前端怎么连：
+
+```bash
+# 1. 启动 mock server
+cd plugins/qq-chat-exporter && npm run mock:server
+
+# 2. 启动前端 dev
+cd ../../qce-v4-tool && npm run dev
+
+# 3. 浏览器打开
+open 'http://localhost:3000/auth?token=qce_mock_token_for_tests'
+```
+
+### Tier 3 — Playwright Smoke E2E
+
+在 `qce-v4-tool/e2e/`：
+
+```bash
+cd qce-v4-tool
+pnpm exec playwright install chromium  # 只跑一次
+pnpm test:e2e                          # API smoke（需要 mock:server 在跑）
+```
+
+`api-smoke.spec.ts` 走 REST + Auth 主流程；`ui-smoke.spec.ts` 在前端不可达时自动 skip。
+
+## 加新测试
+
+### 加一种消息类型
+
+1. 在 `fixtures/builders.ts` 给 `MessageBuilder` 加方法（参考 `.image()` / `.voice()`）
+2. 在 `unit/SimpleMessageParser.test.ts` 加 case
+3. 跑 `npm run test:update-snapshots` 让 exporter snapshot 接收新 shape
+
+### 复现 bug
+
+1. 在 `fixtures/conversations.ts` 加一个新场景，名字跟 issue 编号关联
+2. 在 `integration/` 写一个 case 用这个 fixture
+3. 修代码直到测试过
+
+不需要登录 QQ。

--- a/plugins/qq-chat-exporter/__tests__/fixtures/builders.ts
+++ b/plugins/qq-chat-exporter/__tests__/fixtures/builders.ts
@@ -1,0 +1,325 @@
+/**
+ * Fixture builders.
+ *
+ * Hand-writing NTQQ-shaped RawMessage objects in a test is painful — every
+ * message is a deeply nested object with a dozen-plus optional fields. The
+ * builders here trade verbosity for fluency:
+ *
+ *     msg('text-1', { senderUid: 'u_alice' })
+ *         .at(0)
+ *         .text('Hi ')
+ *         .at(123, 'Bob')
+ *         .text('!')
+ *         .build()
+ *
+ *     conversation(privatePeer('u_alice'))
+ *         .add(msg().text('first').build())
+ *         .add(msg().image({ url: 'https://x/1.png' }).build())
+ *         .build()
+ */
+
+import type { MessageElement, RawMessage } from 'NapCatQQ/src/core/index.js';
+import type { MockConversation, MockPeer } from '../helpers/types.js';
+
+let _counter = 0;
+const nextId = () => `m_${++_counter}`;
+const nextSeq = () => String(1000 + _counter);
+
+export function resetIds(): void {
+    _counter = 0;
+}
+
+/* ------------------------------ Peer helpers ------------------------------ */
+
+export function privatePeer(uid: string): MockPeer {
+    return { chatType: 1, peerUid: uid };
+}
+
+export function groupPeer(groupCode: string): MockPeer {
+    return { chatType: 2, peerUid: groupCode };
+}
+
+/* -------------------------- MessageBuilder (chainable) -------------------- */
+
+interface InitialMsgOptions {
+    msgId?: string;
+    msgSeq?: string;
+    msgTime?: number;
+    msgType?: number;
+    chatType?: number;
+    peerUid?: string;
+    senderUid?: string;
+    senderUin?: string;
+    sendNickName?: string;
+    sendMemberName?: string;
+    sendRemarkName?: string;
+    recallTime?: string;
+}
+
+export class MessageBuilder {
+    private msg: RawMessage;
+    private elements: MessageElement[];
+    private records: RawMessage[] = [];
+
+    constructor(opts: InitialMsgOptions = {}) {
+        const id = opts.msgId ?? nextId();
+        const seq = opts.msgSeq ?? nextSeq();
+        // Default time is deterministic: 2024-01-01 00:00:00 + 60s per message
+        const baseTime = 1704067200; // 2024-01-01T00:00:00Z
+        this.elements = [];
+        const initial: Partial<RawMessage> = {
+            msgId: id,
+            msgSeq: seq,
+            msgTime: opts.msgTime != null ? String(opts.msgTime) : String(baseTime + _counter * 60),
+            msgType: opts.msgType ?? 2,
+            chatType: opts.chatType ?? 1,
+            peerUid: opts.peerUid ?? 'peer_default',
+            senderUid: opts.senderUid ?? 'u_alice',
+            senderUin: opts.senderUin ?? '11111',
+            sendNickName: opts.sendNickName ?? 'Alice',
+            sendMemberName: opts.sendMemberName ?? '',
+            sendRemarkName: opts.sendRemarkName ?? '',
+            recallTime: opts.recallTime ?? '0',
+            elements: this.elements
+        };
+        this.msg = initial as RawMessage;
+    }
+
+    text(content: string): this {
+        this.elements.push({
+            elementType: 1,
+            textElement: { content, atType: 0, atUid: '', atNtUid: '' }
+        } as unknown as MessageElement);
+        return this;
+    }
+
+    atAll(): this {
+        this.elements.push({
+            elementType: 1,
+            textElement: { content: '@全体成员', atType: 1, atUid: '0', atNtUid: '' }
+        } as unknown as MessageElement);
+        return this;
+    }
+
+    at(uin: string | number, name: string, uid?: string): this {
+        this.elements.push({
+            elementType: 1,
+            textElement: {
+                content: `@${name}`,
+                atType: 2,
+                atUid: String(uin),
+                atNtUid: uid ?? `u_${uin}`
+            }
+        } as unknown as MessageElement);
+        return this;
+    }
+
+    face(faceIndex: number, faceText?: string): this {
+        this.elements.push({
+            elementType: 6,
+            faceElement: { faceIndex, faceText: faceText ?? '' }
+        } as unknown as MessageElement);
+        return this;
+    }
+
+    marketFace(opts: { name?: string; tabName?: string; emojiId?: string; emojiPackageId?: number; key?: string }): this {
+        this.elements.push({
+            elementType: 37,
+            marketFaceElement: {
+                faceName: opts.name ?? '商城表情',
+                tabName: opts.tabName ?? '',
+                emojiId: opts.emojiId ?? 'emoji_001',
+                emojiPackageId: opts.emojiPackageId ?? 1,
+                key: opts.key ?? 'mock_key'
+            }
+        } as unknown as MessageElement);
+        return this;
+    }
+
+    image(opts: {
+        filename?: string;
+        size?: number;
+        width?: number;
+        height?: number;
+        md5?: string;
+        url?: string;
+    } = {}): this {
+        this.elements.push({
+            elementType: 2,
+            picElement: {
+                fileName: opts.filename ?? 'pic.jpg',
+                fileSize: String(opts.size ?? 1024),
+                picWidth: opts.width ?? 800,
+                picHeight: opts.height ?? 600,
+                md5HexStr: opts.md5 ?? 'deadbeef',
+                originImageUrl: opts.url ?? 'https://multimedia.nt.qq.com.cn/mock.jpg'
+            }
+        } as unknown as MessageElement);
+        return this;
+    }
+
+    file(opts: { filename?: string; size?: number; md5?: string } = {}): this {
+        this.elements.push({
+            elementType: 3,
+            fileElement: {
+                fileName: opts.filename ?? 'doc.pdf',
+                fileSize: String(opts.size ?? 2048),
+                fileMd5: opts.md5 ?? 'abcdef0123456789'
+            }
+        } as unknown as MessageElement);
+        this.msg.msgType = 3;
+        return this;
+    }
+
+    voice(opts: { filename?: string; size?: number; duration?: number } = {}): this {
+        this.elements.push({
+            elementType: 4,
+            pttElement: {
+                fileName: opts.filename ?? 'voice.silk',
+                fileSize: String(opts.size ?? 4096),
+                duration: opts.duration ?? 3
+            }
+        } as unknown as MessageElement);
+        this.msg.msgType = 6;
+        return this;
+    }
+
+    video(opts: { filename?: string; size?: number; duration?: number; thumbSize?: number } = {}): this {
+        this.elements.push({
+            elementType: 4,
+            videoElement: {
+                fileName: opts.filename ?? 'video.mp4',
+                fileSize: String(opts.size ?? 8192),
+                duration: opts.duration ?? 10,
+                thumbSize: String(opts.thumbSize ?? 2048)
+            }
+        } as unknown as MessageElement);
+        this.msg.msgType = 7;
+        return this;
+    }
+
+    reply(opts: {
+        sourceMsgId: string;
+        senderUin?: string;
+        senderName?: string;
+        content?: string;
+        msgSeq?: string;
+        msgTime?: number;
+    }): this {
+        this.elements.push({
+            elementType: 7,
+            replyElement: {
+                sourceMsgIdInRecords: opts.sourceMsgId,
+                replayMsgId: opts.sourceMsgId,
+                senderUin: opts.senderUin ?? '11111',
+                senderUinStr: opts.senderUin ?? '11111',
+                replayMsgSeq: opts.msgSeq ?? '999',
+                replyMsgTime: String(opts.msgTime ?? 1704067100),
+                sourceMsgTextElems: [{ textElemContent: opts.content ?? '' }]
+            }
+        } as unknown as MessageElement);
+        this.msg.msgType = 9;
+        return this;
+    }
+
+    forward(opts: { resId: string; xmlContent?: string; records?: RawMessage[] }): this {
+        this.elements.push({
+            elementType: 16,
+            multiForwardMsgElement: {
+                resId: opts.resId,
+                xmlContent: opts.xmlContent ?? '<msg>合并转发</msg>'
+            }
+        } as unknown as MessageElement);
+        if (opts.records) this.records = opts.records;
+        this.msg.msgType = 8;
+        return this;
+    }
+
+    arkJson(payload: object): this {
+        this.elements.push({
+            elementType: 10,
+            arkElement: { bytesData: JSON.stringify(payload) }
+        } as unknown as MessageElement);
+        this.msg.msgType = 11;
+        return this;
+    }
+
+    greyTip(content: string): this {
+        this.elements.push({
+            elementType: 8,
+            grayTipElement: {
+                subElementType: 1,
+                jsonGrayTipElement: { busiId: 1, jsonStr: JSON.stringify({ items: [{ txt: content }] }) }
+            }
+        } as unknown as MessageElement);
+        this.msg.msgType = 5;
+        return this;
+    }
+
+    recall(time: number = Math.floor(Date.now() / 1000)): this {
+        this.msg.recallTime = String(time);
+        return this;
+    }
+
+    /** Stamp a deterministic msgTime (Unix seconds). */
+    at_time(seconds: number): this {
+        this.msg.msgTime = String(seconds);
+        return this;
+    }
+
+    sender(opts: { uid?: string; uin?: string; nick?: string; card?: string; remark?: string }): this {
+        if (opts.uid) this.msg.senderUid = opts.uid;
+        if (opts.uin) this.msg.senderUin = opts.uin;
+        if (opts.nick) this.msg.sendNickName = opts.nick;
+        if (opts.card) this.msg.sendMemberName = opts.card;
+        if (opts.remark) this.msg.sendRemarkName = opts.remark;
+        return this;
+    }
+
+    build(): RawMessage {
+        if (this.records.length > 0) {
+            (this.msg as RawMessage & { records: RawMessage[] }).records = this.records;
+        }
+        return this.msg;
+    }
+}
+
+export function msg(opts: InitialMsgOptions = {}): MessageBuilder {
+    return new MessageBuilder(opts);
+}
+
+/* --------------------------- ConversationBuilder --------------------------- */
+
+export class ConversationBuilder {
+    private peer: MockPeer;
+    private chatInfo: MockConversation['chatInfo'];
+    private messages: RawMessage[] = [];
+
+    constructor(peer: MockPeer, chatInfo?: MockConversation['chatInfo']) {
+        this.peer = peer;
+        this.chatInfo = chatInfo;
+    }
+
+    info(chatInfo: NonNullable<MockConversation['chatInfo']>): this {
+        this.chatInfo = chatInfo;
+        return this;
+    }
+
+    add(...rawMessages: RawMessage[]): this {
+        for (const m of rawMessages) {
+            // Stamp peer info if missing
+            if (!m.peerUid) m.peerUid = this.peer.peerUid;
+            if (!m.chatType) m.chatType = this.peer.chatType;
+            this.messages.push(m);
+        }
+        return this;
+    }
+
+    build(): MockConversation {
+        return { peer: this.peer, chatInfo: this.chatInfo, messages: this.messages };
+    }
+}
+
+export function conversation(peer: MockPeer, chatInfo?: MockConversation['chatInfo']): ConversationBuilder {
+    return new ConversationBuilder(peer, chatInfo);
+}

--- a/plugins/qq-chat-exporter/__tests__/fixtures/conversations.ts
+++ b/plugins/qq-chat-exporter/__tests__/fixtures/conversations.ts
@@ -1,0 +1,164 @@
+/**
+ * Canned conversations used by the integration tests.
+ *
+ * Each scenario exercises a particular slice of the export pipeline. Keep
+ * them deterministic — fixed msgTime / msgSeq so snapshots stay stable.
+ */
+
+import type { MockConversation, MockFriend, MockGroup } from '../helpers/types.js';
+import { conversation, groupPeer, msg, privatePeer, resetIds } from './builders.js';
+
+const T = 1704067200; // 2024-01-01T00:00:00Z
+
+/* ------------------------------ Friends / Groups ----------------------------- */
+
+export const FRIENDS: MockFriend[] = [
+    { uid: 'u_alice', uin: '11111', nick: 'Alice', remark: 'Alice (Real Name)' },
+    { uid: 'u_bob', uin: '22222', nick: 'Bob' },
+    { uid: 'u_charlie', uin: '33333', nick: 'Charlie' }
+];
+
+export const GROUPS: MockGroup[] = [
+    {
+        groupCode: '999000',
+        groupName: 'QCE Testing Group',
+        memberCount: 4,
+        maxMember: 200,
+        members: [
+            { uid: 'u_alice', uin: '11111', nick: 'Alice', cardName: 'Alice (PM)', role: 2 },
+            { uid: 'u_bob', uin: '22222', nick: 'Bob', cardName: 'Bob (Eng)', role: 3 },
+            { uid: 'u_charlie', uin: '33333', nick: 'Charlie', role: 3 },
+            { uid: 'self_test_uid', uin: '10000', nick: 'TestSelf', cardName: 'Me', role: 1 }
+        ]
+    }
+];
+
+/* --------------------------- Scenario 1: Plain text -------------------------- */
+
+export function privateTextOnly(): MockConversation {
+    resetIds();
+    return conversation(privatePeer('u_alice'), { name: 'Alice', type: 'private' })
+        .add(msg().sender({ uid: 'u_alice', uin: '11111', nick: 'Alice' }).text('Hello there').at_time(T + 0).build())
+        .add(msg().sender({ uid: 'self_test_uid', uin: '10000', nick: 'TestSelf' }).text('General Kenobi!').at_time(T + 60).build())
+        .add(msg().sender({ uid: 'u_alice', uin: '11111', nick: 'Alice' }).text('How was your day?').at_time(T + 120).build())
+        .build();
+}
+
+/* ------------------------- Scenario 2: Mixed elements ------------------------ */
+
+export function groupMixedMedia(): MockConversation {
+    resetIds();
+    const replyTarget = msg()
+        .sender({ uid: 'u_alice', uin: '11111', nick: 'Alice', card: 'Alice (PM)' })
+        .text('Anyone seen the build break?')
+        .at_time(T + 100)
+        .build();
+
+    return conversation(groupPeer('999000'), { name: 'QCE Testing Group', type: 'group', participantCount: 4 })
+        .add(replyTarget)
+        .add(
+            msg()
+                .sender({ uid: 'u_bob', uin: '22222', nick: 'Bob', card: 'Bob (Eng)' })
+                .text('Looking now ')
+                .face(178, '[微笑]')
+                .at_time(T + 160)
+                .build()
+        )
+        .add(
+            msg()
+                .sender({ uid: 'u_bob', uin: '22222', nick: 'Bob', card: 'Bob (Eng)' })
+                .image({ filename: 'screenshot.png', width: 1920, height: 1080, md5: 'cafef00d', url: 'https://multimedia.nt.qq.com.cn/screenshot.png' })
+                .at_time(T + 165)
+                .build()
+        )
+        .add(
+            msg()
+                .sender({ uid: 'u_charlie', uin: '33333', nick: 'Charlie' })
+                .at(11111, 'Alice', 'u_alice')
+                .text(' sentry has the trace, sending now')
+                .at_time(T + 200)
+                .build()
+        )
+        .add(
+            msg()
+                .sender({ uid: 'u_charlie', uin: '33333', nick: 'Charlie' })
+                .file({ filename: 'trace.json', size: 51200, md5: 'feedface' })
+                .at_time(T + 210)
+                .build()
+        )
+        .add(
+            msg()
+                .sender({ uid: 'u_alice', uin: '11111', nick: 'Alice', card: 'Alice (PM)' })
+                .reply({
+                    sourceMsgId: replyTarget.msgId,
+                    senderUin: '11111',
+                    senderName: 'Alice (PM)',
+                    content: 'Anyone seen the build break?',
+                    msgSeq: replyTarget.msgSeq,
+                    msgTime: Number(replyTarget.msgTime)
+                })
+                .text('thanks team, fix incoming')
+                .at_time(T + 240)
+                .build()
+        )
+        .add(
+            msg()
+                .sender({ uid: 'u_alice', uin: '11111', nick: 'Alice', card: 'Alice (PM)' })
+                .voice({ filename: 'voice_msg.silk', duration: 7, size: 12_000 })
+                .at_time(T + 300)
+                .build()
+        )
+        .build();
+}
+
+/* ----------------------------- Scenario 3: Recall ---------------------------- */
+
+export function privateWithRecall(): MockConversation {
+    resetIds();
+    return conversation(privatePeer('u_bob'), { name: 'Bob', type: 'private' })
+        .add(msg().sender({ uid: 'u_bob', uin: '22222', nick: 'Bob' }).text('whoops sent wrong link').at_time(T + 0).recall(T + 5).build())
+        .add(msg().sender({ uid: 'u_bob', uin: '22222', nick: 'Bob' }).text('https://example.com/correct').at_time(T + 10).build())
+        .build();
+}
+
+/* ----------------------------- Scenario 4: Forward --------------------------- */
+
+export function privateWithForward(): MockConversation {
+    resetIds();
+    const inner = [
+        msg().sender({ uid: 'u_alice', uin: '11111', nick: 'Alice' }).text('Q1 plan v3').at_time(T + 1000).build(),
+        msg().sender({ uid: 'u_alice', uin: '11111', nick: 'Alice' }).image({ filename: 'plan.png', md5: 'abc123' }).at_time(T + 1010).build()
+    ];
+
+    return conversation(privatePeer('u_bob'), { name: 'Bob', type: 'private' })
+        .add(
+            msg()
+                .sender({ uid: 'u_alice', uin: '11111', nick: 'Alice' })
+                .forward({ resId: 'forward_res_001', xmlContent: '<msg brief="[聊天记录]"></msg>', records: inner })
+                .at_time(T + 1500)
+                .build()
+        )
+        .build();
+}
+
+/* --------------------------- Scenario 5: Volume ---------------------------- */
+
+/**
+ * Creates `count` text messages spanning `count` minutes. Used by fetcher
+ * pagination tests — the BatchMessageFetcher splits this across batches and
+ * we want to be sure none of the messages get dropped or duplicated.
+ */
+export function privateVolume(count: number): MockConversation {
+    resetIds();
+    const builder = conversation(privatePeer('u_alice'), { name: 'Alice', type: 'private' });
+    for (let i = 0; i < count; i++) {
+        builder.add(
+            msg()
+                .sender({ uid: 'u_alice', uin: '11111', nick: 'Alice' })
+                .text(`message #${i + 1}`)
+                .at_time(T + i * 60)
+                .build()
+        );
+    }
+    return builder.build();
+}

--- a/plugins/qq-chat-exporter/__tests__/helpers/MockNapCatCore.ts
+++ b/plugins/qq-chat-exporter/__tests__/helpers/MockNapCatCore.ts
@@ -1,0 +1,330 @@
+/**
+ * MockNapCatCore - factory for a NapCatCore-shaped object suitable for use as
+ * the bridge `core` in tests.
+ *
+ * Why this exists:
+ *   The QCE plugin reaches into NapCatQQ via a Bridge proxy
+ *   (`globalThis.__NAPCAT_BRIDGE__`). At runtime every `core.apis.X.Y` call
+ *   gets forwarded to whatever the Bridge exposes. By providing a Bridge whose
+ *   `core` returns deterministic data from in-memory fixtures we can run the
+ *   real fetchers / parsers / exporters end-to-end without ever logging into
+ *   QQ. One fixture file = one regression test = one lifetime of confidence.
+ */
+
+import type { RawMessage } from 'NapCatQQ/src/core/index.js';
+import type {
+    MockConfig,
+    MockConversation,
+    MockFriend,
+    MockGroup,
+    MockGroupMember,
+    MockPeer,
+    MockSelfInfo
+} from './types.js';
+
+interface CallLogEntry {
+    timestamp: number;
+    api: string;
+    args: unknown[];
+}
+
+export interface MockNapCatCore {
+    apis: {
+        MsgApi: MsgApi;
+        FileApi: FileApi;
+        GroupApi: GroupApi;
+        UserApi: UserApi;
+        FriendApi: FriendApi;
+        WebApi: WebApi;
+    };
+    context: {
+        workingEnv: 1 | 2;
+        logger: Logger;
+        pathWrapper: { cachePath: string; tmpPath: string; logsPath: string };
+        session: SessionFacade;
+    };
+    selfInfo: MockSelfInfo;
+
+    /* --- test-only escape hatches --- */
+    __getCallLog(): readonly CallLogEntry[];
+    __clearCallLog(): void;
+    __setConversations(conversations: MockConversation[]): void;
+    __setFriends(friends: MockFriend[]): void;
+    __setGroups(groups: MockGroup[]): void;
+}
+
+interface Logger {
+    log(...args: unknown[]): void;
+    logError(...args: unknown[]): void;
+    logWarn(...args: unknown[]): void;
+    logDebug(...args: unknown[]): void;
+}
+
+interface MsgApi {
+    getMsgHistory(peer: MockPeer, msgId: string, count: number, reverse: boolean): Promise<{ msgList: RawMessage[] }>;
+    getAioFirstViewLatestMsgs(peer: MockPeer, count: number): Promise<{ msgList: RawMessage[] }>;
+    getMultiMsg(params: { peer?: MockPeer; rootMsgId?: string; parentMsgId?: string; forwardId?: string; resId?: string }): Promise<{ msgList: RawMessage[] } | undefined>;
+}
+
+interface FileApi {
+    downloadMedia(
+        msgId: string,
+        chatType: number,
+        peerUid: string,
+        elementId: string,
+        thumbPath: string,
+        sourcePath: string,
+        timeout?: number,
+        force?: boolean
+    ): Promise<string>;
+}
+
+interface GroupApi {
+    getGroups(forceRefresh?: boolean): Promise<MockGroup[]>;
+    fetchGroupDetail(groupCode: string): Promise<MockGroup | undefined>;
+    getGroupMemberAll(groupCode: string, forceRefresh?: boolean): Promise<{ result: { infos: Map<string, MockGroupMember> } }>;
+}
+
+interface UserApi {
+    getUserDetailInfo(uid: string, noCache?: boolean): Promise<{ uid: string; uin?: string; nick: string; longNick?: string }>;
+    getUidByUinV2(uin: string): Promise<string>;
+    getRecentContactListSnapShot(): Promise<unknown[]>;
+}
+
+interface FriendApi {
+    getBuddy(): Promise<MockFriend[]>;
+    getFriends(forceRefresh?: boolean): Promise<MockFriend[]>;
+    getBuddyV2ExWithCate(): Promise<unknown[]>;
+}
+
+interface WebApi {
+    getGroupEssenceMsgAll(groupCode: string): Promise<{ msgList: unknown[] }>;
+}
+
+interface SessionFacade {
+    getMsgService(): {
+        getAioFirstViewLatestMsgs(peer: MockPeer, count: number): Promise<{ msgList: RawMessage[] }>;
+        getMsgsBySeqRange(peer: MockPeer, endSeq: string, startSeq: string): Promise<{ msgList: RawMessage[] }>;
+    };
+    getRichMediaService(): Record<string, never>;
+}
+
+/**
+ * Build a MockNapCatCore from a configuration object.
+ *
+ * The returned core can be passed to `installBridge({ core })` (or any helper
+ * that produces a Bridge) to make the plugin code believe it is talking to a
+ * live NapCat instance.
+ */
+export function createMockCore(config: MockConfig = {}): MockNapCatCore {
+    const callLog: CallLogEntry[] = [];
+    const logSink = config.logSink ?? (() => undefined);
+
+    const selfInfo: MockSelfInfo = {
+        uid: config.selfInfo?.uid ?? 'self_test_uid',
+        uin: config.selfInfo?.uin ?? '10000',
+        nick: config.selfInfo?.nick ?? 'TestSelf',
+        online: config.selfInfo?.online ?? true
+    };
+
+    let friends: MockFriend[] = config.friends ? [...config.friends] : [];
+    let groups: MockGroup[] = config.groups ? [...config.groups] : [];
+    let conversations: MockConversation[] = config.conversations ? [...config.conversations] : [];
+
+    function track(api: string, args: unknown[]): void {
+        callLog.push({ timestamp: Date.now(), api, args });
+    }
+
+    function findConversation(peer: MockPeer): MockConversation | undefined {
+        return conversations.find(
+            (c) => c.peer.peerUid === peer.peerUid && c.peer.chatType === peer.chatType
+        );
+    }
+
+    function sortByTimeDesc(a: RawMessage, b: RawMessage): number {
+        const ta = Number(a.msgTime ?? 0);
+        const tb = Number(b.msgTime ?? 0);
+        return tb - ta;
+    }
+
+    const logger: Logger = {
+        log: (...args) => logSink('log', args),
+        logError: (...args) => logSink('error', args),
+        logWarn: (...args) => logSink('warn', args),
+        logDebug: (...args) => logSink('debug', args)
+    };
+
+    const MsgApi: MsgApi = {
+        async getMsgHistory(peer, msgId, count, _reverse) {
+            track('MsgApi.getMsgHistory', [peer, msgId, count, _reverse]);
+            const conv = findConversation(peer);
+            if (!conv) return { msgList: [] };
+            const sorted = [...conv.messages].sort(sortByTimeDesc);
+            // msgId === '' or '0' means "latest"
+            const anchorIdx = msgId && msgId !== '0'
+                ? sorted.findIndex((m) => m.msgId === msgId)
+                : -1;
+            const startIdx = anchorIdx >= 0 ? anchorIdx + 1 : 0;
+            const slice = sorted.slice(startIdx, startIdx + count);
+            return { msgList: slice };
+        },
+
+        async getAioFirstViewLatestMsgs(peer, count) {
+            track('MsgApi.getAioFirstViewLatestMsgs', [peer, count]);
+            const conv = findConversation(peer);
+            if (!conv) return { msgList: [] };
+            const sorted = [...conv.messages].sort(sortByTimeDesc);
+            return { msgList: sorted.slice(0, count) };
+        },
+
+        async getMultiMsg(params) {
+            track('MsgApi.getMultiMsg', [params]);
+            // Look up forward by resId or rootMsgId across all conversations
+            const target = params.forwardId ?? params.resId ?? params.rootMsgId;
+            if (!target) return { msgList: [] };
+            for (const conv of conversations) {
+                for (const msg of conv.messages) {
+                    if (msg.msgId === target && Array.isArray((msg as { records?: RawMessage[] }).records)) {
+                        return { msgList: (msg as { records: RawMessage[] }).records };
+                    }
+                    const forwardEl = (msg.elements ?? []).find(
+                        (e) => (e as { multiForwardMsgElement?: { resId?: string } })
+                            .multiForwardMsgElement?.resId === target
+                    );
+                    if (forwardEl && Array.isArray((msg as { records?: RawMessage[] }).records)) {
+                        return { msgList: (msg as { records: RawMessage[] }).records };
+                    }
+                }
+            }
+            return { msgList: [] };
+        }
+    };
+
+    const FileApi: FileApi = {
+        async downloadMedia(msgId, chatType, peerUid, elementId, _thumbPath, sourcePath) {
+            track('FileApi.downloadMedia', [msgId, chatType, peerUid, elementId]);
+            // Pretend we wrote to sourcePath. The exporter only needs a string back.
+            return sourcePath || `/tmp/mock-media/${msgId}-${elementId}`;
+        }
+    };
+
+    const GroupApi: GroupApi = {
+        async getGroups(forceRefresh) {
+            track('GroupApi.getGroups', [forceRefresh]);
+            return groups.map((g) => ({ ...g, members: undefined }));
+        },
+        async fetchGroupDetail(groupCode) {
+            track('GroupApi.fetchGroupDetail', [groupCode]);
+            const g = groups.find((x) => x.groupCode === groupCode);
+            return g ? { ...g, members: undefined } : undefined;
+        },
+        async getGroupMemberAll(groupCode, forceRefresh) {
+            track('GroupApi.getGroupMemberAll', [groupCode, forceRefresh]);
+            const g = groups.find((x) => x.groupCode === groupCode);
+            const infos = new Map<string, MockGroupMember>();
+            for (const m of g?.members ?? []) infos.set(m.uid, m);
+            return { result: { infos } };
+        }
+    };
+
+    const UserApi: UserApi = {
+        async getUserDetailInfo(uid, noCache) {
+            track('UserApi.getUserDetailInfo', [uid, noCache]);
+            const f = friends.find((x) => x.uid === uid || x.uin === uid);
+            if (f) return { uid: f.uid, uin: f.uin, nick: f.nick, longNick: f.longNick };
+            for (const g of groups) {
+                const m = (g.members ?? []).find((x) => x.uid === uid || x.uin === uid);
+                if (m) return { uid: m.uid, uin: m.uin, nick: m.nick };
+            }
+            return { uid, nick: `Unknown_${uid}` };
+        },
+        async getUidByUinV2(uin) {
+            track('UserApi.getUidByUinV2', [uin]);
+            const f = friends.find((x) => x.uin === uin);
+            if (f) return f.uid;
+            for (const g of groups) {
+                const m = (g.members ?? []).find((x) => x.uin === uin);
+                if (m) return m.uid;
+            }
+            return `u_${uin}`;
+        },
+        async getRecentContactListSnapShot() {
+            track('UserApi.getRecentContactListSnapShot', []);
+            return [];
+        }
+    };
+
+    const FriendApi: FriendApi = {
+        async getBuddy() {
+            track('FriendApi.getBuddy', []);
+            return [...friends];
+        },
+        async getFriends(forceRefresh) {
+            track('FriendApi.getFriends', [forceRefresh]);
+            return [...friends];
+        },
+        async getBuddyV2ExWithCate() {
+            track('FriendApi.getBuddyV2ExWithCate', []);
+            const cats = new Map<number, { categoryId: number; categoryName: string; buddyList: MockFriend[] }>();
+            for (const f of friends) {
+                const cid = f.categoryId ?? 0;
+                if (!cats.has(cid)) cats.set(cid, { categoryId: cid, categoryName: f.categoryName ?? 'Default', buddyList: [] });
+                cats.get(cid)!.buddyList.push(f);
+            }
+            return Array.from(cats.values());
+        }
+    };
+
+    const WebApi: WebApi = {
+        async getGroupEssenceMsgAll(groupCode) {
+            track('WebApi.getGroupEssenceMsgAll', [groupCode]);
+            return { msgList: [] };
+        }
+    };
+
+    const session: SessionFacade = {
+        getMsgService() {
+            return {
+                getAioFirstViewLatestMsgs: (peer, count) =>
+                    MsgApi.getAioFirstViewLatestMsgs(peer, count),
+                async getMsgsBySeqRange(peer, endSeq, startSeq) {
+                    track('session.getMsgsBySeqRange', [peer, endSeq, startSeq]);
+                    const conv = findConversation(peer);
+                    if (!conv) return { msgList: [] };
+                    const lo = parseInt(endSeq, 10);
+                    const hi = parseInt(startSeq, 10);
+                    return {
+                        msgList: conv.messages.filter((m) => {
+                            const s = parseInt(m.msgSeq ?? '0', 10);
+                            return s >= lo && s <= hi;
+                        }).sort(sortByTimeDesc)
+                    };
+                }
+            };
+        },
+        getRichMediaService() {
+            return {};
+        }
+    };
+
+    return {
+        apis: { MsgApi, FileApi, GroupApi, UserApi, FriendApi, WebApi },
+        context: {
+            workingEnv: config.workingEnv ?? 2,
+            logger,
+            pathWrapper: {
+                cachePath: config.paths?.cachePath ?? '/tmp/qce-test-cache',
+                tmpPath: config.paths?.tmpPath ?? '/tmp/qce-test-tmp',
+                logsPath: config.paths?.logsPath ?? '/tmp/qce-test-logs'
+            },
+            session
+        },
+        selfInfo,
+
+        __getCallLog: () => callLog,
+        __clearCallLog: () => { callLog.length = 0; },
+        __setConversations: (next) => { conversations = [...next]; },
+        __setFriends: (next) => { friends = [...next]; },
+        __setGroups: (next) => { groups = [...next]; }
+    };
+}

--- a/plugins/qq-chat-exporter/__tests__/helpers/installBridge.ts
+++ b/plugins/qq-chat-exporter/__tests__/helpers/installBridge.ts
@@ -1,0 +1,103 @@
+/**
+ * Bridge installation helpers.
+ *
+ * The QCE plugin reads its environment from `globalThis.__NAPCAT_BRIDGE__`.
+ * Tests need to make that global look like a real NapCat host. These helpers
+ * wrap the boilerplate so each test file is a single function call.
+ */
+
+import type { MockNapCatCore } from './MockNapCatCore.js';
+
+export interface MockBridge {
+    core: MockNapCatCore;
+    obContext: {
+        actions: Map<string, { handle: (...args: unknown[]) => Promise<{ data?: unknown }> }>;
+        adapterName: string;
+    };
+    actions: Map<string, { handle: (...args: unknown[]) => Promise<{ data?: unknown }> }>;
+    instance: { actions: Map<string, unknown>; core: MockNapCatCore; config: Record<string, unknown> };
+}
+
+declare global {
+    // eslint-disable-next-line no-var
+    var __NAPCAT_BRIDGE__: MockBridge | undefined;
+}
+
+interface InstallOptions {
+    core: MockNapCatCore;
+    extraActions?: Record<string, (params: unknown) => Promise<unknown>>;
+}
+
+/**
+ * Install a bridge backed by the supplied MockNapCatCore.
+ *
+ * Returns the bridge so tests can grab references to actions/instance for
+ * extra assertions. Always pair with a call to `uninstallBridge()` (typically
+ * in `afterEach` / `t.after`) to keep tests isolated.
+ */
+export function installBridge(options: InstallOptions): MockBridge {
+    const actions = new Map<string, { handle: (...args: unknown[]) => Promise<{ data?: unknown }> }>([
+        [
+            'get_version_info',
+            {
+                handle: async () => ({ data: { app_name: 'NapCat', app_version: 'mock' } })
+            }
+        ],
+        [
+            'get_login_info',
+            {
+                handle: async () => ({
+                    data: { user_id: Number(options.core.selfInfo.uin), nickname: options.core.selfInfo.nick }
+                })
+            }
+        ],
+        [
+            'get_forward_msg',
+            {
+                handle: async (params: unknown) => {
+                    const id = (params as { id?: string }).id;
+                    if (!id) return { data: { messages: [] } };
+                    const result = await options.core.apis.MsgApi.getMultiMsg({ forwardId: id, resId: id });
+                    return { data: { messages: result?.msgList ?? [] } };
+                }
+            }
+        ]
+    ]);
+
+    if (options.extraActions) {
+        for (const [name, fn] of Object.entries(options.extraActions)) {
+            actions.set(name, {
+                handle: async (params: unknown) => ({ data: await fn(params) })
+            });
+        }
+    }
+
+    const obContext = { actions, adapterName: 'OneBot' };
+    const instance = { actions, core: options.core, config: {} };
+
+    const bridge: MockBridge = { core: options.core, obContext, actions, instance };
+    globalThis.__NAPCAT_BRIDGE__ = bridge;
+    return bridge;
+}
+
+/** Tear the global bridge down so tests don't leak state between files. */
+export function uninstallBridge(): void {
+    delete (globalThis as { __NAPCAT_BRIDGE__?: unknown }).__NAPCAT_BRIDGE__;
+}
+
+/**
+ * Convenience wrapper: install for the duration of `fn` and uninstall after.
+ *
+ * Useful inside `it()` blocks when you don't want lifecycle hooks.
+ */
+export async function withBridge<T>(
+    options: InstallOptions,
+    fn: (bridge: MockBridge) => Promise<T>
+): Promise<T> {
+    const bridge = installBridge(options);
+    try {
+        return await fn(bridge);
+    } finally {
+        uninstallBridge();
+    }
+}

--- a/plugins/qq-chat-exporter/__tests__/helpers/silenceConsole.ts
+++ b/plugins/qq-chat-exporter/__tests__/helpers/silenceConsole.ts
@@ -1,0 +1,41 @@
+/**
+ * Console silencer.
+ *
+ * Production code logs aggressively via `console.log` / `console.warn`. The
+ * test runner output is unreadable with that noise, so we patch the global
+ * console while tests run. Set `QCE_TEST_VERBOSE=1` to pass through.
+ */
+
+interface SilencedConsole {
+    captured: { level: 'log' | 'warn' | 'error' | 'debug' | 'info'; args: unknown[] }[];
+    restore(): void;
+}
+
+export function silenceConsole(): SilencedConsole {
+    if (process.env.QCE_TEST_VERBOSE) {
+        return { captured: [], restore: () => undefined };
+    }
+    const captured: SilencedConsole['captured'] = [];
+    const original = {
+        log: console.log,
+        warn: console.warn,
+        error: console.error,
+        debug: console.debug,
+        info: console.info
+    };
+    console.log = (...args: unknown[]) => captured.push({ level: 'log', args });
+    console.warn = (...args: unknown[]) => captured.push({ level: 'warn', args });
+    console.error = (...args: unknown[]) => captured.push({ level: 'error', args });
+    console.debug = (...args: unknown[]) => captured.push({ level: 'debug', args });
+    console.info = (...args: unknown[]) => captured.push({ level: 'info', args });
+    return {
+        captured,
+        restore() {
+            console.log = original.log;
+            console.warn = original.warn;
+            console.error = original.error;
+            console.debug = original.debug;
+            console.info = original.info;
+        }
+    };
+}

--- a/plugins/qq-chat-exporter/__tests__/helpers/snapshot.ts
+++ b/plugins/qq-chat-exporter/__tests__/helpers/snapshot.ts
@@ -29,19 +29,25 @@ function resolveSnapshotPath(opts: SnapshotOptions): string {
     return path.join(snapDir, `${opts.name}${opts.ext ?? '.snap.txt'}`);
 }
 
+/** Normalize CRLF -> LF so snapshots compare equal regardless of git's autocrlf. */
+function normalizeLineEndings(s: string): string {
+    return s.replace(/\r\n/g, '\n');
+}
+
 export function assertSnapshot(actual: string, opts: SnapshotOptions): void {
     const file = resolveSnapshotPath(opts);
+    const actualNorm = normalizeLineEndings(actual);
 
     if (process.env[UPDATE_ENV] || !fs.existsSync(file)) {
-        fs.writeFileSync(file, actual, 'utf8');
+        fs.writeFileSync(file, actualNorm, 'utf8');
         return;
     }
 
-    const expected = fs.readFileSync(file, 'utf8');
-    if (actual === expected) return;
+    const expected = normalizeLineEndings(fs.readFileSync(file, 'utf8'));
+    if (actualNorm === expected) return;
 
     const errorPath = `${file}.actual`;
-    fs.writeFileSync(errorPath, actual, 'utf8');
+    fs.writeFileSync(errorPath, actualNorm, 'utf8');
     assert.fail(
         `Snapshot mismatch for "${opts.name}".\n` +
         `  expected: ${file}\n` +

--- a/plugins/qq-chat-exporter/__tests__/helpers/snapshot.ts
+++ b/plugins/qq-chat-exporter/__tests__/helpers/snapshot.ts
@@ -1,0 +1,58 @@
+/**
+ * Tiny snapshot helper used by exporter / parser tests.
+ *
+ * `node:test` ships its own snapshot API in Node 22 but it's still
+ * experimental and changes shape between minor versions, so we ship our own
+ * extremely small implementation. Run with `QCE_UPDATE_SNAPSHOTS=1` to refresh.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+
+const UPDATE_ENV = 'QCE_UPDATE_SNAPSHOTS';
+
+export interface SnapshotOptions {
+    /** Absolute path to the test file (use `import.meta.url`). */
+    testFileUrl: string;
+    /** Snapshot identifier (becomes the filename, sans ext). */
+    name: string;
+    /** Snapshot extension, defaults to `.snap.txt`. */
+    ext?: string;
+}
+
+function resolveSnapshotPath(opts: SnapshotOptions): string {
+    const testDir = path.dirname(fileURLToPath(opts.testFileUrl));
+    const snapDir = path.join(testDir, '__snapshots__');
+    fs.mkdirSync(snapDir, { recursive: true });
+    return path.join(snapDir, `${opts.name}${opts.ext ?? '.snap.txt'}`);
+}
+
+export function assertSnapshot(actual: string, opts: SnapshotOptions): void {
+    const file = resolveSnapshotPath(opts);
+
+    if (process.env[UPDATE_ENV] || !fs.existsSync(file)) {
+        fs.writeFileSync(file, actual, 'utf8');
+        return;
+    }
+
+    const expected = fs.readFileSync(file, 'utf8');
+    if (actual === expected) return;
+
+    const errorPath = `${file}.actual`;
+    fs.writeFileSync(errorPath, actual, 'utf8');
+    assert.fail(
+        `Snapshot mismatch for "${opts.name}".\n` +
+        `  expected: ${file}\n` +
+        `  actual:   ${errorPath}\n` +
+        `Run with ${UPDATE_ENV}=1 to update snapshots.`
+    );
+}
+
+export function assertJsonSnapshot(actual: unknown, opts: SnapshotOptions): void {
+    assertSnapshot(
+        JSON.stringify(actual, null, 2) + '\n',
+        { ...opts, ext: opts.ext ?? '.snap.json' }
+    );
+}

--- a/plugins/qq-chat-exporter/__tests__/helpers/tempDir.ts
+++ b/plugins/qq-chat-exporter/__tests__/helpers/tempDir.ts
@@ -1,0 +1,42 @@
+/**
+ * Disposable temp directory helper for exporter tests.
+ *
+ * Unlike `os.tmpdir()` we keep everything under a known location so failed
+ * tests can be inspected after the fact. Pass `keep: true` (or set
+ * `QCE_TEST_KEEP_TMP=1`) to skip cleanup.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const KEEP_ENV = 'QCE_TEST_KEEP_TMP';
+
+export interface TempDirHandle {
+    path: string;
+    cleanup(): void;
+}
+
+export function createTempDir(prefix = 'qce-test-'): TempDirHandle {
+    const root = path.join(os.tmpdir(), 'qce-tests');
+    fs.mkdirSync(root, { recursive: true });
+    const dir = fs.mkdtempSync(path.join(root, prefix));
+
+    let cleaned = false;
+    const cleanup = () => {
+        if (cleaned) return;
+        cleaned = true;
+        if (process.env[KEEP_ENV]) {
+            // eslint-disable-next-line no-console
+            console.log(`[tempDir] keeping ${dir} (${KEEP_ENV} set)`);
+            return;
+        }
+        try {
+            fs.rmSync(dir, { recursive: true, force: true });
+        } catch {
+            // best effort
+        }
+    };
+
+    return { path: dir, cleanup };
+}

--- a/plugins/qq-chat-exporter/__tests__/helpers/types.ts
+++ b/plugins/qq-chat-exporter/__tests__/helpers/types.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared types for the test harness.
+ * Kept loose because the production code talks to NTQQ shaped objects via the
+ * overlay bridge — strict typing the entire surface would require shipping
+ * the real NapCatQQ type bundle, which is not available in this repo.
+ */
+
+import type { RawMessage } from 'NapCatQQ/src/core/index.js';
+
+export type ChatType = 1 | 2 | 100 | 4;
+
+export interface MockPeer {
+    chatType: ChatType;
+    peerUid: string;
+    guildId?: string;
+}
+
+export interface MockFriend {
+    uid: string;
+    uin: string;
+    nick: string;
+    remark?: string;
+    longNick?: string;
+    avatarUrl?: string;
+    categoryId?: number;
+    categoryName?: string;
+}
+
+export interface MockGroupMember {
+    uid: string;
+    uin: string;
+    nick: string;
+    cardName?: string;
+    role?: number;
+    joinTime?: number;
+    avatarUrl?: string;
+}
+
+export interface MockGroup {
+    groupCode: string;
+    groupName: string;
+    memberCount?: number;
+    maxMember?: number;
+    avatarUrl?: string;
+    remarkName?: string;
+    members?: MockGroupMember[];
+}
+
+export interface MockConversation {
+    peer: MockPeer;
+    chatInfo?: {
+        name?: string;
+        type?: 'private' | 'group' | 'temp';
+        avatar?: string;
+        participantCount?: number;
+    };
+    messages: RawMessage[];
+}
+
+export interface MockSelfInfo {
+    uid: string;
+    uin: string;
+    nick: string;
+    online: boolean;
+}
+
+export interface MockConfig {
+    selfInfo?: Partial<MockSelfInfo>;
+    friends?: MockFriend[];
+    groups?: MockGroup[];
+    conversations?: MockConversation[];
+    /** Working environment: 1=shell, 2=framework. Defaults to 2. */
+    workingEnv?: 1 | 2;
+    /** Override paths exposed via core.context.pathWrapper */
+    paths?: {
+        cachePath?: string;
+        tmpPath?: string;
+        logsPath?: string;
+    };
+    /** Optional logger sink. Defaults to a silent in-memory logger. */
+    logSink?: (level: 'log' | 'error' | 'warn' | 'debug', args: unknown[]) => void;
+}

--- a/plugins/qq-chat-exporter/__tests__/integration/BatchMessageFetcher.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/integration/BatchMessageFetcher.test.ts
@@ -1,0 +1,104 @@
+/**
+ * BatchMessageFetcher integration tests.
+ *
+ * Drives the real fetcher against a MockNapCatCore that returns deterministic
+ * page-able message lists. We assert: pagination produces the right slices,
+ * every fixture message is observed exactly once, time / sender filters work,
+ * and the recorded API call sequence matches expectations.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createMockCore } from '../helpers/MockNapCatCore.js';
+import { installBridge, uninstallBridge } from '../helpers/installBridge.js';
+import { silenceConsole } from '../helpers/silenceConsole.js';
+import { privateVolume } from '../fixtures/conversations.js';
+
+async function loadFetcher() {
+    return await import('../../lib/core/fetcher/BatchMessageFetcher.js');
+}
+
+async function loadIndex() {
+    return await import('NapCatQQ/src/core/index.js' as string);
+}
+
+const TOTAL = 25;
+
+let core: ReturnType<typeof createMockCore>;
+let console_!: ReturnType<typeof silenceConsole>;
+
+test.beforeEach(() => {
+    console_ = silenceConsole();
+    const fixture = privateVolume(TOTAL);
+    core = createMockCore({ conversations: [fixture] });
+    installBridge({ core });
+});
+
+test.afterEach(() => {
+    uninstallBridge();
+    console_.restore();
+});
+
+test('fetches every message via fetchAllMessagesInTimeRange', async () => {
+    const { BatchMessageFetcher } = await loadFetcher();
+    const { Peer } = await loadIndex();
+
+    const peer = new Peer(1, 'u_alice');
+    const fetcher = new BatchMessageFetcher(core as never, { batchSize: 10 });
+
+    const collected: string[] = [];
+    for await (const batch of fetcher.fetchAllMessagesInTimeRange(peer, 0, Number.MAX_SAFE_INTEGER)) {
+        for (const m of batch) collected.push(m.msgId);
+    }
+
+    // Every fixture message exactly once. Order may vary because pagination
+    // is descending — assert by set comparison.
+    assert.equal(collected.length, TOTAL);
+    assert.equal(new Set(collected).size, TOTAL);
+});
+
+test('respects batchSize during pagination', async () => {
+    const { BatchMessageFetcher } = await loadFetcher();
+    const { Peer } = await loadIndex();
+
+    const peer = new Peer(1, 'u_alice');
+    const fetcher = new BatchMessageFetcher(core as never, { batchSize: 7 });
+
+    let calls = 0;
+    for await (const _ of fetcher.fetchAllMessagesInTimeRange(peer, 0, Number.MAX_SAFE_INTEGER)) {
+        calls++;
+    }
+    // 25 messages / 7 per batch -> at least 4 batches (last one may yield fewer)
+    assert.ok(calls >= 4, `expected at least 4 batches, got ${calls}`);
+
+    // First call uses getAioFirstViewLatestMsgs, subsequent ones use getMsgHistory
+    const log = core.__getCallLog().filter((e) => e.api.startsWith('MsgApi.'));
+    assert.equal(log[0].api, 'MsgApi.getAioFirstViewLatestMsgs');
+    assert.ok(
+        log.slice(1).every((e) => e.api === 'MsgApi.getMsgHistory'),
+        'expected only history calls after the first'
+    );
+});
+
+test('time filter removes out-of-range messages', async () => {
+    const { BatchMessageFetcher } = await loadFetcher();
+    const { Peer } = await loadIndex();
+
+    const peer = new Peer(1, 'u_alice');
+    const fetcher = new BatchMessageFetcher(core as never, { batchSize: 100 });
+
+    // Fixture timestamps are baseTime + i*60s starting at 2024-01-01T00:00:00Z
+    // in seconds. The fetcher's filter compares against ms timestamps.
+    const baseMs = 1704067200_000;
+    const startMs = baseMs + 5 * 60_000;
+    const endMs = baseMs + 9 * 60_000;
+
+    const collected: string[] = [];
+    for await (const batch of fetcher.fetchAllMessagesInTimeRange(peer, startMs, endMs)) {
+        for (const m of batch) collected.push(m.msgId);
+    }
+
+    // Messages 6..10 inclusive (5 messages) match the window.
+    assert.equal(collected.length, 5);
+});

--- a/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/.gitattributes
+++ b/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/HtmlExporter.groupMixedMedia.snap.html
+++ b/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/HtmlExporter.groupMixedMedia.snap.html
@@ -1,0 +1,614 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="QCE Testing Group的聊天记录导出文件">
+    <meta name="generator" content="<GENERATOR>">
+    <title>QCE Testing Group - 聊天记录</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+            background-color: #ffffff;
+            color: #262626;
+            line-height: 1.6;
+            
+            font-size: 14px;
+            @media (max-width: 768px) {
+                font-size: 12px;
+            }
+        }
+
+        .chat-container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            
+            @media (max-width: 768px) {
+                padding: 10px;
+            }
+        }
+
+        .chat-header {
+            text-align: center;
+            padding: 30px 0;
+            border-bottom: 2px solid #f0f2f5;
+            margin-bottom: 30px;
+        }
+
+        .chat-title {
+            font-size: 2.5em;
+            font-weight: bold;
+            color: #1890ff;
+            margin-bottom: 10px;
+        }
+
+        .chat-info {
+            font-size: 1.1em;
+            color: #262626;
+            opacity: 0.8;
+        }
+
+        .chat-avatar {
+            width: 80px;
+            height: 80px;
+            border-radius: 50%;
+            margin: 0 auto 20px;
+            background: #f0f2f5;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 2em;
+        }
+
+        .statistics {
+            background: #f0f2f5;
+            border-radius: 10px;
+            padding: 20px;
+            margin-bottom: 30px;
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 15px;
+        }
+
+        .stat-item {
+            text-align: center;
+        }
+
+        .stat-number {
+            font-size: 2em;
+            font-weight: bold;
+            color: #1890ff;
+        }
+
+        .stat-label {
+            font-size: 0.9em;
+            opacity: 0.8;
+            margin-top: 5px;
+        }
+
+        .search-bar {
+            margin-bottom: 20px;
+        }
+
+        .search-input {
+            width: 100%;
+            padding: 12px 20px;
+            border: 2px solid #f0f2f5;
+            border-radius: 25px;
+            font-size: 1em;
+            background: #ffffff;
+            color: #262626;
+            transition: border-color 0.3s;
+        }
+
+        .search-input:focus {
+            outline: none;
+            border-color: #1890ff;
+        }
+
+        .messages-container {
+            margin-bottom: 50px;
+        }
+
+        .message {
+            margin-bottom: 20px;
+            padding: 15px;
+            border-radius: 12px;
+            background: #e6f7ff;
+            position: relative;
+            word-wrap: break-word;
+            
+            @media (max-width: 768px) {
+                padding: 12px;
+                margin-bottom: 15px;
+            }
+        }
+
+        .message.system {
+            text-align: center;
+            background: #f0f2f5;
+            font-style: italic;
+            opacity: 0.8;
+        }
+
+        .message-header {
+            display: flex;
+            align-items: center;
+            margin-bottom: 8px;
+            gap: 10px;
+        }
+
+        .message-avatar {
+            width: 36px;
+            height: 36px;
+            border-radius: 50%;
+            background: #1890ff;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            font-weight: bold;
+            font-size: 0.8em;
+        }
+
+        .message-sender {
+            font-weight: bold;
+            color: #1890ff;
+            flex-grow: 1;
+        }
+
+        .message-time {
+            font-size: 0.85em;
+            opacity: 0.6;
+            
+            @media (max-width: 768px) {
+                display: none;
+            }
+        }
+
+        .message-content {
+            margin-left: 46px;
+            
+            @media (max-width: 768px) {
+                margin-left: 0;
+            }
+        }
+
+        .reply-content {
+            background: #f0f2f5;
+            padding: 8px 12px;
+            border-radius: 8px;
+            margin-bottom: 8px;
+            border-left: 3px solid #1890ff;
+            font-size: 0.9em;
+            opacity: 0.8;
+        }
+
+        .mention {
+            color: #1890ff;
+            font-weight: bold;
+            text-decoration: none;
+        }
+
+        .mention:hover {
+            text-decoration: underline;
+        }
+
+        .emoji {
+            font-size: 1.2em;
+        }
+
+        .message-image, .message-video {
+            max-width: 100%;
+            max-height: 400px;
+            border-radius: 8px;
+            margin: 8px 0;
+            cursor: pointer;
+            transition: transform 0.2s;
+        }
+
+        .message-image:hover, .message-video:hover {
+            transform: scale(1.02);
+        }
+
+        .message-audio {
+            width: 100%;
+            margin: 8px 0;
+        }
+
+        .message-file {
+            display: inline-flex;
+            align-items: center;
+            padding: 8px 12px;
+            background: #f0f2f5;
+            border-radius: 8px;
+            text-decoration: none;
+            color: #262626;
+            margin: 8px 0;
+            transition: background-color 0.2s;
+        }
+
+        .message-file:hover {
+            background: #1890ff;
+            color: white;
+        }
+
+        .resource-placeholder {
+            display: inline-block;
+            padding: 4px 8px;
+            background: #f0f2f5;
+            border-radius: 4px;
+            font-size: 0.9em;
+            opacity: 0.8;
+        }
+
+        .resources-list {
+            margin-top: 8px;
+            padding: 8px;
+            background: #f0f2f5;
+            border-radius: 6px;
+            font-size: 0.9em;
+        }
+
+        .resource-item {
+            margin: 4px 0;
+            padding: 4px 0;
+            border-bottom: 1px solid rgba(0,0,0,0.1);
+        }
+
+        .resource-item:last-child {
+            border-bottom: none;
+        }
+
+        .chat-footer {
+            text-align: center;
+            padding: 30px 0;
+            border-top: 2px solid #f0f2f5;
+            font-size: 0.9em;
+            opacity: 0.6;
+        }
+
+        .loading {
+            text-align: center;
+            padding: 20px;
+            opacity: 0.6;
+        }
+
+        /* 响应式设计 */
+        
+        @media (max-width: 768px) {
+            .chat-title {
+                font-size: 1.8em;
+            }
+            
+            .statistics {
+                grid-template-columns: repeat(2, 1fr);
+                gap: 10px;
+                padding: 15px;
+            }
+            
+            .stat-number {
+                font-size: 1.5em;
+            }
+            
+            .message-header {
+                flex-wrap: wrap;
+            }
+            
+            .message-time {
+                width: 100%;
+                margin-top: 5px;
+                margin-left: 46px;
+            }
+        }
+
+        /* 打印样式 */
+        @media print {
+            .search-bar, .chat-footer {
+                display: none;
+            }
+            
+            .message {
+                break-inside: avoid;
+                margin-bottom: 10px;
+            }
+            
+            .message-image, .message-video {
+                max-height: 200px;
+            }
+        }
+
+        /* 暗色主题适配 */
+        @media (prefers-color-scheme: dark) {
+            
+            body {
+                background-color: #1f1f1f;
+                color: #ffffff;
+            }
+            
+            .message {
+                background: #3a3a3a;
+            }
+            
+            .statistics {
+                background: #2f2f2f;
+            }
+        }
+
+        /* 动画效果 */
+        .message {
+            animation: fadeIn 0.3s ease-in;
+        }
+
+        @keyframes fadeIn {
+            from {
+                opacity: 0;
+                transform: translateY(10px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        /* 滚动条样式 */
+        ::-webkit-scrollbar {
+            width: 8px;
+        }
+
+        ::-webkit-scrollbar-track {
+            background: #f0f2f5;
+        }
+
+        ::-webkit-scrollbar-thumb {
+            background: #1890ff;
+            border-radius: 4px;
+        }
+
+        ::-webkit-scrollbar-thumb:hover {
+            background: #1890ffCC;
+        }
+        </style>
+    
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><text y='20' font-size='20'>💬</text></svg>">
+</head>
+<body>
+    <div class="chat-container">
+        
+        <div class="chat-header">
+            
+            <div class="chat-avatar">
+                👥
+            </div>
+            <h1 class="chat-title">QCE Testing Group</h1>
+            <div class="chat-info">
+                <div>群聊</div>
+                <div>参与人数: 4</div>
+                <div>导出时间: <TIMESTAMP></div>
+                <div>时间范围: 2024-01-01 00:01:40 至 2024-01-01 00:05:00</div>
+            </div>
+        </div>
+        
+        <div class="statistics">
+            <div class="stat-item">
+                <div class="stat-number">7</div>
+                <div class="stat-label">总消息数</div>
+            </div>
+            <div class="stat-item">
+                <div class="stat-number">3</div>
+                <div class="stat-label">参与者</div>
+            </div>
+            <div class="stat-item">
+                <div class="stat-number">3</div>
+                <div class="stat-label">资源文件</div>
+            </div>
+            <div class="stat-item">
+                <div class="stat-number">1</div>
+                <div class="stat-label">时间跨度(天)</div>
+            </div>
+        </div>
+        
+        <div class="messages-container" id="messagesContainer">
+            
+        <div class="message" data-message-id="m_1">
+            <div class="message-header">
+                
+                <div class="message-avatar">
+                    A
+                </div>
+                <span class="message-sender">Alice</span>
+                
+                <span class="message-time">2024-01-01 00:01:40</span>
+            </div>
+            <div class="message-content">
+                
+                Anyone seen the build break?
+                
+            </div>
+        </div>
+
+        <div class="message" data-message-id="m_2">
+            <div class="message-header">
+                
+                <div class="message-avatar">
+                    B
+                </div>
+                <span class="message-sender">Bob</span>
+                
+                <span class="message-time">2024-01-01 00:02:40</span>
+            </div>
+            <div class="message-content">
+                
+                Looking now [[微笑]]
+                
+            </div>
+        </div>
+
+        <div class="message" data-message-id="m_3">
+            <div class="message-header">
+                
+                <div class="message-avatar">
+                    B
+                </div>
+                <span class="message-sender">Bob</span>
+                
+                <span class="message-time">2024-01-01 00:02:45</span>
+            </div>
+            <div class="message-content">
+                
+                [图片: screenshot.png]
+                <img src="https://multimedia.nt.qq.com.cn/screenshot.png" alt="screenshot.png" class="message-image" loading="lazy">
+            </div>
+        </div>
+
+        <div class="message" data-message-id="m_4">
+            <div class="message-header">
+                
+                <div class="message-avatar">
+                    C
+                </div>
+                <span class="message-sender">Charlie</span>
+                
+                <span class="message-time">2024-01-01 00:03:20</span>
+            </div>
+            <div class="message-content">
+                
+                @Alice sentry has the trace, sending now
+                
+            </div>
+        </div>
+
+        <div class="message" data-message-id="m_5">
+            <div class="message-header">
+                
+                <div class="message-avatar">
+                    C
+                </div>
+                <span class="message-sender">Charlie</span>
+                
+                <span class="message-time">2024-01-01 00:03:30</span>
+            </div>
+            <div class="message-content">
+                
+                [文件: trace.json]
+                <span class="resource-placeholder">[文件: trace.json]</span>
+            </div>
+        </div>
+
+        <div class="message" data-message-id="m_6">
+            <div class="message-header">
+                
+                <div class="message-avatar">
+                    A
+                </div>
+                <span class="message-sender">Alice</span>
+                
+                <span class="message-time">2024-01-01 00:04:00</span>
+            </div>
+            <div class="message-content">
+                
+        <div class="reply-content">
+            <strong>用户:</strong>
+            Anyone seen the build break?
+        </div>
+                [回复 : Anyone seen the build break?]<br>thanks team, fix incoming
+                
+            </div>
+        </div>
+
+        <div class="message" data-message-id="m_7">
+            <div class="message-header">
+                
+                <div class="message-avatar">
+                    A
+                </div>
+                <span class="message-sender">Alice</span>
+                
+                <span class="message-time">2024-01-01 00:05:00</span>
+            </div>
+            <div class="message-content">
+                
+                [语音 7秒]
+                <span class="resource-placeholder">[语音: voice_msg.silk]</span>
+            </div>
+        </div>
+        </div>
+        
+        <div class="chat-footer">
+            <p>由 <strong>QQ聊天记录导出工具</strong> 生成</p>
+            <p>导出时间: <TIMESTAMP></p>
+        </div>
+    </div>
+    
+        <script>
+        (function() {
+            // 搜索功能
+            
+
+            // 图片点击放大
+            document.addEventListener('click', function(e) {
+                if (e.target.classList.contains('message-image')) {
+                    const img = e.target;
+                    const overlay = document.createElement('div');
+                    overlay.style.cssText = 'position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.8); z-index: 1000; display: flex; align-items: center; justify-content: center; cursor: pointer;';
+                    
+                    const enlargedImg = img.cloneNode();
+                    enlargedImg.style.cssText = 'max-width: 90%; max-height: 90%; object-fit: contain;';
+                    
+                    overlay.appendChild(enlargedImg);
+                    document.body.appendChild(overlay);
+                    
+                    overlay.addEventListener('click', () => {
+                        document.body.removeChild(overlay);
+                    });
+                }
+            });
+
+            // 懒加载实现
+            
+            if ('IntersectionObserver' in window) {
+                const imageObserver = new IntersectionObserver((entries, observer) => {
+                    entries.forEach(entry => {
+                        if (entry.isIntersecting) {
+                            const img = entry.target;
+                            if (img.dataset.src) {
+                                img.src = img.dataset.src;
+                                img.removeAttribute('data-src');
+                                observer.unobserve(img);
+                            }
+                        }
+                    });
+                });
+
+                document.querySelectorAll('img[data-src]').forEach(img => {
+                    imageObserver.observe(img);
+                });
+            }
+
+            // 平滑滚动到锚点
+            document.addEventListener('click', function(e) {
+                if (e.target.tagName === 'A' && e.target.hash) {
+                    e.preventDefault();
+                    const target = document.querySelector(e.target.hash);
+                    if (target) {
+                        target.scrollIntoView({ behavior: 'smooth' });
+                    }
+                }
+            });
+
+            // 自定义JavaScript
+            
+
+            console.log('QQ聊天记录导出工具 - HTML页面已加载完成');
+        })();
+        </script>
+</body>
+</html>

--- a/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/JsonExporter.groupMixedMedia.snap.json
+++ b/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/JsonExporter.groupMixedMedia.snap.json
@@ -1,0 +1,335 @@
+{
+  "metadata": {
+    "name": "QQChatExporter V5 / https://github.com/shuakami/qq-chat-exporter",
+    "copyright": "本软件是免费的开源项目~ 如果您是买来的，请立即退款！如果有帮助到您，欢迎给我点个Star~"
+  },
+  "chatInfo": {
+    "name": "QCE Testing Group",
+    "type": "group",
+    "participantCount": 4
+  },
+  "statistics": {
+    "totalMessages": 7,
+    "timeRange": {
+      "start": "2024-01-01T00:01:40.000Z",
+      "end": "2024-01-01T00:05:00.000Z",
+      "durationDays": 1
+    },
+    "messageTypes": {
+      "text": 4,
+      "file": 1,
+      "reply": 1,
+      "audio": 1
+    },
+    "senders": [
+      {
+        "uid": "u_alice",
+        "name": "Alice",
+        "messageCount": 3,
+        "percentage": 42.86
+      },
+      {
+        "uid": "u_bob",
+        "name": "Bob",
+        "messageCount": 2,
+        "percentage": 28.57
+      },
+      {
+        "uid": "u_charlie",
+        "name": "Charlie",
+        "messageCount": 2,
+        "percentage": 28.57
+      }
+    ],
+    "resources": {
+      "total": 3,
+      "byType": {
+        "image": 1,
+        "file": 1,
+        "audio": 1
+      },
+      "totalSize": 64224
+    }
+  },
+  "messages": [
+    {
+      "seq": "1001",
+      "timestamp": 1704067300000,
+      "time": "2024-01-01 00:01:40",
+      "sender": {
+        "uid": "u_alice",
+        "uin": "11111",
+        "name": "Alice"
+      },
+      "type": "type_1",
+      "content": {
+        "text": "Anyone seen the build break?",
+        "html": "",
+        "elements": [
+          {
+            "type": "text",
+            "data": {
+              "text": "Anyone seen the build break?"
+            }
+          }
+        ],
+        "resources": [],
+        "mentions": []
+      },
+      "recalled": false,
+      "system": false
+    },
+    {
+      "seq": "1002",
+      "timestamp": 1704067360000,
+      "time": "2024-01-01 00:02:40",
+      "sender": {
+        "uid": "u_bob",
+        "uin": "22222",
+        "name": "Bob"
+      },
+      "type": "type_1",
+      "content": {
+        "text": "Looking now [[微笑]]",
+        "html": "",
+        "elements": [
+          {
+            "type": "text",
+            "data": {
+              "text": "Looking now [[微笑]]"
+            }
+          },
+          {
+            "type": "face",
+            "data": {
+              "id": "178",
+              "name": "[微笑]"
+            }
+          }
+        ],
+        "resources": [],
+        "mentions": []
+      },
+      "recalled": false,
+      "system": false
+    },
+    {
+      "seq": "1003",
+      "timestamp": 1704067365000,
+      "time": "2024-01-01 00:02:45",
+      "sender": {
+        "uid": "u_bob",
+        "uin": "22222",
+        "name": "Bob"
+      },
+      "type": "type_1",
+      "content": {
+        "text": "[图片: screenshot.png]",
+        "html": "",
+        "elements": [
+          {
+            "type": "text",
+            "data": {
+              "text": "[图片: screenshot.png]"
+            }
+          },
+          {
+            "type": "image",
+            "data": {
+              "filename": "screenshot.png",
+              "size": 1024,
+              "url": "https://multimedia.nt.qq.com.cn/screenshot.png"
+            }
+          }
+        ],
+        "resources": [
+          {
+            "type": "image",
+            "filename": "screenshot.png",
+            "size": 1024,
+            "url": "https://multimedia.nt.qq.com.cn/screenshot.png"
+          }
+        ],
+        "mentions": []
+      },
+      "recalled": false,
+      "system": false
+    },
+    {
+      "seq": "1004",
+      "timestamp": 1704067400000,
+      "time": "2024-01-01 00:03:20",
+      "sender": {
+        "uid": "u_charlie",
+        "uin": "33333",
+        "name": "Charlie"
+      },
+      "type": "type_1",
+      "content": {
+        "text": "@Alice sentry has the trace, sending now",
+        "html": "",
+        "elements": [
+          {
+            "type": "text",
+            "data": {
+              "text": "@Alice sentry has the trace, sending now"
+            }
+          },
+          {
+            "type": "at",
+            "data": {
+              "uid": "u_alice",
+              "name": "Alice"
+            }
+          }
+        ],
+        "resources": [],
+        "mentions": [
+          {
+            "uid": "u_alice",
+            "name": "Alice",
+            "type": "user"
+          }
+        ]
+      },
+      "recalled": false,
+      "system": false
+    },
+    {
+      "seq": "1005",
+      "timestamp": 1704067410000,
+      "time": "2024-01-01 00:03:30",
+      "sender": {
+        "uid": "u_charlie",
+        "uin": "33333",
+        "name": "Charlie"
+      },
+      "type": "type_8",
+      "content": {
+        "text": "[文件: trace.json]",
+        "html": "",
+        "elements": [
+          {
+            "type": "text",
+            "data": {
+              "text": "[文件: trace.json]"
+            }
+          },
+          {
+            "type": "file",
+            "data": {
+              "filename": "trace.json",
+              "size": 51200,
+              "url": ""
+            }
+          }
+        ],
+        "resources": [
+          {
+            "type": "file",
+            "filename": "trace.json",
+            "size": 51200,
+            "url": ""
+          }
+        ],
+        "mentions": []
+      },
+      "recalled": false,
+      "system": false
+    },
+    {
+      "seq": "1006",
+      "timestamp": 1704067440000,
+      "time": "2024-01-01 00:04:00",
+      "sender": {
+        "uid": "u_alice",
+        "uin": "11111",
+        "name": "Alice"
+      },
+      "type": "type_3",
+      "content": {
+        "text": "[回复 : Anyone seen the build break?]\nthanks team, fix incoming",
+        "html": "",
+        "elements": [
+          {
+            "type": "text",
+            "data": {
+              "text": "[回复 : Anyone seen the build break?]\nthanks team, fix incoming"
+            }
+          },
+          {
+            "type": "reply",
+            "data": {
+              "messageId": "m_1",
+              "referencedMessageId": "m_1",
+              "senderName": "",
+              "content": "Anyone seen the build break?"
+            }
+          }
+        ],
+        "resources": [],
+        "mentions": []
+      },
+      "recalled": false,
+      "system": false
+    },
+    {
+      "seq": "1007",
+      "timestamp": 1704067500000,
+      "time": "2024-01-01 00:05:00",
+      "sender": {
+        "uid": "u_alice",
+        "uin": "11111",
+        "name": "Alice"
+      },
+      "type": "type_6",
+      "content": {
+        "text": "[语音 7秒]",
+        "html": "",
+        "elements": [
+          {
+            "type": "text",
+            "data": {
+              "text": "[语音 7秒]"
+            }
+          },
+          {
+            "type": "audio",
+            "data": {
+              "filename": "voice_msg.silk",
+              "size": 12000,
+              "url": ""
+            }
+          }
+        ],
+        "resources": [
+          {
+            "type": "audio",
+            "filename": "voice_msg.silk",
+            "size": 12000,
+            "url": ""
+          }
+        ],
+        "mentions": []
+      },
+      "recalled": false,
+      "system": false
+    }
+  ],
+  "exportOptions": {
+    "includedFields": [
+      "id",
+      "timestamp",
+      "sender",
+      "content",
+      "resources"
+    ],
+    "filters": {},
+    "options": {
+      "includeResourceLinks": true,
+      "includeSystemMessages": true,
+      "timeFormat": "YYYY-MM-DD HH:mm:ss",
+      "encoding": "utf-8"
+    }
+  }
+}

--- a/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/TextExporter.groupMixedMedia.snap.txt
+++ b/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/TextExporter.groupMixedMedia.snap.txt
@@ -1,0 +1,63 @@
+[QQChatExporter V5 / https://github.com/shuakami/qq-chat-exporter]
+[本软件是免费的开源项目~ 如果您是买来的，请立即退款！如果有帮助到您，欢迎给我点个Star~]
+
+===============================================
+           QQ聊天记录导出文件
+===============================================
+
+聊天名称: QCE Testing Group
+聊天类型: 群聊
+参与人数: 4
+导出时间: <TIMESTAMP>
+消息总数: 7
+时间范围: 2024-01-01 00:01:40 - 2024-01-01 00:05:00
+
+
+Alice:
+时间: 2024-01-01 00:01:40
+内容: Anyone seen the build break?
+
+
+Bob:
+时间: 2024-01-01 00:02:40
+内容: Looking now [[微笑]]
+
+
+Bob:
+时间: 2024-01-01 00:02:45
+内容: [图片: screenshot.png]
+资源: 1 个文件
+  - image: screenshot.png
+
+
+Charlie:
+时间: 2024-01-01 00:03:20
+内容: @Alice sentry has the trace, sending now
+提及: Alice
+
+
+Charlie:
+时间: 2024-01-01 00:03:30
+内容: [文件: trace.json]
+资源: 1 个文件
+  - file: trace.json
+
+
+Alice:
+时间: 2024-01-01 00:04:00
+内容: [回复 : Anyone seen the build break?]
+thanks team, fix incoming
+回复:  - Anyone seen the build break?
+
+
+Alice:
+时间: 2024-01-01 00:05:00
+内容: [语音 7秒]
+资源: 1 个文件
+  - audio: voice_msg.silk
+
+===============================================
+              导出完成
+===============================================
+总计导出 7 条消息
+导出时间: <TIMESTAMP>

--- a/plugins/qq-chat-exporter/__tests__/integration/exporters.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/integration/exporters.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Exporter snapshot tests.
+ *
+ * For each exporter we feed the same fixture conversation, redact volatile
+ * metadata (timestamps, version strings, host paths) and snapshot the file
+ * contents. A pure additive change to an exporter then surfaces as a small
+ * snapshot diff instead of silently shifting the on-disk output.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { createMockCore } from '../helpers/MockNapCatCore.js';
+import { installBridge, uninstallBridge } from '../helpers/installBridge.js';
+import { silenceConsole } from '../helpers/silenceConsole.js';
+import { createTempDir } from '../helpers/tempDir.js';
+import { assertSnapshot } from '../helpers/snapshot.js';
+import { groupMixedMedia, GROUPS } from '../fixtures/conversations.js';
+
+let console_!: ReturnType<typeof silenceConsole>;
+let tmp!: ReturnType<typeof createTempDir>;
+
+test.beforeEach(() => {
+    console_ = silenceConsole();
+    tmp = createTempDir();
+});
+
+test.afterEach(() => {
+    uninstallBridge();
+    tmp.cleanup();
+    console_.restore();
+});
+
+interface RunOptions {
+    extension: 'txt' | 'json' | 'html';
+    exporter: 'TextExporter' | 'JsonExporter' | 'HtmlExporter';
+    format: 'txt' | 'json' | 'html';
+}
+
+async function runExport(opts: RunOptions): Promise<string> {
+    const fixture = groupMixedMedia();
+    const core = createMockCore({ groups: GROUPS, conversations: [fixture] });
+    installBridge({ core });
+
+    const mod = await import(`../../lib/core/exporter/${opts.exporter}.js`);
+    const Exporter = mod[opts.exporter];
+
+    const outputPath = path.join(tmp.path, `out.${opts.extension}`);
+    const exporter = new Exporter(
+        {
+            outputPath,
+            includeResourceLinks: true,
+            includeSystemMessages: true,
+            filterPureImageMessages: false,
+            timeFormat: 'YYYY-MM-DD HH:mm:ss',
+            prettyFormat: true,
+            encoding: 'utf-8'
+        },
+        {},
+        core
+    );
+    await exporter.export(fixture.messages, fixture.chatInfo);
+    return fs.readFileSync(outputPath, 'utf8');
+}
+
+/** Strip volatile fields so the snapshot stays stable across runs. */
+function redact(content: string): string {
+    return content
+        .replaceAll(/qce-test-tmp[^"'\s]*/g, '<TMP_PATH>')
+        .replaceAll(/\/tmp\/[^"'\s]+/g, '<TMP_PATH>')
+        .replaceAll(/"exportTime"\s*:\s*"[^"]+"/g, '"exportTime":"<TIMESTAMP>"')
+        .replaceAll(/"exportedAt"\s*:\s*"[^"]+"/g, '"exportedAt":"<TIMESTAMP>"')
+        .replaceAll(/"createdAt"\s*:\s*"[^"]+"/g, '"createdAt":"<TIMESTAMP>"')
+        .replaceAll(/导出时间[：: ]+[\d\-:T.Z+ ]+/g, '导出时间: <TIMESTAMP>')
+        .replaceAll(/"version"\s*:\s*"[^"]+"/g, '"version":"<VERSION>"')
+        .replaceAll(/QQ Chat Exporter v[\d.]+/g, 'QQ Chat Exporter v<VERSION>')
+        .replaceAll(/\sdata-export-time="[^"]*"/g, ' data-export-time="<TIMESTAMP>"')
+        .replaceAll(/Generated at [^<\n]+/g, 'Generated at <TIMESTAMP>')
+        .replaceAll(/<meta name="generator" content="[^"]*">/g, '<meta name="generator" content="<GENERATOR>">');
+}
+
+test('TextExporter produces stable output for groupMixedMedia fixture', async () => {
+    const output = await runExport({ extension: 'txt', exporter: 'TextExporter', format: 'txt' });
+    assertSnapshot(redact(output), {
+        testFileUrl: import.meta.url,
+        name: 'TextExporter.groupMixedMedia',
+        ext: '.snap.txt'
+    });
+});
+
+test('JsonExporter produces stable output for groupMixedMedia fixture', async () => {
+    const output = await runExport({ extension: 'json', exporter: 'JsonExporter', format: 'json' });
+    // JSON output may have non-deterministic key ordering in metadata; reparse
+    // for deep stability.
+    const parsed = JSON.parse(output);
+    if (parsed.metadata) {
+        delete parsed.metadata.exportTime;
+        delete parsed.metadata.createdAt;
+        delete parsed.metadata.version;
+        delete parsed.metadata.appInfo;
+        delete parsed.metadata.totalSize;
+    }
+    if (Array.isArray(parsed.messages)) {
+        for (const m of parsed.messages) delete m.id;
+    }
+    assertSnapshot(JSON.stringify(parsed, null, 2) + '\n', {
+        testFileUrl: import.meta.url,
+        name: 'JsonExporter.groupMixedMedia',
+        ext: '.snap.json'
+    });
+});
+
+test('HtmlExporter produces stable output for groupMixedMedia fixture', async () => {
+    const output = await runExport({ extension: 'html', exporter: 'HtmlExporter', format: 'html' });
+    assertSnapshot(redact(output), {
+        testFileUrl: import.meta.url,
+        name: 'HtmlExporter.groupMixedMedia',
+        ext: '.snap.html'
+    });
+});
+
+test('TextExporter is deterministic across runs', async () => {
+    const a = await runExport({ extension: 'txt', exporter: 'TextExporter', format: 'txt' });
+    uninstallBridge();
+    const b = await runExport({ extension: 'txt', exporter: 'TextExporter', format: 'txt' });
+    assert.equal(redact(a), redact(b));
+});

--- a/plugins/qq-chat-exporter/__tests__/scripts/ensure-platform-esbuild.mjs
+++ b/plugins/qq-chat-exporter/__tests__/scripts/ensure-platform-esbuild.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Ensures the esbuild binary for the current platform is available under
+ * `node_modules/@esbuild/<platform>`. The committed `node_modules` only
+ * contains the Windows binary (matching the production build target) so
+ * Linux / macOS test runs need to drop in the right package.
+ *
+ * Idempotent — fast no-op once the binary is present.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PLUGIN_ROOT = path.resolve(__dirname, '../..');
+
+function detectPlatform() {
+    const platform = process.platform;
+    const arch = process.arch;
+    const map = {
+        'linux-x64': 'linux-x64',
+        'linux-arm64': 'linux-arm64',
+        'darwin-x64': 'darwin-x64',
+        'darwin-arm64': 'darwin-arm64',
+        'win32-x64': 'win32-x64',
+        'win32-arm64': 'win32-arm64'
+    };
+    const key = `${platform}-${arch}`;
+    return map[key];
+}
+
+function getEsbuildVersion() {
+    const pkg = JSON.parse(
+        fs.readFileSync(path.join(PLUGIN_ROOT, 'node_modules/esbuild/package.json'), 'utf8')
+    );
+    return pkg.version;
+}
+
+function targetExists(slug) {
+    const candidates = [
+        path.join(PLUGIN_ROOT, 'node_modules/@esbuild', slug, 'bin/esbuild'),
+        path.join(PLUGIN_ROOT, 'node_modules/@esbuild', slug, 'esbuild.exe')
+    ];
+    return candidates.some((p) => fs.existsSync(p));
+}
+
+function installPlatformBinary(slug, version) {
+    const dest = path.join(PLUGIN_ROOT, 'node_modules/@esbuild', slug);
+    fs.mkdirSync(dest, { recursive: true });
+    const tarballName = `esbuild-${slug}-${version}.tgz`;
+    const tmpDir = fs.mkdtempSync(path.join(PLUGIN_ROOT, '.esbuild-platform-'));
+    try {
+        execFileSync('npm', ['pack', `@esbuild/${slug}@${version}`, '--silent'], {
+            cwd: tmpDir,
+            stdio: ['ignore', 'pipe', 'pipe']
+        });
+        execFileSync('tar', ['-xzf', tarballName], { cwd: tmpDir, stdio: 'inherit' });
+        const extracted = path.join(tmpDir, 'package');
+        for (const name of fs.readdirSync(extracted)) {
+            const src = path.join(extracted, name);
+            const dst = path.join(dest, name);
+            if (fs.lstatSync(src).isDirectory()) {
+                fs.cpSync(src, dst, { recursive: true });
+            } else {
+                fs.copyFileSync(src, dst);
+            }
+        }
+        const bin = path.join(dest, 'bin/esbuild');
+        if (fs.existsSync(bin)) fs.chmodSync(bin, 0o755);
+    } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+}
+
+function main() {
+    const slug = detectPlatform();
+    if (!slug) {
+        console.warn(`[esbuild] unsupported platform ${process.platform}-${process.arch}; skipping`);
+        return;
+    }
+    if (targetExists(slug)) {
+        return; // nothing to do
+    }
+    const version = getEsbuildVersion();
+    console.log(`[esbuild] installing @esbuild/${slug}@${version} into node_modules`);
+    installPlatformBinary(slug, version);
+    if (!targetExists(slug)) {
+        throw new Error(`[esbuild] failed to install @esbuild/${slug}@${version}`);
+    }
+    console.log(`[esbuild] installed @esbuild/${slug}@${version}`);
+}
+
+main();

--- a/plugins/qq-chat-exporter/__tests__/scripts/mock-server.mjs
+++ b/plugins/qq-chat-exporter/__tests__/scripts/mock-server.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * mock-server.mjs - launch the real QCE API server (port 40653) backed by a
+ * MockNapCatCore instead of a live NapCatQQ instance.
+ *
+ * Use this for:
+ *   - Frontend development: `npm run mock:server` then point qce-v4-tool dev
+ *     server at http://localhost:40653.
+ *   - Manual smoke testing: hit the same REST/WS endpoints production exposes
+ *     without needing to scan a QR code.
+ *   - Playwright E2E tests (driven by `npm run test:e2e`).
+ *
+ * The fixture scenario is selected via the `QCE_MOCK_SCENARIO` env var. See
+ * `__tests__/fixtures/conversations.ts` for the list. Defaults to `default`,
+ * which loads every conversation in the fixtures module.
+ */
+
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PLUGIN_ROOT = path.resolve(__dirname, '../..');
+
+// Point tsx at the loose-mode test tsconfig so `verbatimModuleSyntax` doesn't
+// fail when the production code imports types as values.
+process.env.TSX_TSCONFIG_PATH ??= path.join(PLUGIN_ROOT, '__tests__', 'tsconfig.json');
+
+// Tell ApiServer where to put its sqlite + cache + downloads. Without this,
+// it would write into the user's real home directory.
+const TMP_HOME = process.env.QCE_MOCK_HOME ?? fs.mkdtempSync(path.join(os.tmpdir(), 'qce-mock-home-'));
+process.env.HOME = TMP_HOME;
+process.env.USERPROFILE = TMP_HOME;
+const SECURITY_DIR = path.join(TMP_HOME, '.qq-chat-exporter');
+fs.mkdirSync(SECURITY_DIR, { recursive: true });
+
+// Pre-seed a deterministic access token so E2E tests can pass `?token=...`
+// without first scraping it from server stdout.
+const FIXED_TOKEN = process.env.QCE_MOCK_TOKEN ?? 'qce_mock_token_for_tests';
+const securityConfig = {
+    accessToken: FIXED_TOKEN,
+    secretKey: 'qce_mock_secret_key_padded_to_64_chars_for_dev_environment_only',
+    createdAt: new Date().toISOString(),
+    allowedIPs: ['127.0.0.1', '::1', '0.0.0.0/0'],
+    tokenExpired: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString(),
+    disableIPWhitelist: true,
+    serverHost: '0.0.0.0'
+};
+fs.writeFileSync(
+    path.join(SECURITY_DIR, 'security.json'),
+    JSON.stringify(securityConfig, null, 2),
+    'utf-8'
+);
+
+async function main() {
+    const { register } = await import('tsx/esm/api');
+    register();
+
+    const { createMockCore } = await import('../helpers/MockNapCatCore.ts');
+    const { installBridge } = await import('../helpers/installBridge.ts');
+    const fixtures = await import('../fixtures/conversations.ts');
+    const { QQChatExporterApiLauncher } = await import('../../lib/api/ApiLauncher.ts');
+
+    const scenario = (process.env.QCE_MOCK_SCENARIO ?? 'default').toLowerCase();
+    const conversations = pickScenario(scenario, fixtures);
+
+    const core = createMockCore({
+        selfInfo: { uid: 'self_test_uid', uin: '10000', nick: 'TestSelf', online: true },
+        friends: fixtures.FRIENDS,
+        groups: fixtures.GROUPS,
+        conversations,
+        paths: {
+            cachePath: path.join(TMP_HOME, '.qq-chat-exporter', 'cache'),
+            tmpPath: path.join(TMP_HOME, '.qq-chat-exporter', 'tmp'),
+            logsPath: path.join(TMP_HOME, '.qq-chat-exporter', 'logs')
+        }
+    });
+
+    installBridge({ core });
+
+    const launcher = new QQChatExporterApiLauncher(core);
+    await launcher.startApiServer();
+
+    const port = launcher.getStatus().port ?? 40653;
+    /* eslint-disable no-console */
+    console.log('\n=========================================================');
+    console.log(`[QCE Mock] API server listening on http://localhost:${port}`);
+    console.log(`[QCE Mock] Token:    ${FIXED_TOKEN}`);
+    console.log(`[QCE Mock] Scenario: ${scenario} (${conversations.length} conversations)`);
+    console.log(`[QCE Mock] Tmp home: ${TMP_HOME}`);
+    console.log(`[QCE Mock] Quick check:`);
+    console.log(`  curl 'http://localhost:${port}/api/groups?token=${FIXED_TOKEN}'`);
+    console.log('=========================================================\n');
+    /* eslint-enable no-console */
+
+    // Keep alive until SIGINT/SIGTERM
+    const shutdown = async (signal) => {
+        console.log(`[QCE Mock] received ${signal}, stopping`);
+        try {
+            await launcher.stopApiServer();
+        } finally {
+            try { fs.rmSync(TMP_HOME, { recursive: true, force: true }); } catch { /* ignore */ }
+            process.exit(0);
+        }
+    };
+    process.on('SIGINT', () => shutdown('SIGINT'));
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
+}
+
+function pickScenario(scenario, fixtures) {
+    switch (scenario) {
+        case 'private':
+            return [fixtures.privateTextOnly()];
+        case 'group':
+            return [fixtures.groupMixedMedia()];
+        case 'recall':
+            return [fixtures.privateWithRecall()];
+        case 'forward':
+            return [fixtures.privateWithForward()];
+        case 'volume':
+            return [fixtures.privateVolume(200)];
+        case 'default':
+        case 'all':
+        default:
+            return [
+                fixtures.privateTextOnly(),
+                fixtures.groupMixedMedia(),
+                fixtures.privateWithRecall(),
+                fixtures.privateWithForward(),
+                fixtures.privateVolume(50)
+            ];
+    }
+}
+
+main().catch((err) => {
+    console.error('[QCE Mock] failed to start:', err);
+    process.exit(1);
+});

--- a/plugins/qq-chat-exporter/__tests__/scripts/run-tests.mjs
+++ b/plugins/qq-chat-exporter/__tests__/scripts/run-tests.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform test runner.
+ *
+ * Sets the env vars tsx + node:test need, then runs `node --test` with the
+ * supplied glob. Used by the npm scripts so the same `npm test` invocation
+ * works on Windows, macOS and Linux without depending on `cross-env`.
+ */
+
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PLUGIN_ROOT = path.resolve(__dirname, '../..');
+
+const args = process.argv.slice(2);
+const updateSnapshots = args.includes('--update-snapshots');
+const filtered = args.filter((a) => a !== '--update-snapshots');
+
+if (filtered.length === 0) {
+    filtered.push('__tests__/**/*.test.ts');
+}
+
+const env = {
+    ...process.env,
+    TSX_TSCONFIG_PATH: path.join('__tests__', 'tsconfig.json'),
+    QCE_UPDATE_SNAPSHOTS: updateSnapshots ? '1' : process.env.QCE_UPDATE_SNAPSHOTS ?? ''
+};
+
+const result = spawnSync(
+    process.execPath,
+    [
+        '--import', 'tsx',
+        '--test',
+        '--test-force-exit',
+        ...filtered
+    ],
+    { cwd: PLUGIN_ROOT, env, stdio: 'inherit' }
+);
+
+process.exit(result.status ?? 1);

--- a/plugins/qq-chat-exporter/__tests__/scripts/run-tests.mjs
+++ b/plugins/qq-chat-exporter/__tests__/scripts/run-tests.mjs
@@ -8,6 +8,7 @@
  */
 
 import path from 'node:path';
+import fs from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
@@ -23,6 +24,70 @@ if (filtered.length === 0) {
     filtered.push('__tests__/**/*.test.ts');
 }
 
+/**
+ * Expand glob patterns. Node's `--test` doesn't expand globs in Node < 22, and
+ * the npm script gets the patterns through verbatim, so we walk them manually.
+ *
+ * Supported: `**`, single segment `*`, exact paths.
+ */
+function globToFiles(pattern) {
+    const abs = path.isAbsolute(pattern) ? pattern : path.join(PLUGIN_ROOT, pattern);
+
+    // Exact file
+    if (!abs.includes('*')) {
+        return fs.existsSync(abs) ? [abs] : [];
+    }
+
+    // Split into base directory + remaining glob.
+    const segments = abs.split(path.sep);
+    const firstGlobIdx = segments.findIndex((s) => s.includes('*'));
+    const baseDir = segments.slice(0, firstGlobIdx).join(path.sep) || path.sep;
+    const tail = segments.slice(firstGlobIdx);
+
+    // Build regex from tail. `**` matches any number of segments (including
+    // none), `*` matches one segment. Build the source manually so `**` can
+    // consume the following `/` separator.
+    let regexSrc = '^';
+    for (let i = 0; i < tail.length; i++) {
+        const seg = tail[i];
+        const isLast = i === tail.length - 1;
+        if (seg === '**') {
+            // Match zero or more path segments. When not the last segment,
+            // also consume the trailing `/` separator.
+            regexSrc += isLast ? '.*' : '(?:[^/]+/)*';
+        } else {
+            regexSrc += seg.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '[^/]*');
+            if (!isLast && tail[i + 1] !== '**') regexSrc += '/';
+        }
+    }
+    regexSrc += '$';
+    const re = new RegExp(regexSrc);
+
+    if (!fs.existsSync(baseDir)) return [];
+
+    const matches = [];
+    function walk(dir) {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            const full = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+                walk(full);
+            } else if (entry.isFile()) {
+                const rel = path.relative(baseDir, full).split(path.sep).join('/');
+                if (re.test(rel)) matches.push(full);
+            }
+        }
+    }
+    walk(baseDir);
+    return matches;
+}
+
+const files = filtered.flatMap(globToFiles);
+
+if (files.length === 0) {
+    console.error(`No test files matched: ${filtered.join(', ')}`);
+    process.exit(1);
+}
+
 const env = {
     ...process.env,
     TSX_TSCONFIG_PATH: path.join('__tests__', 'tsconfig.json'),
@@ -35,7 +100,7 @@ const result = spawnSync(
         '--import', 'tsx',
         '--test',
         '--test-force-exit',
-        ...filtered
+        ...files
     ],
     { cwd: PLUGIN_ROOT, env, stdio: 'inherit' }
 );

--- a/plugins/qq-chat-exporter/__tests__/smoke.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/smoke.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Smoke test - the cheapest possible check that the test harness wires up.
+ *
+ * Run with `npm test` from inside `plugins/qq-chat-exporter/`.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createMockCore } from './helpers/MockNapCatCore.js';
+import { installBridge, uninstallBridge } from './helpers/installBridge.js';
+import { conversation, msg, privatePeer } from './fixtures/builders.js';
+
+test('bridge install/uninstall roundtrip', async () => {
+    const core = createMockCore();
+    installBridge({ core });
+    assert.equal(globalThis.__NAPCAT_BRIDGE__?.core, core);
+    uninstallBridge();
+    assert.equal(globalThis.__NAPCAT_BRIDGE__, undefined);
+});
+
+test('overlay MsgApi proxies through to mock core', async () => {
+    const fixture = conversation(privatePeer('u_alice'))
+        .add(msg().sender({ uid: 'u_alice' }).text('hi').build())
+        .add(msg().sender({ uid: 'u_alice' }).text('there').build())
+        .build();
+
+    const core = createMockCore({ conversations: [fixture] });
+    installBridge({ core });
+    try {
+        const overlay = await import('NapCatQQ/src/core/apis/msg.js' as string);
+        const result = await overlay.MsgApi.getAioFirstViewLatestMsgs(fixture.peer, 10);
+        assert.equal(result.msgList.length, 2);
+        assert.equal(result.msgList[0].msgId, fixture.messages[1].msgId);
+    } finally {
+        uninstallBridge();
+    }
+});

--- a/plugins/qq-chat-exporter/__tests__/tsconfig.json
+++ b/plugins/qq-chat-exporter/__tests__/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "../dist-tests",
+    "noEmit": true,
+    "verbatimModuleSyntax": false,
+    "isolatedModules": true,
+    "types": ["node"],
+    "lib": ["ES2022"]
+  },
+  "include": [
+    "**/*.ts"
+  ]
+}

--- a/plugins/qq-chat-exporter/__tests__/unit/SimpleMessageParser.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/SimpleMessageParser.test.ts
@@ -1,0 +1,167 @@
+/**
+ * SimpleMessageParser unit tests.
+ *
+ * One test per element family. The parser is the place most regressions show
+ * up because every NTQQ release adds a new element subtype.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createMockCore } from '../helpers/MockNapCatCore.js';
+import { installBridge, uninstallBridge } from '../helpers/installBridge.js';
+import { silenceConsole } from '../helpers/silenceConsole.js';
+import { msg } from '../fixtures/builders.js';
+
+const T = 1704067200;
+
+async function loadParser() {
+    // Dynamic import — the parser pulls in the overlay, which requires the
+    // bridge to be installed before the module is evaluated.
+    return await import('../../lib/core/parser/SimpleMessageParser.js');
+}
+
+let console_!: ReturnType<typeof silenceConsole>;
+
+test.beforeEach(() => {
+    console_ = silenceConsole();
+    installBridge({ core: createMockCore() });
+});
+
+test.afterEach(() => {
+    uninstallBridge();
+    console_.restore();
+});
+
+test('parses plain text messages', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const m = msg().sender({ uid: 'u_alice', uin: '11111', nick: 'Alice' }).text('hello world').at_time(T).build();
+    const [parsed] = await parser.parseMessages([m]);
+    assert.equal(parsed.sender.name, 'Alice');
+    assert.equal(parsed.content.text, 'hello world');
+    assert.equal(parsed.content.elements[0].type, 'text');
+    assert.equal(parsed.recalled, false);
+});
+
+test('uses group card name in preference to nickname', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const m = msg()
+        .sender({ uid: 'u_alice', uin: '11111', nick: 'Alice', card: 'Alice (PM)', remark: 'A.Pm' })
+        .text('hi')
+        .build();
+    const [parsed] = await parser.parseMessages([m]);
+    assert.equal(parsed.sender.name, 'Alice (PM)');
+    assert.equal(parsed.sender.groupCard, 'Alice (PM)');
+    assert.equal(parsed.sender.remark, 'A.Pm');
+    assert.equal(parsed.sender.nickname, 'Alice');
+});
+
+test('parses @everyone and @user mentions', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const m = msg()
+        .sender({ uid: 'u_charlie', uin: '33333', nick: 'Charlie' })
+        .atAll()
+        .text(' ')
+        .at(11111, 'Alice', 'u_alice')
+        .text(' please review')
+        .build();
+    const [parsed] = await parser.parseMessages([m]);
+    assert.equal(parsed.content.mentions.length, 2);
+    assert.equal(parsed.content.mentions[0].type, 'all');
+    assert.equal(parsed.content.mentions[1].type, 'user');
+    assert.equal(parsed.content.mentions[1].name, 'Alice');
+    assert.match(parsed.content.text, /@全体成员/);
+    assert.match(parsed.content.text, /please review/);
+});
+
+test('parses image element with metadata', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const m = msg()
+        .image({ filename: 'cat.jpg', width: 1024, height: 768, md5: 'cafebabe' })
+        .build();
+    const [parsed] = await parser.parseMessages([m]);
+    const el = parsed.content.elements[0];
+    assert.equal(el.type, 'image');
+    assert.equal(el.data.filename, 'cat.jpg');
+    assert.equal(el.data.width, 1024);
+    assert.equal(el.data.md5, 'cafebabe');
+    assert.equal(parsed.content.resources[0].type, 'image');
+});
+
+test('parses face / market_face elements', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const m = msg()
+        .face(178, '[微笑]')
+        .marketFace({ name: '[doge]', emojiId: 'doge_v1' })
+        .build();
+    const [parsed] = await parser.parseMessages([m]);
+    const types = parsed.content.elements.map((e) => e.type);
+    assert.deepEqual(types, ['face', 'market_face']);
+    assert.equal(parsed.content.elements[0].data.id, '178');
+    assert.equal(parsed.content.elements[1].data.name, '[doge]');
+});
+
+test('parses voice / video / file elements', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const m = msg()
+        .voice({ filename: 'v.silk', duration: 5, size: 4000 })
+        .video({ filename: 'v.mp4', duration: 30, size: 20000 })
+        .file({ filename: 'doc.pdf', size: 9000 })
+        .build();
+    const [parsed] = await parser.parseMessages([m]);
+    const types = parsed.content.elements.map((e) => e.type);
+    assert.deepEqual(types, ['audio', 'video', 'file']);
+    assert.equal(parsed.content.elements[0].data.duration, 5);
+    assert.equal(parsed.content.elements[1].data.duration, 30);
+    assert.equal(parsed.content.elements[2].data.size, 9000);
+});
+
+test('marks recalled messages', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const m = msg().text('whoops').recall(T + 5).build();
+    const [parsed] = await parser.parseMessages([m]);
+    assert.equal(parsed.recalled, true);
+});
+
+test('reply element resolves referenced content via global map', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const original = msg()
+        .sender({ uid: 'u_bob', uin: '22222', nick: 'Bob' })
+        .text('the question')
+        .at_time(T + 0)
+        .build();
+    const reply = msg()
+        .sender({ uid: 'u_alice', uin: '11111', nick: 'Alice' })
+        .reply({ sourceMsgId: original.msgId, msgSeq: original.msgSeq, msgTime: Number(original.msgTime) })
+        .text('the answer')
+        .at_time(T + 60)
+        .build();
+    const parsed = await parser.parseMessages([original, reply]);
+    const replyEl = parsed[1].content.elements.find((e) => e.type === 'reply');
+    assert.ok(replyEl, 'expected a reply element');
+    assert.equal(replyEl!.data.referencedMessageId, original.msgId);
+    assert.equal(replyEl!.data.content, 'the question');
+    assert.equal(replyEl!.data.senderName, 'Bob');
+});
+
+test('forward element preserves resId and surfaces records via map', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const inner = [
+        msg().sender({ uid: 'u_alice' }).text('inner1').at_time(T + 0).build(),
+        msg().sender({ uid: 'u_alice' }).text('inner2').at_time(T + 60).build()
+    ];
+    const m = msg().forward({ resId: 'fw_001', records: inner }).at_time(T + 120).build();
+    const [parsed] = await parser.parseMessages([m]);
+    const fw = parsed.content.elements[0];
+    assert.equal(fw.type, 'forward');
+    assert.equal(fw.data.resId, 'fw_001');
+});

--- a/plugins/qq-chat-exporter/package.json
+++ b/plugins/qq-chat-exporter/package.json
@@ -7,8 +7,14 @@
   "scripts": {
     "gen:overlay": "node tools/gen-overlay.cjs && node tools/create-overlay-runtime.cjs",
     "fix:imports": "node tools/fix-imports.cjs && node tools/fix-ts-imports.cjs",
-    "test": "node test-plugin.mjs",
-    "test:full": "node test-plugin-full.mjs"
+    "pretest": "node __tests__/scripts/ensure-platform-esbuild.mjs",
+    "test": "node __tests__/scripts/run-tests.mjs \"__tests__/**/*.test.ts\"",
+    "test:legacy": "node test-plugin.mjs",
+    "test:legacy:full": "node test-plugin-full.mjs",
+    "test:unit": "node __tests__/scripts/run-tests.mjs \"__tests__/unit/**/*.test.ts\" \"__tests__/smoke.test.ts\"",
+    "test:integration": "node __tests__/scripts/run-tests.mjs \"__tests__/integration/**/*.test.ts\"",
+    "test:update-snapshots": "node __tests__/scripts/run-tests.mjs --update-snapshots \"__tests__/integration/**/*.test.ts\"",
+    "mock:server": "node __tests__/scripts/mock-server.mjs"
   },
   "keywords": [
     "napcat",

--- a/qce-v4-tool/.gitignore
+++ b/qce-v4-tool/.gitignore
@@ -44,3 +44,8 @@ next-env.d.ts
 .DS_Store
 *.tgz
 *.tar.gz
+
+# playwright
+/playwright-report/
+/test-results/
+/playwright/.cache/

--- a/qce-v4-tool/e2e/api-smoke.spec.ts
+++ b/qce-v4-tool/e2e/api-smoke.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * API smoke tests. Don't need the frontend running — just hit the mock server
+ * directly. These exercise the same auth + REST contract the UI uses.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const API_URL = process.env.E2E_API_URL ?? 'http://localhost:40653';
+const TOKEN = process.env.QCE_MOCK_TOKEN ?? 'qce_mock_token_for_tests';
+
+test.describe('Mock API server', () => {
+    test('GET /health returns healthy', async ({ request }) => {
+        const res = await request.get(`${API_URL}/health`);
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(body.success).toBe(true);
+        expect(body.data.status).toBe('healthy');
+    });
+
+    test('GET /api/groups requires token then lists fixture groups', async ({ request }) => {
+        const noAuth = await request.get(`${API_URL}/api/groups`);
+        expect([401, 403]).toContain(noAuth.status());
+
+        const res = await request.get(`${API_URL}/api/groups?token=${TOKEN}`);
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(body.success).toBe(true);
+        expect(Array.isArray(body.data.groups)).toBe(true);
+        expect(body.data.groups.length).toBeGreaterThan(0);
+        expect(body.data.groups[0]).toMatchObject({ groupCode: '999000', groupName: 'QCE Testing Group' });
+    });
+
+    test('GET /api/friends lists fixture friends', async ({ request }) => {
+        const res = await request.get(`${API_URL}/api/friends?token=${TOKEN}`);
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(body.success).toBe(true);
+        const uids = body.data.friends.map((f: { uid: string }) => f.uid).sort();
+        expect(uids).toEqual(['u_alice', 'u_bob', 'u_charlie']);
+    });
+
+    test('GET /api/system/info returns mock self info', async ({ request }) => {
+        const res = await request.get(`${API_URL}/api/system/info?token=${TOKEN}`);
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(body.success).toBe(true);
+        expect(body.data.napcat.selfInfo.uin).toBe('10000');
+        expect(body.data.napcat.selfInfo.nick).toBe('TestSelf');
+    });
+
+    test('POST /api/messages/fetch returns mock conversation messages', async ({ request }) => {
+        const res = await request.post(`${API_URL}/api/messages/fetch?token=${TOKEN}`, {
+            data: {
+                peer: { chatType: 2, peerUid: '999000' },
+                page: 1,
+                limit: 50
+            },
+            headers: { 'X-Access-Token': TOKEN }
+        });
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(body.success).toBe(true);
+        expect(Array.isArray(body.data?.messages)).toBe(true);
+    });
+});

--- a/qce-v4-tool/e2e/ui-smoke.spec.ts
+++ b/qce-v4-tool/e2e/ui-smoke.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * UI smoke test - boots the auth page, drops a token and makes sure we land
+ * on the main app shell. Skipped automatically when the frontend isn't
+ * reachable so this can run in environments where only the API is up.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const TOKEN = process.env.QCE_MOCK_TOKEN ?? 'qce_mock_token_for_tests';
+
+test.describe('Auth flow', () => {
+    test('home page loads', async ({ page }) => {
+        const response = await page.goto('/').catch(() => null);
+        test.skip(!response || response.status() >= 500, 'frontend not reachable');
+        // We expect either the main app page or a redirect to /auth
+        const title = await page.title();
+        expect(title.length).toBeGreaterThan(0);
+    });
+
+    test('passing ?token=... in URL stores it for future requests', async ({ page }) => {
+        const response = await page.goto(`/auth?token=${TOKEN}`).catch(() => null);
+        test.skip(!response || response.status() >= 500, 'frontend not reachable');
+        // The auth manager pulls the token out of the URL and stashes it in
+        // localStorage. We just check that the storage entry shows up.
+        const stored = await page.evaluate(() => localStorage.getItem('qce_access_token'));
+        expect(stored).toBe(TOKEN);
+    });
+});

--- a/qce-v4-tool/package.json
+++ b/qce-v4-tool/package.json
@@ -7,7 +7,10 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
-    "start": "next start"
+    "start": "next start",
+    "test:e2e": "playwright test",
+    "test:e2e:install": "playwright install chromium",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -71,5 +74,8 @@
     "typescript": "^5",
     "vaul": "^0.9.9",
     "zod": "3.25.67"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1"
   }
 }

--- a/qce-v4-tool/playwright.config.ts
+++ b/qce-v4-tool/playwright.config.ts
@@ -1,0 +1,55 @@
+/**
+ * Playwright E2E config.
+ *
+ * Pointed at the Mock API Server in `plugins/qq-chat-exporter`. Run with:
+ *
+ *     # 1. start the mock server on :40653
+ *     cd plugins/qq-chat-exporter && npm run mock:server
+ *
+ *     # 2. start the frontend dev server on :3000 (separate terminal)
+ *     cd qce-v4-tool && npm run dev
+ *
+ *     # 3. run the tests (this directory)
+ *     npx playwright install chromium  # one-time
+ *     npx playwright test
+ *
+ * Set `E2E_FRONTEND_URL` to point at a different frontend host (e.g. the
+ * built bundle served by the mock server itself at
+ * http://localhost:40653/qce-v4-tool/).
+ */
+
+import { defineConfig, devices } from '@playwright/test';
+
+const FRONTEND_URL = process.env.E2E_FRONTEND_URL ?? 'http://localhost:3000';
+const API_URL = process.env.E2E_API_URL ?? 'http://localhost:40653';
+const MOCK_TOKEN = process.env.QCE_MOCK_TOKEN ?? 'qce_mock_token_for_tests';
+
+export default defineConfig({
+    testDir: './e2e',
+    timeout: 30_000,
+    expect: { timeout: 5_000 },
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 1 : 0,
+    workers: process.env.CI ? 1 : undefined,
+    reporter: [
+        ['list'],
+        ['html', { outputFolder: 'playwright-report', open: 'never' }]
+    ],
+    use: {
+        baseURL: FRONTEND_URL,
+        trace: 'on-first-retry',
+        screenshot: 'only-on-failure',
+        video: 'retain-on-failure'
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] }
+        }
+    ],
+    metadata: {
+        api_url: API_URL,
+        token: MOCK_TOKEN
+    }
+});

--- a/qce-v4-tool/pnpm-lock.yaml
+++ b/qce-v4-tool/pnpm-lock.yaml
@@ -106,7 +106,7 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vercel/analytics':
         specifier: 1.3.1
-        version: 1.3.1(next@16.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 1.3.1(next@16.1.0(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.21(postcss@8.5.6)
@@ -130,7 +130,7 @@ importers:
         version: 12.23.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       geist:
         specifier: ^1.3.1
-        version: 1.4.2(next@16.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 1.4.2(next@16.1.0(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       input-otp:
         specifier: 1.4.1
         version: 1.4.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -142,7 +142,7 @@ importers:
         version: 12.38.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next:
         specifier: latest
-        version: 16.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.0(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: latest
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -191,6 +191,10 @@ importers:
       zod:
         specifier: 3.25.67
         version: 3.25.67
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
 
 packages:
 
@@ -258,105 +262,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -421,28 +409,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.0':
     resolution: {integrity: sha512-TojQnDRoX7wJWXEEwdfuJtakMDW64Q7NrxQPviUnfYJvAx5/5wcGE+1vZzQ9F17m+SdpFeeXuOr6v3jbyusYMQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.0':
     resolution: {integrity: sha512-quhNFVySW4QwXiZkZ34SbfzNBm27vLrxZ2HwTfFFO1BBP0OY1+pI0nbyewKeq1FriqU+LZrob/cm26lwsiAi8Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.0':
     resolution: {integrity: sha512-6JW0z2FZUK5iOVhUIWqE4RblAhUj1EwhZ/MwteGb//SpFTOHydnhbp3868gxalwea+mbOLWO6xgxj9wA9wNvNw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.0':
     resolution: {integrity: sha512-+DK/akkAvvXn5RdYN84IOmLkSy87SCmpofJPdB8vbLmf01BzntPBSYXnMvnEEv/Vcf3HYJwt24QZ/s6sWAwOMQ==}
@@ -455,6 +439,11 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.0':
     resolution: {integrity: sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==}
@@ -1153,28 +1142,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.12':
     resolution: {integrity: sha512-V8pAM3s8gsrXcCv6kCHSuwyb/gPsd863iT+v1PGXC4fSL/OJqsKhfK//v8P+w9ThKIoqNbEnsZqNy+WDnwQqCA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.12':
     resolution: {integrity: sha512-xYfqYLjvm2UQ3TZggTGrwxjYaLB62b1Wiysw/YE3Yqbh86sOMoTn0feF98PonP7LtjsWOWcXEbGqDL7zv0uW8Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.12':
     resolution: {integrity: sha512-ha0pHPamN+fWZY7GCzz5rKunlv9L5R8kdh+YNvP5awe3LtuXb5nRi/H27GeL2U+TdhDOptU7T6Is7mdwh5Ar3A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.12':
     resolution: {integrity: sha512-4tSyu3dW+ktzdEpuk6g49KdEangu3eCYoqPhWNsZgUhyegEda3M9rG0/j1GV/JjVVsj+lG7jWAyrTlLzd/WEBg==}
@@ -1434,6 +1419,11 @@ packages:
       react-dom:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   geist@1.4.2:
     resolution: {integrity: sha512-OQUga/KUc8ueijck6EbtT07L4tZ5+TZgjw8PyWfxo16sL5FWk7gNViPNU8hgCFjy6bJi9yuTP+CRpywzaGN8zw==}
     peerDependencies:
@@ -1492,28 +1482,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -1630,6 +1616,16 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -2030,6 +2026,10 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.1.0':
     optional: true
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@radix-ui/number@1.1.0': {}
 
@@ -2835,11 +2835,11 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vercel/analytics@1.3.1(next@16.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@vercel/analytics@1.3.1(next@16.1.0(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     dependencies:
       server-only: 0.0.1
     optionalDependencies:
-      next: 16.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.0(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
   aria-hidden@1.2.6:
@@ -2994,9 +2994,12 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  geist@1.4.2(next@16.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
+  fsevents@2.3.2:
+    optional: true
+
+  geist@1.4.2(next@16.1.0(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
     dependencies:
-      next: 16.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.0(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   get-nonce@1.0.1: {}
 
@@ -3107,7 +3110,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  next@16.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.0(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.0
       '@swc/helpers': 0.5.15
@@ -3126,6 +3129,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.0
       '@next/swc-win32-arm64-msvc': 16.1.0
       '@next/swc-win32-x64-msvc': 16.1.0
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -3138,6 +3142,14 @@ snapshots:
   object-assign@4.1.1: {}
 
   picocolors@1.1.1: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-value-parser@4.2.0: {}
 


### PR DESCRIPTION
## 背景

每次修改 plugin 或前端代码都需要登录 NapCat（扫码、等待会话恢复、手动触发导出）才能验证，本地开发与 CI 回归成本较高。本 PR 引入一套零登录的测试基建，使单元测试、集成测试、API Server 与 Playwright 端到端测试均能脱离真实 QQ 环境运行。

## 设计

QCE 的 plugin 入口通过 `globalThis.__NAPCAT_BRIDGE__` 向下游（Fetcher / Parser / Exporter / ApiServer）注入 NapCatCore 实例。由于注入点是单一全局变量，可以在测试初始化阶段替换为 mock 实现，生产代码无须改动。

按此结构分三层。

### Tier 1 — 单元 / 集成测试

- `__tests__/helpers/MockNapCatCore.ts`：按真实 NapCatCore 接口形状实现 `MsgApi` / `GroupApi` / `FriendApi` / `UserApi` / `FileApi` / `WebApi`，行为由 fixture 数据驱动。
- `__tests__/helpers/installBridge.ts`：将 MockCore 写入 `globalThis.__NAPCAT_BRIDGE__`。
- `__tests__/fixtures/builders.ts`：链式 DSL，`msg().text().image().reply().forward().build()`，覆盖文本、@、图片、文件、语音、视频、表情、商城表情、回复、转发、撤回。
- `__tests__/fixtures/conversations.ts`：预置场景（`privateTextOnly` / `groupMixedMedia` / `privateWithRecall` / `privateWithForward` / `privateVolume(N)`）。
- 测试基于 `node:test` + `tsx`，不引入 jest / vitest。
  - `unit/SimpleMessageParser.test.ts`：9 个用例，覆盖每种 element 类型。
  - `integration/BatchMessageFetcher.test.ts`：分页、批次大小、时间窗口过滤。
  - `integration/exporters.test.ts`：HTML / JSON / TXT snapshot 与一致性回归。
- snapshot 使用自实现的极简版本（`helpers/snapshot.ts`），单文件单 baseline，自动归一化 CRLF / LF。

完整运行 18 个用例，本地耗时约 1.7 秒。

### Tier 2 — Mock API Server

```bash
cd plugins/qq-chat-exporter && npm run mock:server
# [QCE Mock] API server listening on http://localhost:40653
# [QCE Mock] Token:    qce_mock_token_for_tests
```

启动的是生产代码中的 `QQChatExporterApiServer`，仅将 `core` 替换为 MockNapCatCore。token 在启动前通过预写 `security.json` 固定为 `qce_mock_token_for_tests`，避免每次启动生成新 token。

```
QCE_MOCK_TOKEN     自定义 token
QCE_MOCK_SCENARIO  default | private | group | recall | forward | volume
QCE_MOCK_HOME      自定义临时目录（默认 mkdtemp，进程退出时清理）
```

前端开发可直接连接：

```bash
cd qce-v4-tool && npm run dev
# http://localhost:3000/auth?token=qce_mock_token_for_tests
```

### Tier 3 — Playwright Smoke

`qce-v4-tool/e2e/api-smoke.spec.ts`：5 个用例覆盖 `/health`、`/api/groups`、`/api/friends`、`/api/system/info`、`/api/messages/fetch`，验证 mock server 接口形状与前端 client 一致。
`qce-v4-tool/e2e/ui-smoke.spec.ts`：前端不可达时自动 skip。

## CI

`.github/workflows/test-plugin.yml`：

- `unit-and-integration` 矩阵：Ubuntu + Windows × Node 20 / 22 × unit / integration，共 8 个 job
- `api-e2e`：缓存 Playwright Chromium → 启动 mock server → 执行 API smoke

不影响现有 `build-plugin.yml` 与 `release-plugin.yml`。

## 命令

```bash
cd plugins/qq-chat-exporter
npm test                      # 全量
npm run test:unit             # parser + smoke
npm run test:integration      # Fetcher + Exporter
npm run test:update-snapshots # 更新 exporter baseline
npm run mock:server           # 启动 :40653 mock 服务
```

原有 `test-plugin.mjs` 与 `test-plugin-full.mjs` 保留不变，对应脚本迁移至 `npm run test:legacy` 与 `npm run test:legacy:full`。

## 兼容性与限制

- 不修改 `lib/` 下任何生产代码。
- `BatchMessageFetcher` 内部 `createTimeoutPromise` 未清理自身创建的 timer，导致 `node --test` 完成后无法自动退出。此处通过 `--test-force-exit` 规避，建议后续单独修复。
- snapshot baseline 通过 `__snapshots__/.gitattributes` 锁定为 LF，并在读取时归一化 CRLF，避免 Windows 端 git autocrlf 影响回归一致性。
- Playwright 浏览器二进制不纳入版本管理，CI 通过 `actions/cache` 缓存 `~/.cache/ms-playwright`。

详细文档见 `plugins/qq-chat-exporter/__tests__/README.md`。
