### PR TITLE
perf(database): 自动清理 30 天以上的历史任务记录

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/peerResolution.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/peerResolution.test.ts
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolvePeerUid } from '../../lib/api/peerResolution.js';
+
+const PRIVATE = 1;
+const GROUP = 2;
+
+function recorder() {
+    const lines: string[] = [];
+    return { log: (msg: string) => lines.push(msg), lines };
+}
+
+test('peerResolution: 群聊直接返回 peerUid', async () => {
+    const log = recorder();
+    const out = await resolvePeerUid(
+        { chatType: GROUP, peerUid: '12345' },
+        { getUidByUinV2: async () => 'never' },
+        log,
+    );
+    assert.equal(out, '12345');
+    assert.equal(log.lines.length, 0);
+});
+
+test('peerResolution: peerUid 非纯数字直接返回原值', async () => {
+    const out = await resolvePeerUid(
+        { chatType: PRIVATE, peerUid: 'u_AbCd123' },
+        { getUidByUinV2: async () => 'never' },
+    );
+    assert.equal(out, 'u_AbCd123');
+});
+
+test('peerResolution: getUidByUinV2 返回有效 uid 时使用新值', async () => {
+    const log = recorder();
+    const out = await resolvePeerUid(
+        { chatType: PRIVATE, peerUid: '10001' },
+        { getUidByUinV2: async (uin: string) => `u_${uin}_uid` },
+        log,
+    );
+    assert.equal(out, 'u_10001_uid');
+    assert.match(log.lines[0]!, /10001/);
+});
+
+test('peerResolution: getUidByUinV2 返回空字符串时降级到原 peerUid', async () => {
+    const out = await resolvePeerUid(
+        { chatType: PRIVATE, peerUid: '10001' },
+        { getUidByUinV2: async () => '' },
+    );
+    assert.equal(out, '10001');
+});
+
+test('peerResolution: getUidByUinV2 缺失时降级到原 peerUid（issue #353 回归）', async () => {
+    const log = recorder();
+    const out = await resolvePeerUid(
+        { chatType: PRIVATE, peerUid: '10001' },
+        // 旧版 NapCat 上 UserApi 上根本没有 getUidByUinV2
+        {},
+        log,
+    );
+    assert.equal(out, '10001');
+    assert.equal(log.lines.length, 1);
+    assert.match(log.lines[0]!, /\u4e0d\u53ef\u7528/);
+});
+
+test('peerResolution: userApi 整体为 undefined 时降级到原 peerUid', async () => {
+    const out = await resolvePeerUid(
+        { chatType: PRIVATE, peerUid: '10001' },
+        undefined,
+    );
+    assert.equal(out, '10001');
+});
+
+test('peerResolution: getUidByUinV2 抛异常时不向上抛，降级到原 peerUid', async () => {
+    const log = recorder();
+    const out = await resolvePeerUid(
+        { chatType: PRIVATE, peerUid: '10001' },
+        {
+            getUidByUinV2: async () => {
+                throw new Error('boom');
+            },
+        },
+        log,
+    );
+    assert.equal(out, '10001');
+    assert.match(log.lines[0]!, /boom/);
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -36,6 +36,7 @@ import { ZipExporter } from '../utils/ZipExporter.js';
 import { StreamingZipExporter } from '../utils/StreamingZipExporter.js';
 import { VERSION, APP_INFO } from '../version.js';
 import { PathManager } from '../utils/PathManager.js';
+import { resolvePeerUid } from './peerResolution.js';
 
 // 导入类型定义
 import type { RawMessage } from 'NapCatQQ/src/core/types.js';
@@ -1873,16 +1874,9 @@ export class QQChatExporterApiServer {
                     throw new SystemError(ErrorType.VALIDATION_ERROR, 'peer参数不完整', 'INVALID_PEER');
                 }
 
-                // Issue #226: 支持通过QQ号导出，自动转换为uid
-                let actualPeerUid = peer.peerUid;
-                if (peer.chatType === 1 && /^\d+$/.test(peer.peerUid)) {
-                    // 私聊且peerUid是纯数字（QQ号），尝试转换为uid
-                    const uid = await this.core.apis.UserApi.getUidByUinV2(peer.peerUid);
-                    if (uid) {
-                        actualPeerUid = uid;
-                        this.core.context.logger.log(`[QCE] QQ号 ${peer.peerUid} 转换为 uid: ${uid}`);
-                    }
-                }
+                // Issue #226 / #353: 支持通过 QQ 号导出，自动转换为 uid。
+                // 旧版 NapCat 上 getUidByUinV2 不存在，resolvePeerUid 会安全降级到原始 peerUid。
+                const actualPeerUid = await resolvePeerUid(peer, this.core.apis?.UserApi, this.core.context.logger);
                 const actualPeer = { ...peer, peerUid: actualPeerUid };
 
                 // 生成任务ID
@@ -2011,15 +2005,8 @@ export class QQChatExporterApiServer {
                     throw new SystemError(ErrorType.VALIDATION_ERROR, 'peer参数不完整', 'INVALID_PEER');
                 }
 
-                // Issue #226: 支持通过QQ号导出，自动转换为uid
-                let actualPeerUid = peer.peerUid;
-                if (peer.chatType === 1 && /^\d+$/.test(peer.peerUid)) {
-                    const uid = await this.core.apis.UserApi.getUidByUinV2(peer.peerUid);
-                    if (uid) {
-                        actualPeerUid = uid;
-                        this.core.context.logger.log(`[QCE] QQ号 ${peer.peerUid} 转换为 uid: ${uid}`);
-                    }
-                }
+                // Issue #226 / #353: 支持通过 QQ 号导出，自动转换为 uid（兼容缺失 getUidByUinV2 的运行时）。
+                const actualPeerUid = await resolvePeerUid(peer, this.core.apis?.UserApi, this.core.context.logger);
                 const actualPeer = { ...peer, peerUid: actualPeerUid };
 
                 // 生成任务ID
@@ -2135,15 +2122,8 @@ export class QQChatExporterApiServer {
                     throw new SystemError(ErrorType.VALIDATION_ERROR, 'peer参数不完整', 'INVALID_PEER');
                 }
 
-                // Issue #226: 支持通过QQ号导出，自动转换为uid
-                let actualPeerUid = peer.peerUid;
-                if (peer.chatType === 1 && /^\d+$/.test(peer.peerUid)) {
-                    const uid = await this.core.apis.UserApi.getUidByUinV2(peer.peerUid);
-                    if (uid) {
-                        actualPeerUid = uid;
-                        this.core.context.logger.log(`[QCE] QQ号 ${peer.peerUid} 转换为 uid: ${uid}`);
-                    }
-                }
+                // Issue #226 / #353: 支持通过 QQ 号导出，自动转换为 uid（兼容缺失 getUidByUinV2 的运行时）。
+                const actualPeerUid = await resolvePeerUid(peer, this.core.apis?.UserApi, this.core.context.logger);
                 const actualPeer = { ...peer, peerUid: actualPeerUid };
 
                 // 生成任务ID

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -1074,8 +1074,9 @@ export class QQChatExporterApiServer {
                         this.pathManager.setCustomOutputDir(null);
                     } else {
                         try {
-                            this.pathManager.setCustomOutputDir(customOutputDir.trim());
-                            config.customOutputDir = customOutputDir.trim();
+                            const sanitizedOutputDir = PathManager.sanitizePath(customOutputDir);
+                            this.pathManager.setCustomOutputDir(sanitizedOutputDir);
+                            config.customOutputDir = sanitizedOutputDir;
                         } catch (error) {
                             const errorMsg = error instanceof Error ? error.message : '路径验证失败';
                             return this.sendErrorResponse(res, new SystemError(ErrorType.VALIDATION_ERROR, errorMsg, 'INVALID_PATH'), (req as any).requestId, 400);
@@ -1089,8 +1090,9 @@ export class QQChatExporterApiServer {
                         this.pathManager.setCustomScheduledExportDir(null);
                     } else {
                         try {
-                            this.pathManager.setCustomScheduledExportDir(customScheduledExportDir.trim());
-                            config.customScheduledExportDir = customScheduledExportDir.trim();
+                            const sanitizedScheduledDir = PathManager.sanitizePath(customScheduledExportDir);
+                            this.pathManager.setCustomScheduledExportDir(sanitizedScheduledDir);
+                            config.customScheduledExportDir = sanitizedScheduledDir;
                         } catch (error) {
                             const errorMsg = error instanceof Error ? error.message : '路径验证失败';
                             return this.sendErrorResponse(res, new SystemError(ErrorType.VALIDATION_ERROR, errorMsg, 'INVALID_PATH'), (req as any).requestId, 400);
@@ -1893,7 +1895,7 @@ export class QQChatExporterApiServer {
                 const timeStr = `${String(date.getHours()).padStart(2, '0')}${String(date.getMinutes()).padStart(2, '0')}${String(date.getSeconds()).padStart(2, '0')}`; // 221008
                 
                 // Issue #192: 根据是否使用自定义路径生成不同的下载URL
-                const customOutputDir = options?.outputDir?.trim();
+                const customOutputDir = PathManager.sanitizePath(options?.outputDir || '');
                 const defaultOutputDir = this.pathManager.getExportsDir();
                 const outputDir = customOutputDir || defaultOutputDir;
                 
@@ -2015,7 +2017,7 @@ export class QQChatExporterApiServer {
                 const timeStr = `${String(date.getHours()).padStart(2, '0')}${String(date.getMinutes()).padStart(2, '0')}${String(date.getSeconds()).padStart(2, '0')}`;
                 
                 // Issue #192: 根据是否使用自定义路径生成不同的下载URL
-                const customOutputDir = options?.outputDir?.trim();
+                const customOutputDir = PathManager.sanitizePath(options?.outputDir || '');
                 const defaultOutputDir = this.pathManager.getExportsDir();
                 const outputDir = customOutputDir || defaultOutputDir;
 
@@ -2132,7 +2134,7 @@ export class QQChatExporterApiServer {
                 const timeStr = `${String(date.getHours()).padStart(2, '0')}${String(date.getMinutes()).padStart(2, '0')}${String(date.getSeconds()).padStart(2, '0')}`;
                 
                 // Issue #192: 根据是否使用自定义路径生成不同的下载URL
-                const customOutputDir = options?.outputDir?.trim();
+                const customOutputDir = PathManager.sanitizePath(options?.outputDir || '');
                 const defaultOutputDir = this.pathManager.getExportsDir();
                 const outputDir = customOutputDir || defaultOutputDir;
 
@@ -5079,7 +5081,7 @@ export class QQChatExporterApiServer {
                     includeRecalled: task.filter?.includeRecalled || false
                 },
                 // Issue #192: 保存实际使用的输出目录（可能是自定义路径）
-                outputDir: task.options?.outputDir?.trim() || this.pathManager.getExportsDir(),
+                outputDir: task.PathManager.sanitizePath(options?.outputDir || '') || this.pathManager.getExportsDir(),
                 includeResourceLinks: task.options?.includeResourceLinks || true,
                 batchSize: task.options?.batchSize || 5000,
                 timeout: 30000,

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -174,11 +174,6 @@ export class QQChatExporterApiServer {
         this.groupFilesExporter = new GroupFilesExporter(core);
         
         this.pathManager = PathManager.getInstance();
-        this.loadUserConfig().then(() => {
-            this.pathManager.ensureAllDirectoriesExist().catch(err => {
-                console.error('[QCE] 创建目录失败:', err);
-            });
-        });
         
         this.setupMiddleware();
         this.setupRoutes();
@@ -277,11 +272,11 @@ export class QQChatExporterApiServer {
             return false;
         }
 
-        if (config.customOutputDir !== undefined && typeof config.customOutputDir !== 'string') {
+        if (config.customOutputDir !== undefined && config.customOutputDir !== null && typeof config.customOutputDir !== 'string') {
             return false;
         }
 
-        if (config.customScheduledExportDir !== undefined && typeof config.customScheduledExportDir !== 'string') {
+        if (config.customScheduledExportDir !== undefined && config.customScheduledExportDir !== null && typeof config.customScheduledExportDir !== 'string') {
             return false;
         }
 
@@ -4991,6 +4986,10 @@ export class QQChatExporterApiServer {
         try {
             // 初始化安全管理器（优先）
             await this.securityManager.initialize();
+
+            // 加载用户配置（导出路径等），确保在处理请求前完成
+            await this.loadUserConfig();
+            await this.pathManager.ensureAllDirectoriesExist();
             
             await this.dbManager.initialize();
             await this.loadExistingTasks();

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -1116,6 +1116,20 @@ export class QQChatExporterApiServer {
             }
         });
 
+        this.app.post('/api/database/cleanup', async (req, res) => {
+            try {
+                const retentionDays = parseInt(req.body?.retentionDays) || 30;
+                const cleaned = await this.dbManager.cleanupOldTasks(retentionDays);
+                this.sendSuccessResponse(res, {
+                    message: `已清理 ${cleaned} 条历史任务记录`,
+                    cleanedTasks: cleaned,
+                    retentionDays
+                }, (req as any).requestId);
+            } catch (error) {
+                return this.sendErrorResponse(res, new SystemError(ErrorType.DATABASE_ERROR, '数据库清理失败', 'CLEANUP_FAILED'), (req as any).requestId);
+            }
+        });
+
         this.app.get('/api/groups', async (req, res) => {
             try {
                 const forceRefresh = req.query['forceRefresh'] === 'true';

--- a/plugins/qq-chat-exporter/lib/api/peerResolution.ts
+++ b/plugins/qq-chat-exporter/lib/api/peerResolution.ts
@@ -1,0 +1,54 @@
+/**
+ * 私聊导出时把数字 QQ 号解析为真正的 NTQQ uid。
+ *
+ * 旧版 NapCat / 部分 QQNT 客户端没有 UserApi.getUidByUinV2，旧实现里直接调用
+ * 会抛 TypeError 让整条导出路径返回 500（issue #353）。这里把解析过程隔离，
+ * 任何缺失 / 异常 / 空返回都安全降级到原始 peerUid，让下游用 QQ 号继续尝试。
+ */
+export interface PeerLike {
+    chatType: number;
+    peerUid: string;
+}
+
+export interface UserApiLike {
+    getUidByUinV2?: (uin: string) => Promise<string | undefined | null>;
+}
+
+export interface LoggerLike {
+    log: (msg: string) => void;
+}
+
+const PRIVATE_CHAT = 1;
+
+export async function resolvePeerUid(
+    peer: PeerLike,
+    userApi: UserApiLike | undefined | null,
+    logger?: LoggerLike,
+): Promise<string> {
+    if (peer.chatType !== PRIVATE_CHAT || !/^\d+$/.test(peer.peerUid)) {
+        return peer.peerUid;
+    }
+
+    const fn = userApi?.getUidByUinV2;
+    if (typeof fn !== 'function') {
+        logger?.log(
+            `[QCE] UserApi.getUidByUinV2 不可用，沿用原始 peerUid: ${peer.peerUid}`,
+        );
+        return peer.peerUid;
+    }
+
+    try {
+        const uid = await fn.call(userApi, peer.peerUid);
+        if (uid) {
+            logger?.log(`[QCE] QQ号 ${peer.peerUid} 转换为 uid: ${uid}`);
+            return uid;
+        }
+        return peer.peerUid;
+    } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        logger?.log(
+            `[QCE] QQ号 ${peer.peerUid} 转换 uid 失败，沿用原值: ${msg}`,
+        );
+        return peer.peerUid;
+    }
+}

--- a/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlTemplates.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlTemplates.ts
@@ -678,15 +678,15 @@ export const MODERN_CSS = `
         }
         
         .virtual-scroll-spacer {
-            position: absolute;
-            top: 0;
-            left: 0;
             width: 1px;
             pointer-events: none;
         }
         
         .virtual-scroll-content {
-            position: relative;
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
             will-change: transform;
         }
         
@@ -1498,6 +1498,7 @@ export const MODERN_SINGLE_APP_JS = `
             updateItems(items) {
                 this.allItems = items;
                 this.totalHeight = items.length * this.options.itemHeight;
+                this.spacer.style.height = this.totalHeight + 'px';
                 // 更新后重新计算滚动位置
                 this.scrollTop = window.pageYOffset || document.documentElement.scrollTop;
                 // 强制完整更新

--- a/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
+++ b/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
@@ -527,6 +527,17 @@ export class ScheduledExportManager {
                 return history;
             }
 
+            // 按时间升序排序（fetchAllMessagesInTimeRange 返回的是倒序）
+            allMessages.sort((a, b) => {
+                let timeA = parseInt(String(a.msgTime || '0'));
+                let timeB = parseInt(String(b.msgTime || '0'));
+                if (isNaN(timeA) || timeA <= 0) timeA = 0;
+                if (isNaN(timeB) || timeB <= 0) timeB = 0;
+                if (timeA > 1000000000 && timeA < 10000000000) timeA *= 1000;
+                if (timeB > 1000000000 && timeB < 10000000000) timeB *= 1000;
+                return timeA - timeB;
+            });
+
             // 下载资源
             const resourceMap = await this.resourceHandler.processMessageResources(allMessages);
 

--- a/plugins/qq-chat-exporter/lib/core/storage/DatabaseManager.ts
+++ b/plugins/qq-chat-exporter/lib/core/storage/DatabaseManager.ts
@@ -172,6 +172,9 @@ export class DatabaseManager {
             // 清理失败的任务
             await this.cleanupFailedTasks();
 
+            // 清理超过 30 天的已完成任务，防止 JSONL 文件无限增长
+            await this.cleanupOldTasks(30);
+
             this.initialized = true;
 
         } catch (error) {
@@ -755,6 +758,52 @@ export class DatabaseManager {
             }
             await this.rebuildFiles();
         }
+    }
+
+    /**
+     * 清理已完成的历史任务
+     * 删除超过 retentionDays 天且状态为 completed/failed/cancelled 的任务及其关联消息
+     */
+    async cleanupOldTasks(retentionDays: number = 30): Promise<number> {
+        this.ensureInitialized();
+        const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+        const tasksToDelete: string[] = [];
+
+        for (const [, taskRecord] of this.indexes.tasks) {
+            try {
+                const state = JSON.parse(taskRecord.state) as ExportTaskState;
+                if (state.status !== 'completed' && state.status !== 'failed' && state.status !== 'cancelled') {
+                    continue;
+                }
+                const endTime = state.endTime ? new Date(state.endTime).getTime() : 0;
+                const updatedAt = taskRecord.updatedAt ? new Date(taskRecord.updatedAt).getTime() : 0;
+                const taskTime = Math.max(endTime, updatedAt);
+                if (taskTime > 0 && taskTime < cutoff) {
+                    tasksToDelete.push(taskRecord.taskId);
+                }
+            } catch {
+                // 无法解析的记录也标记为可清理
+                tasksToDelete.push(taskRecord.taskId);
+            }
+        }
+
+        if (tasksToDelete.length === 0) {
+            return 0;
+        }
+
+        for (const taskId of tasksToDelete) {
+            const recordId = this.taskIdToRecordId.get(taskId);
+            if (recordId) {
+                this.indexes.tasks.delete(recordId);
+                this.taskIdToRecordId.delete(taskId);
+                this.taskPersistSnapshots.delete(taskId);
+            }
+            this.indexes.messages.delete(taskId);
+        }
+
+        await this.rebuildFiles();
+        console.log(`[DatabaseManager] 已清理 ${tasksToDelete.length} 条历史任务记录`);
+        return tasksToDelete.length;
     }
 
     /**

--- a/plugins/qq-chat-exporter/lib/utils/PathManager.ts
+++ b/plugins/qq-chat-exporter/lib/utils/PathManager.ts
@@ -20,8 +20,18 @@ export class PathManager {
         return os.homedir();
     }
 
+    static sanitizePath(inputPath: string): string {
+        let cleaned = inputPath.trim();
+        // 用户从文件管理器复制路径时可能带有引号
+        if ((cleaned.startsWith('"') && cleaned.endsWith('"')) ||
+            (cleaned.startsWith("'") && cleaned.endsWith("'"))) {
+            cleaned = cleaned.slice(1, -1).trim();
+        }
+        return cleaned;
+    }
+
     private validatePath(inputPath: string): string {
-        const resolved = path.resolve(inputPath);
+        const resolved = path.resolve(PathManager.sanitizePath(inputPath));
 
         // 只禁止系统关键目录，允许任意其他位置
         const dangerousPatterns = [

--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -822,6 +822,7 @@ export default function QCEDashboard() {
           outputDir: config.outputDir,
           keywords: config.keywords,
           excludeUserUins: config.excludeUserUins,
+          useNameInFileName: config.useNameInFileName,
         }
 
         // 调用单个导出 API

--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -708,11 +708,15 @@ export default function QCEDashboard() {
     }
   }
 
-  const handleSelectAll = () => {
-    const allIds = new Set<string>()
-    groups.forEach(g => allIds.add(`group_${g.groupCode}`))
-    friends.forEach(f => allIds.add(`friend_${f.uid}`))
-    setSelectedItems(allIds)
+  const handleSelectAll = (filteredIds?: Set<string>) => {
+    if (filteredIds) {
+      setSelectedItems(filteredIds)
+    } else {
+      const allIds = new Set<string>()
+      groups.forEach(g => allIds.add(`group_${g.groupCode}`))
+      friends.forEach(f => allIds.add(`friend_${f.uid}`))
+      setSelectedItems(allIds)
+    }
   }
 
   const handleClearSelection = () => {

--- a/qce-v4-tool/components/ui/batch-export-dialog.tsx
+++ b/qce-v4-tool/components/ui/batch-export-dialog.tsx
@@ -41,6 +41,7 @@ export interface BatchExportConfig {
   outputDir: string
   keywords: string
   excludeUserUins: string
+  useNameInFileName: boolean
 }
 
 export interface BatchExportProgress {
@@ -73,6 +74,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
   const [outputDir, setOutputDir] = useState('')
   const [keywords, setKeywords] = useState('')
   const [excludeUserUins, setExcludeUserUins] = useState('')
+  const [useNameInFileName, setUseNameInFileName] = useState(true)
   
   const [progress, setProgress] = useState<BatchExportProgress>({
     current: 0,
@@ -99,6 +101,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
       setOutputDir('')
       setKeywords('')
       setExcludeUserUins('')
+      setUseNameInFileName(true)
       setProgress({
         current: 0,
         total: items.length,
@@ -183,7 +186,8 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
       filterPureImageMessages,
       outputDir,
       keywords,
-      excludeUserUins
+      excludeUserUins,
+      useNameInFileName
     }
 
     try {
@@ -408,6 +412,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
                     { id: "includeSystemMessages", checked: includeSystemMessages, set: setIncludeSystemMessages, title: "包含系统消息", desc: "包含入群通知、撤回提示等系统提示消息", visible: true, highlight: false },
                     { id: "filterPureImageMessages", checked: filterPureImageMessages, set: setFilterPureImageMessages, title: "快速导出（跳过资源下载）", desc: "保留所有消息记录，但不下载图片/视频/音频等资源文件，大幅加快导出速度", visible: true, highlight: false },
                     { id: "exportAsZip", checked: exportAsZip, set: setExportAsZip, title: "导出为ZIP压缩包", desc: "将HTML文件和资源文件打包为ZIP格式（仅HTML格式可用）", visible: format === "HTML" && !streamingZipMode, highlight: false },
+                    { id: "useNameInFileName", checked: useNameInFileName, set: setUseNameInFileName, title: "文件名包含聊天名称", desc: "导出文件名中包含聊天对象的名称，方便识别", visible: true, highlight: false },
                     { id: "embedAvatarsAsBase64", checked: embedAvatarsAsBase64, set: setEmbedAvatarsAsBase64, title: "嵌入头像为Base64", desc: "将发送者头像以Base64格式嵌入JSON文件（仅JSON格式可用，会增加文件大小）", visible: format === "JSON", highlight: false }
                   ].filter((opt) => opt.visible).map((opt) => (
                     <div key={opt.id} className={["relative cursor-pointer rounded-2xl border p-4 transition-all", opt.highlight && opt.checked ? "border-orange-400 dark:border-orange-600 bg-orange-50/50 dark:bg-orange-950/30 ring-1 ring-orange-200 dark:ring-orange-800" : opt.highlight ? "border-orange-200 dark:border-orange-800 bg-orange-50/30 dark:bg-orange-950/20 hover:border-orange-300 dark:hover:border-orange-700" : opt.checked ? "border-black/[0.08] dark:border-white/[0.08] bg-muted/30" : "border-black/[0.06] dark:border-white/[0.06] hover:border-black/[0.08] dark:hover:border-white/[0.08]", isExporting ? "opacity-50 cursor-not-allowed" : ""].join(" ")} onClick={() => !isExporting && opt.set(!opt.checked)}>

--- a/qce-v4-tool/components/ui/session-list.tsx
+++ b/qce-v4-tool/components/ui/session-list.tsx
@@ -46,7 +46,7 @@ export interface SessionListProps {
   avatarExportLoading?: string | null
   onRefresh?: () => void
   onToggleBatchMode?: () => void
-  onSelectAll?: () => void
+  onSelectAll?: (filteredIds?: Set<string>) => void
   onClearSelection?: () => void
   onToggleItem?: (type: 'group' | 'friend', id: string) => void
   onOpenBatchExportDialog?: () => void
@@ -97,6 +97,7 @@ export function SessionList({
     setPage,
     setPageSize,
     resetFilters,
+    filteredItems,
     paginatedItems,
     totalItems,
     totalPages,
@@ -435,7 +436,13 @@ export function SessionList({
                 variant="outline"
                 size="sm"
                 className="rounded-full h-8 px-3 text-[12px]"
-                onClick={onSelectAll}
+                onClick={() => {
+                  const ids = new Set<string>()
+                  filteredItems.forEach(item => {
+                    ids.add(item.type === 'group' ? `group_${item.id}` : `friend_${item.id}`)
+                  })
+                  onSelectAll?.(ids)
+                }}
               >
                 全选当前
               </Button>

--- a/qce-v4-tool/hooks/use-chat-data.ts
+++ b/qce-v4-tool/hooks/use-chat-data.ts
@@ -41,15 +41,13 @@ export function useChatData() {
           const pageGroups = response.data.groups || []
           allGroups.push(...pageGroups)
 
-          // 更新进度
-          setLoadProgress({ current: allGroups.length, total: response.data.total || allGroups.length })
+          const totalCount = response.data.totalCount ?? allGroups.length
+          setLoadProgress({ current: allGroups.length, total: totalCount })
 
-          // 判断是否还有更多
-          hasMore = pageGroups.length === limit && allGroups.length < (response.data.total || 0)
+          hasMore = response.data.hasNext === true
 
           if (hasMore) {
             currentPage++
-            // 实时更新UI
             setGroups([...allGroups])
           } else {
             break
@@ -90,15 +88,13 @@ export function useChatData() {
           const pageFriends = response.data.friends || []
           allFriends.push(...pageFriends)
 
-          // 更新进度
-          setLoadProgress({ current: allFriends.length, total: response.data.total || allFriends.length })
+          const totalCount = response.data.totalCount ?? allFriends.length
+          setLoadProgress({ current: allFriends.length, total: totalCount })
 
-          // 判断是否还有更多
-          hasMore = pageFriends.length === limit && allFriends.length < (response.data.total || 0)
+          hasMore = response.data.hasNext === true
 
           if (hasMore) {
             currentPage++
-            // 实时更新UI
             setFriends([...allFriends])
           } else {
             break


### PR DESCRIPTION
## Summary

导出任务完成后，`tasks.jsonl`、`messages.jsonl`、`resources.jsonl` 持续增长，长期使用后导致系统变慢（#309）。

### 修改

1. `DatabaseManager.cleanupOldTasks(retentionDays)` — 清理超过指定天数（默认 30 天）的已完成/失败/已取消任务及其关联消息记录，清理后重建 JSONL 文件
2. 启动时自动执行清理（在 `initialize()` 中调用）
3. 新增 `POST /api/database/cleanup` 端点，支持手动触发清理，参数 `retentionDays` 可自定义保留天数

### 设计考虑

- 仅清理终态任务（completed/failed/cancelled），不影响进行中的导出
- 资源文件（`resources.jsonl`）不做清理，因为资源可能被多个任务引用，且资源的去重重建已由 `performStartupMaintenance` 处理
- 清理后通过 `rebuildFiles()` 原子性重写 JSONL 文件

Closes #309