### PR TITLE
fix(path): 自动清理导出路径中的引号字符

### DIFF
--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -1074,8 +1074,9 @@ export class QQChatExporterApiServer {
                         this.pathManager.setCustomOutputDir(null);
                     } else {
                         try {
-                            this.pathManager.setCustomOutputDir(customOutputDir.trim());
-                            config.customOutputDir = customOutputDir.trim();
+                            const sanitizedOutputDir = PathManager.sanitizePath(customOutputDir);
+                            this.pathManager.setCustomOutputDir(sanitizedOutputDir);
+                            config.customOutputDir = sanitizedOutputDir;
                         } catch (error) {
                             const errorMsg = error instanceof Error ? error.message : '路径验证失败';
                             return this.sendErrorResponse(res, new SystemError(ErrorType.VALIDATION_ERROR, errorMsg, 'INVALID_PATH'), (req as any).requestId, 400);
@@ -1089,8 +1090,9 @@ export class QQChatExporterApiServer {
                         this.pathManager.setCustomScheduledExportDir(null);
                     } else {
                         try {
-                            this.pathManager.setCustomScheduledExportDir(customScheduledExportDir.trim());
-                            config.customScheduledExportDir = customScheduledExportDir.trim();
+                            const sanitizedScheduledDir = PathManager.sanitizePath(customScheduledExportDir);
+                            this.pathManager.setCustomScheduledExportDir(sanitizedScheduledDir);
+                            config.customScheduledExportDir = sanitizedScheduledDir;
                         } catch (error) {
                             const errorMsg = error instanceof Error ? error.message : '路径验证失败';
                             return this.sendErrorResponse(res, new SystemError(ErrorType.VALIDATION_ERROR, errorMsg, 'INVALID_PATH'), (req as any).requestId, 400);
@@ -1893,7 +1895,7 @@ export class QQChatExporterApiServer {
                 const timeStr = `${String(date.getHours()).padStart(2, '0')}${String(date.getMinutes()).padStart(2, '0')}${String(date.getSeconds()).padStart(2, '0')}`; // 221008
                 
                 // Issue #192: 根据是否使用自定义路径生成不同的下载URL
-                const customOutputDir = options?.outputDir?.trim();
+                const customOutputDir = PathManager.sanitizePath(options?.outputDir || '');
                 const defaultOutputDir = this.pathManager.getExportsDir();
                 const outputDir = customOutputDir || defaultOutputDir;
                 
@@ -2015,7 +2017,7 @@ export class QQChatExporterApiServer {
                 const timeStr = `${String(date.getHours()).padStart(2, '0')}${String(date.getMinutes()).padStart(2, '0')}${String(date.getSeconds()).padStart(2, '0')}`;
                 
                 // Issue #192: 根据是否使用自定义路径生成不同的下载URL
-                const customOutputDir = options?.outputDir?.trim();
+                const customOutputDir = PathManager.sanitizePath(options?.outputDir || '');
                 const defaultOutputDir = this.pathManager.getExportsDir();
                 const outputDir = customOutputDir || defaultOutputDir;
 
@@ -2132,7 +2134,7 @@ export class QQChatExporterApiServer {
                 const timeStr = `${String(date.getHours()).padStart(2, '0')}${String(date.getMinutes()).padStart(2, '0')}${String(date.getSeconds()).padStart(2, '0')}`;
                 
                 // Issue #192: 根据是否使用自定义路径生成不同的下载URL
-                const customOutputDir = options?.outputDir?.trim();
+                const customOutputDir = PathManager.sanitizePath(options?.outputDir || '');
                 const defaultOutputDir = this.pathManager.getExportsDir();
                 const outputDir = customOutputDir || defaultOutputDir;
 
@@ -5079,7 +5081,7 @@ export class QQChatExporterApiServer {
                     includeRecalled: task.filter?.includeRecalled || false
                 },
                 // Issue #192: 保存实际使用的输出目录（可能是自定义路径）
-                outputDir: task.options?.outputDir?.trim() || this.pathManager.getExportsDir(),
+                outputDir: task.PathManager.sanitizePath(options?.outputDir || '') || this.pathManager.getExportsDir(),
                 includeResourceLinks: task.options?.includeResourceLinks || true,
                 batchSize: task.options?.batchSize || 5000,
                 timeout: 30000,

--- a/plugins/qq-chat-exporter/lib/utils/PathManager.ts
+++ b/plugins/qq-chat-exporter/lib/utils/PathManager.ts
@@ -20,8 +20,18 @@ export class PathManager {
         return os.homedir();
     }
 
+    static sanitizePath(inputPath: string): string {
+        let cleaned = inputPath.trim();
+        // 用户从文件管理器复制路径时可能带有引号
+        if ((cleaned.startsWith('"') && cleaned.endsWith('"')) ||
+            (cleaned.startsWith("'") && cleaned.endsWith("'"))) {
+            cleaned = cleaned.slice(1, -1).trim();
+        }
+        return cleaned;
+    }
+
     private validatePath(inputPath: string): string {
-        const resolved = path.resolve(inputPath);
+        const resolved = path.resolve(PathManager.sanitizePath(inputPath));
 
         // 只禁止系统关键目录，允许任意其他位置
         const dangerousPatterns = [


### PR DESCRIPTION
## Summary

用户从 Windows 文件管理器复制路径后粘贴到导出路径输入框时，路径可能带有包裹的引号（如 `"D:\exports"`），导致路径解析失败或在文件系统中创建包含引号字面量的目录。

### 修改

1. `PathManager` 新增静态方法 `sanitizePath()`：去除首尾空白和包裹的单/双引号
2. `PathManager.validatePath()` 调用 `sanitizePath()` 预处理路径
3. `PUT /api/config` 端点使用 `sanitizePath()` 处理后再写入配置文件
4. 导出任务创建时的 per-task `outputDir` 统一通过 `PathManager.sanitizePath()` 处理

Closes #304