### PR TITLE
fix: fall back to original peerUid when UserApi.getUidByUinV2 is unavailable (#353)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/peerResolution.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/peerResolution.test.ts
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolvePeerUid } from '../../lib/api/peerResolution.js';
+
+const PRIVATE = 1;
+const GROUP = 2;
+
+function recorder() {
+    const lines: string[] = [];
+    return { log: (msg: string) => lines.push(msg), lines };
+}
+
+test('peerResolution: 群聊直接返回 peerUid', async () => {
+    const log = recorder();
+    const out = await resolvePeerUid(
+        { chatType: GROUP, peerUid: '12345' },
+        { getUidByUinV2: async () => 'never' },
+        log,
+    );
+    assert.equal(out, '12345');
+    assert.equal(log.lines.length, 0);
+});
+
+test('peerResolution: peerUid 非纯数字直接返回原值', async () => {
+    const out = await resolvePeerUid(
+        { chatType: PRIVATE, peerUid: 'u_AbCd123' },
+        { getUidByUinV2: async () => 'never' },
+    );
+    assert.equal(out, 'u_AbCd123');
+});
+
+test('peerResolution: getUidByUinV2 返回有效 uid 时使用新值', async () => {
+    const log = recorder();
+    const out = await resolvePeerUid(
+        { chatType: PRIVATE, peerUid: '10001' },
+        { getUidByUinV2: async (uin: string) => `u_${uin}_uid` },
+        log,
+    );
+    assert.equal(out, 'u_10001_uid');
+    assert.match(log.lines[0]!, /10001/);
+});
+
+test('peerResolution: getUidByUinV2 返回空字符串时降级到原 peerUid', async () => {
+    const out = await resolvePeerUid(
+        { chatType: PRIVATE, peerUid: '10001' },
+        { getUidByUinV2: async () => '' },
+    );
+    assert.equal(out, '10001');
+});
+
+test('peerResolution: getUidByUinV2 缺失时降级到原 peerUid（issue #353 回归）', async () => {
+    const log = recorder();
+    const out = await resolvePeerUid(
+        { chatType: PRIVATE, peerUid: '10001' },
+        // 旧版 NapCat 上 UserApi 上根本没有 getUidByUinV2
+        {},
+        log,
+    );
+    assert.equal(out, '10001');
+    assert.equal(log.lines.length, 1);
+    assert.match(log.lines[0]!, /\u4e0d\u53ef\u7528/);
+});
+
+test('peerResolution: userApi 整体为 undefined 时降级到原 peerUid', async () => {
+    const out = await resolvePeerUid(
+        { chatType: PRIVATE, peerUid: '10001' },
+        undefined,
+    );
+    assert.equal(out, '10001');
+});
+
+test('peerResolution: getUidByUinV2 抛异常时不向上抛，降级到原 peerUid', async () => {
+    const log = recorder();
+    const out = await resolvePeerUid(
+        { chatType: PRIVATE, peerUid: '10001' },
+        {
+            getUidByUinV2: async () => {
+                throw new Error('boom');
+            },
+        },
+        log,
+    );
+    assert.equal(out, '10001');
+    assert.match(log.lines[0]!, /boom/);
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -36,6 +36,7 @@ import { ZipExporter } from '../utils/ZipExporter.js';
 import { StreamingZipExporter } from '../utils/StreamingZipExporter.js';
 import { VERSION, APP_INFO } from '../version.js';
 import { PathManager } from '../utils/PathManager.js';
+import { resolvePeerUid } from './peerResolution.js';
 
 // 导入类型定义
 import type { RawMessage } from 'NapCatQQ/src/core/types.js';
@@ -1873,16 +1874,9 @@ export class QQChatExporterApiServer {
                     throw new SystemError(ErrorType.VALIDATION_ERROR, 'peer参数不完整', 'INVALID_PEER');
                 }
 
-                // Issue #226: 支持通过QQ号导出，自动转换为uid
-                let actualPeerUid = peer.peerUid;
-                if (peer.chatType === 1 && /^\d+$/.test(peer.peerUid)) {
-                    // 私聊且peerUid是纯数字（QQ号），尝试转换为uid
-                    const uid = await this.core.apis.UserApi.getUidByUinV2(peer.peerUid);
-                    if (uid) {
-                        actualPeerUid = uid;
-                        this.core.context.logger.log(`[QCE] QQ号 ${peer.peerUid} 转换为 uid: ${uid}`);
-                    }
-                }
+                // Issue #226 / #353: 支持通过 QQ 号导出，自动转换为 uid。
+                // 旧版 NapCat 上 getUidByUinV2 不存在，resolvePeerUid 会安全降级到原始 peerUid。
+                const actualPeerUid = await resolvePeerUid(peer, this.core.apis?.UserApi, this.core.context.logger);
                 const actualPeer = { ...peer, peerUid: actualPeerUid };
 
                 // 生成任务ID
@@ -2011,15 +2005,8 @@ export class QQChatExporterApiServer {
                     throw new SystemError(ErrorType.VALIDATION_ERROR, 'peer参数不完整', 'INVALID_PEER');
                 }
 
-                // Issue #226: 支持通过QQ号导出，自动转换为uid
-                let actualPeerUid = peer.peerUid;
-                if (peer.chatType === 1 && /^\d+$/.test(peer.peerUid)) {
-                    const uid = await this.core.apis.UserApi.getUidByUinV2(peer.peerUid);
-                    if (uid) {
-                        actualPeerUid = uid;
-                        this.core.context.logger.log(`[QCE] QQ号 ${peer.peerUid} 转换为 uid: ${uid}`);
-                    }
-                }
+                // Issue #226 / #353: 支持通过 QQ 号导出，自动转换为 uid（兼容缺失 getUidByUinV2 的运行时）。
+                const actualPeerUid = await resolvePeerUid(peer, this.core.apis?.UserApi, this.core.context.logger);
                 const actualPeer = { ...peer, peerUid: actualPeerUid };
 
                 // 生成任务ID
@@ -2135,15 +2122,8 @@ export class QQChatExporterApiServer {
                     throw new SystemError(ErrorType.VALIDATION_ERROR, 'peer参数不完整', 'INVALID_PEER');
                 }
 
-                // Issue #226: 支持通过QQ号导出，自动转换为uid
-                let actualPeerUid = peer.peerUid;
-                if (peer.chatType === 1 && /^\d+$/.test(peer.peerUid)) {
-                    const uid = await this.core.apis.UserApi.getUidByUinV2(peer.peerUid);
-                    if (uid) {
-                        actualPeerUid = uid;
-                        this.core.context.logger.log(`[QCE] QQ号 ${peer.peerUid} 转换为 uid: ${uid}`);
-                    }
-                }
+                // Issue #226 / #353: 支持通过 QQ 号导出，自动转换为 uid（兼容缺失 getUidByUinV2 的运行时）。
+                const actualPeerUid = await resolvePeerUid(peer, this.core.apis?.UserApi, this.core.context.logger);
                 const actualPeer = { ...peer, peerUid: actualPeerUid };
 
                 // 生成任务ID

--- a/plugins/qq-chat-exporter/lib/api/peerResolution.ts
+++ b/plugins/qq-chat-exporter/lib/api/peerResolution.ts
@@ -1,0 +1,54 @@
+/**
+ * 私聊导出时把数字 QQ 号解析为真正的 NTQQ uid。
+ *
+ * 旧版 NapCat / 部分 QQNT 客户端没有 UserApi.getUidByUinV2，旧实现里直接调用
+ * 会抛 TypeError 让整条导出路径返回 500（issue #353）。这里把解析过程隔离，
+ * 任何缺失 / 异常 / 空返回都安全降级到原始 peerUid，让下游用 QQ 号继续尝试。
+ */
+export interface PeerLike {
+    chatType: number;
+    peerUid: string;
+}
+
+export interface UserApiLike {
+    getUidByUinV2?: (uin: string) => Promise<string | undefined | null>;
+}
+
+export interface LoggerLike {
+    log: (msg: string) => void;
+}
+
+const PRIVATE_CHAT = 1;
+
+export async function resolvePeerUid(
+    peer: PeerLike,
+    userApi: UserApiLike | undefined | null,
+    logger?: LoggerLike,
+): Promise<string> {
+    if (peer.chatType !== PRIVATE_CHAT || !/^\d+$/.test(peer.peerUid)) {
+        return peer.peerUid;
+    }
+
+    const fn = userApi?.getUidByUinV2;
+    if (typeof fn !== 'function') {
+        logger?.log(
+            `[QCE] UserApi.getUidByUinV2 不可用，沿用原始 peerUid: ${peer.peerUid}`,
+        );
+        return peer.peerUid;
+    }
+
+    try {
+        const uid = await fn.call(userApi, peer.peerUid);
+        if (uid) {
+            logger?.log(`[QCE] QQ号 ${peer.peerUid} 转换为 uid: ${uid}`);
+            return uid;
+        }
+        return peer.peerUid;
+    } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        logger?.log(
+            `[QCE] QQ号 ${peer.peerUid} 转换 uid 失败，沿用原值: ${msg}`,
+        );
+        return peer.peerUid;
+    }
+}


### PR DESCRIPTION
## 背景

#353 在 QQNT 9.9.21 / QCE v5.5.5 上遇到的 `TypeError: this.core.apis.UserApi.getUidByUinV2 is not a function`：

```
[API] 请求错误: TypeError: this.core.apis.UserApi.getUidByUinV2 is not a function
    at <anonymous> (...\lib\api\ApiServer.ts:1878:62)
```

部分较旧的 NapCat / QQNT 客户端 UserApi 上没有 `getUidByUinV2`，旧实现里直接调用会抛 TypeError，让整条导出路径返回 500，用户拿 QQ 号开任务直接失败。

## 改动

抽出 `lib/api/peerResolution.ts`，把"私聊数字 QQ 号 → uid"的解析隔离成纯函数 `resolvePeerUid(peer, userApi, logger)`：

- `chatType !== 1` 或 `peerUid` 不是纯数字 → 直接返回原值
- `userApi.getUidByUinV2` 不存在 → 记一条 log，沿用原始 `peerUid`
- 调用抛异常或返回空值 → 同样降级到原始 `peerUid`，不向上抛
- 调用返回有效 uid → 替换为 uid

`ApiServer` 里三个原本各自 inline 这段逻辑的导出端点 (`/api/messages/export`、`/api/messages/export-streaming-zip`、`/api/messages/export-streaming-jsonl`) 全部改为调用这个函数。

下游 NapCat 真的不支持转 uid 时，至少导出会用 QQ 号继续走，而不是直接 500。

## 测试

新增 `__tests__/unit/peerResolution.test.ts`：

- 群聊路径直接返回原 `peerUid`
- 私聊但 `peerUid` 非纯数字直接返回
- `getUidByUinV2` 缺失（issue #353 回归）
- `getUidByUinV2` 抛异常
- `getUidByUinV2` 返回空字符串 / undefined
- `getUidByUinV2` 返回有效 uid

```
$ npm test
…
ℹ tests 25
ℹ pass 25
ℹ fail 0
```

无生产代码行为兼容性变更（成功路径输出和原来一致），仅在原本会抛 TypeError 的路径上从 500 退化为继续用原始 peerUid 跑下去。
