### PR TITLE
fix(qce-v4-tool): paginate full session list via hasNext

### DIFF
--- a/qce-v4-tool/hooks/use-chat-data.ts
+++ b/qce-v4-tool/hooks/use-chat-data.ts
@@ -41,15 +41,13 @@ export function useChatData() {
           const pageGroups = response.data.groups || []
           allGroups.push(...pageGroups)
 
-          // 更新进度
-          setLoadProgress({ current: allGroups.length, total: response.data.total || allGroups.length })
+          const totalCount = response.data.totalCount ?? allGroups.length
+          setLoadProgress({ current: allGroups.length, total: totalCount })
 
-          // 判断是否还有更多
-          hasMore = pageGroups.length === limit && allGroups.length < (response.data.total || 0)
+          hasMore = response.data.hasNext === true
 
           if (hasMore) {
             currentPage++
-            // 实时更新UI
             setGroups([...allGroups])
           } else {
             break
@@ -90,15 +88,13 @@ export function useChatData() {
           const pageFriends = response.data.friends || []
           allFriends.push(...pageFriends)
 
-          // 更新进度
-          setLoadProgress({ current: allFriends.length, total: response.data.total || allFriends.length })
+          const totalCount = response.data.totalCount ?? allFriends.length
+          setLoadProgress({ current: allFriends.length, total: totalCount })
 
-          // 判断是否还有更多
-          hasMore = pageFriends.length === limit && allFriends.length < (response.data.total || 0)
+          hasMore = response.data.hasNext === true
 
           if (hasMore) {
             currentPage++
-            // 实时更新UI
             setFriends([...allFriends])
           } else {
             break


### PR DESCRIPTION
## Summary

修复前端无法加载超过 1000 条会话的问题（#339）。

`hooks/use-chat-data.ts` 里的 `loadGroups` / `loadFriends` 用 `response.data.total` 判断是否还有下一页，但 `/api/groups` 与 `/api/friends` 返回的是 `totalCount` / `hasNext`（参见 `types/api.ts` 的 `GroupsResponse` / `FriendsResponse`）。`total` 永远是 `undefined`，使得 `allFriends.length < (response.data.total || 0)` 短路为 `false`，分页循环在第一页之后终止，列表最多展示 `limit` 个（默认 1000）会话。

改动：直接读取 `response.data.hasNext` 决定循环是否继续，进度展示用 `totalCount`，与 `hooks/use-search.ts` 的实现对齐。

## 关联

- Closes #339