### PR TITLE
fix(config): 修复导出目录设置重启后不生效

### DIFF
--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -174,11 +174,6 @@ export class QQChatExporterApiServer {
         this.groupFilesExporter = new GroupFilesExporter(core);
         
         this.pathManager = PathManager.getInstance();
-        this.loadUserConfig().then(() => {
-            this.pathManager.ensureAllDirectoriesExist().catch(err => {
-                console.error('[QCE] 创建目录失败:', err);
-            });
-        });
         
         this.setupMiddleware();
         this.setupRoutes();
@@ -277,11 +272,11 @@ export class QQChatExporterApiServer {
             return false;
         }
 
-        if (config.customOutputDir !== undefined && typeof config.customOutputDir !== 'string') {
+        if (config.customOutputDir !== undefined && config.customOutputDir !== null && typeof config.customOutputDir !== 'string') {
             return false;
         }
 
-        if (config.customScheduledExportDir !== undefined && typeof config.customScheduledExportDir !== 'string') {
+        if (config.customScheduledExportDir !== undefined && config.customScheduledExportDir !== null && typeof config.customScheduledExportDir !== 'string') {
             return false;
         }
 
@@ -4991,6 +4986,10 @@ export class QQChatExporterApiServer {
         try {
             // 初始化安全管理器（优先）
             await this.securityManager.initialize();
+
+            // 加载用户配置（导出路径等），确保在处理请求前完成
+            await this.loadUserConfig();
+            await this.pathManager.ensureAllDirectoriesExist();
             
             await this.dbManager.initialize();
             await this.loadExistingTasks();


### PR DESCRIPTION
## Summary

修复了自定义导出目录设置在重启后丢失的问题（#323）。

### 根因

1. **配置校验逻辑错误**：`isValidConfig()` 在字段值为 `null` 时返回 `false`，导致整个配置文件被丢弃。`PUT /api/config` 在用户清空某个路径时会将对应字段写为 `null`（这是正常行为），但 `null` 无法通过 `typeof x !== "string"` 检查（`null !== undefined` 为 true，`typeof null !== "string"` 也为 true），因此包含任一 `null` 字段的配置文件在下次启动时会被整体判定为无效。

2. **配置加载时序问题**：`loadUserConfig()` 在构造函数中以 fire-and-forget 方式调用（`.then()` 不阻塞），理论上存在请求到达时配置尚未加载完成的窗口期。将其移入 `initialize()` 方法中 await 执行，确保在服务器开始接收请求前完成配置加载。

### 修改

- `isValidConfig()`：允许 `null` 作为 `customOutputDir` 和 `customScheduledExportDir` 的合法值
- `initialize()`：在此处 await `loadUserConfig()` 和 `ensureAllDirectoriesExist()`，替代构造函数中的 fire-and-forget 调用

Closes #323