### PR TITLE
fix(scheduler): 定时导出消息按时间正序排列

### DIFF
--- a/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
+++ b/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
@@ -527,6 +527,17 @@ export class ScheduledExportManager {
                 return history;
             }
 
+            // 按时间升序排序（fetchAllMessagesInTimeRange 返回的是倒序）
+            allMessages.sort((a, b) => {
+                let timeA = parseInt(String(a.msgTime || '0'));
+                let timeB = parseInt(String(b.msgTime || '0'));
+                if (isNaN(timeA) || timeA <= 0) timeA = 0;
+                if (isNaN(timeB) || timeB <= 0) timeB = 0;
+                if (timeA > 1000000000 && timeA < 10000000000) timeA *= 1000;
+                if (timeB > 1000000000 && timeB < 10000000000) timeB *= 1000;
+                return timeA - timeB;
+            });
+
             // 下载资源
             const resourceMap = await this.resourceHandler.processMessageResources(allMessages);
 


### PR DESCRIPTION
## Summary

`fetchAllMessagesInTimeRange` 返回的消息是倒序的（最新在前）。手动导出端点在 v5.5.9（#356）中已通过 `spoolCleanMessagesChronologically` 修复了流式 ZIP 导出的排序问题，但定时导出（`ScheduledExportManager`）仍然直接将未排序的消息传给 HTML/JSON/TXT 导出器，导致输出文件中消息顺序颠倒。

本次修复在定时导出路径中，收集完全部消息后按 `msgTime` 升序排列，与手动导出端点的 `sortedMessages` 逻辑一致。

Closes #322