### PR TITLE
fix(html-export): 修复导出 HTML 中页脚位置错误

### DIFF
--- a/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlTemplates.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlTemplates.ts
@@ -678,15 +678,15 @@ export const MODERN_CSS = `
         }
         
         .virtual-scroll-spacer {
-            position: absolute;
-            top: 0;
-            left: 0;
             width: 1px;
             pointer-events: none;
         }
         
         .virtual-scroll-content {
-            position: relative;
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
             will-change: transform;
         }
         
@@ -1498,6 +1498,7 @@ export const MODERN_SINGLE_APP_JS = `
             updateItems(items) {
                 this.allItems = items;
                 this.totalHeight = items.length * this.options.itemHeight;
+                this.spacer.style.height = this.totalHeight + 'px';
                 // 更新后重新计算滚动位置
                 this.scrollTop = window.pageYOffset || document.documentElement.scrollTop;
                 // 强制完整更新


### PR DESCRIPTION
## Summary

修复了导出 HTML 文件中 GitHub 链接/页脚出现在页面中部而非底部的问题（#366）。

### 根因

单文件 HTML 导出在消息数超过 100 条时启用虚拟滚动。虚拟滚动的 spacer 元素使用了 `position: absolute`，导致它脱离了正常文档流，不参与容器（`.chat-content`）的高度计算。容器高度仅由当前可见的少量消息决定（约 30 条 × 120px），页脚紧跟在这个较短的容器之后，视觉上出现在页面中部。

### 修改

1. **spacer 元素**：移除 `position: absolute`，改为普通流内元素。其动态设置的高度（消息总数 × 单条估计高度）直接撑起容器，确保页脚始终位于底部。

2. **content 元素**：改为 `position: absolute; top: 0; left: 0; width: 100%`，覆盖在 spacer 之上，通过 `transform: translateY()` 定位到当前滚动位置对应的消息区域。

3. **`updateItems()` 同步更新 spacer 高度**：筛选/搜索导致消息数量变化时，spacer 高度随之调整。

Closes #366