### PR TITLE
fix(qce-v4-tool): 批量模式全选只选中当前筛选结果

### DIFF
--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -708,11 +708,15 @@ export default function QCEDashboard() {
     }
   }
 
-  const handleSelectAll = () => {
-    const allIds = new Set<string>()
-    groups.forEach(g => allIds.add(`group_${g.groupCode}`))
-    friends.forEach(f => allIds.add(`friend_${f.uid}`))
-    setSelectedItems(allIds)
+  const handleSelectAll = (filteredIds?: Set<string>) => {
+    if (filteredIds) {
+      setSelectedItems(filteredIds)
+    } else {
+      const allIds = new Set<string>()
+      groups.forEach(g => allIds.add(`group_${g.groupCode}`))
+      friends.forEach(f => allIds.add(`friend_${f.uid}`))
+      setSelectedItems(allIds)
+    }
   }
 
   const handleClearSelection = () => {

--- a/qce-v4-tool/components/ui/session-list.tsx
+++ b/qce-v4-tool/components/ui/session-list.tsx
@@ -46,7 +46,7 @@ export interface SessionListProps {
   avatarExportLoading?: string | null
   onRefresh?: () => void
   onToggleBatchMode?: () => void
-  onSelectAll?: () => void
+  onSelectAll?: (filteredIds?: Set<string>) => void
   onClearSelection?: () => void
   onToggleItem?: (type: 'group' | 'friend', id: string) => void
   onOpenBatchExportDialog?: () => void
@@ -97,6 +97,7 @@ export function SessionList({
     setPage,
     setPageSize,
     resetFilters,
+    filteredItems,
     paginatedItems,
     totalItems,
     totalPages,
@@ -435,7 +436,13 @@ export function SessionList({
                 variant="outline"
                 size="sm"
                 className="rounded-full h-8 px-3 text-[12px]"
-                onClick={onSelectAll}
+                onClick={() => {
+                  const ids = new Set<string>()
+                  filteredItems.forEach(item => {
+                    ids.add(item.type === 'group' ? `group_${item.id}` : `friend_${item.id}`)
+                  })
+                  onSelectAll?.(ids)
+                }}
               >
                 全选当前
               </Button>


### PR DESCRIPTION
## Summary

修复批量导出模式下"全选当前"按钮无视搜索和类型筛选，始终选中全部会话的问题。

**根因**：`page.tsx` 中的 `handleSelectAll` 直接遍历完整的 `groups` 和 `friends` 数组构建选中集合，未考虑 `SessionList` 内部 `useSessionFilter` hook 维护的筛选状态（搜索关键词、群聊/好友分类、排序）。

**改动**：
- `SessionList` 组件在点击"全选当前"时，从 `useSessionFilter` 取出 `filteredItems`，将其 ID 集合传给父组件的回调
- `handleSelectAll` 接受可选的 `filteredIds` 参数；有值时直接采用，无值时回退到全量选中（兼容其他调用路径）

Closes #342