### PR TITLE
perf(database): skip loading legacy messages.jsonl on startup (#309)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/DatabaseManager.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/DatabaseManager.test.ts
@@ -1,0 +1,101 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { DatabaseManager } from '../../lib/core/storage/DatabaseManager.js';
+
+function tmpDb(): { dbPath: string; dbDir: string; cleanup: () => void } {
+    const dbDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qce-db-'));
+    const dbPath = path.join(dbDir, 'qce.sqlite');
+    return {
+        dbPath,
+        dbDir,
+        cleanup: () => fs.rmSync(dbDir, { recursive: true, force: true }),
+    };
+}
+
+test('initialize 不再加载 messages.jsonl，避免遗留数据拖慢启动 (#309)', async () => {
+    const { dbPath, dbDir, cleanup } = tmpDb();
+    try {
+        const messagesPath = path.join(dbDir, 'messages.jsonl');
+        // 模拟旧版本累积下来的若干消息行
+        const legacy = Array.from({ length: 100 }, (_, i) =>
+            JSON.stringify({
+                id: i,
+                taskId: 'task-legacy',
+                messageId: `m-${i}`,
+                messageSeq: `${i}`,
+                messageTime: `${1700000000 + i}`,
+                senderUid: 'u_x',
+                content: '{}',
+                processed: false,
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+            }),
+        ).join('\n');
+        fs.writeFileSync(messagesPath, legacy + '\n', 'utf8');
+        const beforeSize = fs.statSync(messagesPath).size;
+        assert.ok(beforeSize > 0);
+
+        const db = new DatabaseManager(dbPath);
+        await db.initialize();
+
+        // 文件被清空（归档过去）
+        const afterSize = fs.statSync(messagesPath).size;
+        assert.equal(afterSize, 0, 'messages.jsonl 应被清空');
+
+        // 备份目录里能找到与之大小一致的归档
+        const backupDir = path.join(dbDir, 'backups');
+        const archives = fs
+            .readdirSync(backupDir)
+            .filter(name => name.startsWith('legacy-messages-'));
+        assert.equal(archives.length, 1, '应该恰好有一份归档');
+        const archiveSize = fs.statSync(path.join(backupDir, archives[0]!)).size;
+        assert.equal(archiveSize, beforeSize, '归档大小应等于原文件');
+    } finally {
+        cleanup();
+    }
+});
+
+test('initialize 在缺失 messages.jsonl 时不会创建归档', async () => {
+    const { dbPath, dbDir, cleanup } = tmpDb();
+    try {
+        const db = new DatabaseManager(dbPath);
+        await db.initialize();
+
+        const backupDir = path.join(dbDir, 'backups');
+        if (fs.existsSync(backupDir)) {
+            const archives = fs
+                .readdirSync(backupDir)
+                .filter(name => name.startsWith('legacy-messages-'));
+            assert.equal(archives.length, 0, '空数据库不应该产生归档');
+        }
+
+        // messages.jsonl 仍被作为空文件创建，便于后续运行时一致
+        assert.ok(fs.existsSync(path.join(dbDir, 'messages.jsonl')));
+    } finally {
+        cleanup();
+    }
+});
+
+test('initialize 在已有空 messages.jsonl 时静默跳过', async () => {
+    const { dbPath, dbDir, cleanup } = tmpDb();
+    try {
+        const messagesPath = path.join(dbDir, 'messages.jsonl');
+        fs.writeFileSync(messagesPath, '', 'utf8');
+
+        const db = new DatabaseManager(dbPath);
+        await db.initialize();
+
+        const backupDir = path.join(dbDir, 'backups');
+        if (fs.existsSync(backupDir)) {
+            const archives = fs
+                .readdirSync(backupDir)
+                .filter(name => name.startsWith('legacy-messages-'));
+            assert.equal(archives.length, 0, '空文件不应该被归档');
+        }
+    } finally {
+        cleanup();
+    }
+});

--- a/plugins/qq-chat-exporter/lib/core/storage/DatabaseManager.ts
+++ b/plugins/qq-chat-exporter/lib/core/storage/DatabaseManager.ts
@@ -187,6 +187,11 @@ export class DatabaseManager {
 
     /**
      * 初始化JSONL文件
+     *
+     * 同时一次性回收 messages.jsonl 占用的磁盘空间：当前架构不再读写该文件，
+     * 但旧版本可能在其中堆积了大量历史导出消息。如果文件存在且非空，移动到
+     * backups/legacy-messages-<timestamp>.jsonl 后再清空，确保万一需要回溯仍
+     * 能找回原始内容。详见 #309。
      */
     private async initializeFiles(): Promise<void> {
         // 确保所有JSONL文件存在
@@ -195,10 +200,47 @@ export class DatabaseManager {
                 await fsPromises.writeFile(filePath, '', 'utf8');
             }
         }
+
+        await this.archiveLegacyMessagesFile();
+    }
+
+    private async archiveLegacyMessagesFile(): Promise<void> {
+        try {
+            const messagesPath = this.files.messages;
+            if (!fs.existsSync(messagesPath)) {
+                return;
+            }
+
+            const stats = await fsPromises.stat(messagesPath);
+            if (stats.size === 0) {
+                return;
+            }
+
+            if (!fs.existsSync(this.backupDir)) {
+                await fsPromises.mkdir(this.backupDir, { recursive: true });
+            }
+
+            const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+            const archivePath = path.join(this.backupDir, `legacy-messages-${timestamp}.jsonl`);
+            await fsPromises.rename(messagesPath, archivePath);
+            await fsPromises.writeFile(messagesPath, '', 'utf8');
+            console.warn(
+                `[DatabaseManager] messages.jsonl 已不被使用，归档至 ${archivePath} 以加速启动（${stats.size} 字节）。`
+            );
+        } catch (error) {
+            console.warn('[DatabaseManager] 归档 messages.jsonl 失败，忽略并继续启动:', error);
+        }
     }
 
     /**
      * 加载所有数据到内存索引
+     *
+     * 注：messages.jsonl 自当前导出架构改为流式之后已不再被任何调用方读取
+     * （saveMessages / getUnprocessedMessages 等接口在 lib/ 内没有外部使用方），
+     * 仅是历史遗留文件。如果在升级前累积了大量内容，启动时全量解析会显著拖慢初始化。
+     * 详见 #309。这里改为不再加载该文件，并在 initializeFiles 中一次性清空。
+     *
+     * 其余 5 个索引彼此独立，改为并行加载以缩短启动时间。
      */
     private async loadIndexes(): Promise<void> {
         this.taskIdToRecordId.clear();
@@ -209,23 +251,13 @@ export class DatabaseManager {
             resources: false
         };
 
-        // 加载任务数据
-        await this.loadTaskIndex();
-        
-        // 加载消息数据
-        await this.loadMessageIndex();
-        
-        // 加载资源数据
-        await this.loadResourceIndex();
-        
-        // 加载系统信息
-        await this.loadSystemInfoIndex();
-        
-        // 加载定时导出任务
-        await this.loadScheduledExportIndex();
-        
-        // 加载执行历史
-        await this.loadExecutionHistoryIndex();
+        await Promise.all([
+            this.loadTaskIndex(),
+            this.loadResourceIndex(),
+            this.loadSystemInfoIndex(),
+            this.loadScheduledExportIndex(),
+            this.loadExecutionHistoryIndex()
+        ]);
     }
 
     /**
@@ -659,11 +691,12 @@ export class DatabaseManager {
 
     /**
      * 重建所有文件（用于删除操作后的清理）
+     *
+     * messages.jsonl 不再被现行架构读取，启动期已归档清空，运行期不再重写。
      */
     private async rebuildFiles(): Promise<void> {
         await Promise.all([
             this.rebuildTaskFile(),
-            this.rebuildMessageFile(), 
             this.rebuildResourceFile()
         ]);
     }
@@ -758,22 +791,23 @@ export class DatabaseManager {
     }
 
     /**
-     * 批量保存消息
+     * 批量保存消息（仅维护内存索引）
+     *
+     * 历史接口，保留以便兼容潜在外部调用。当前导出流水线全部走流式写出，
+     * 消息不再持久化到 messages.jsonl，避免该文件无限增长拖慢启动（#309）。
      */
     async saveMessages(taskId: string, messages: any[]): Promise<void> {
         this.ensureInitialized();
 
-        // 确保任务消息索引存在
         if (!this.indexes.messages.has(taskId)) {
             this.indexes.messages.set(taskId, new Map());
         }
 
         const taskMessages = this.indexes.messages.get(taskId)!;
-        const messageRecords: MessageDbRecord[] = [];
 
         messages.forEach(msg => {
             const messageRecord: MessageDbRecord = {
-                id: Date.now() + Math.random(), // 简单的ID生成
+                id: Date.now() + Math.random(),
                 taskId: taskId,
                 messageId: msg.msgId,
                 messageSeq: msg.msgSeq,
@@ -785,19 +819,12 @@ export class DatabaseManager {
                 updatedAt: new Date()
             };
 
-            // 更新内存索引
             taskMessages.set(messageRecord.messageId, messageRecord);
-            messageRecords.push(messageRecord);
-        });
-
-        // 批量写入
-        messageRecords.forEach(record => {
-            this.queueWrite(this.files.messages, record);
         });
     }
 
     /**
-     * 标记消息为已处理
+     * 标记消息为已处理（仅维护内存索引，参见 saveMessages 注释）
      */
     async markMessageProcessed(taskId: string, messageId: string): Promise<void> {
         this.ensureInitialized();
@@ -807,9 +834,6 @@ export class DatabaseManager {
             const message = taskMessages.get(messageId)!;
             message.processed = true;
             message.updatedAt = new Date();
-            
-            // 重新写入整个消息记录
-            this.queueWrite(this.files.messages, message);
         }
     }
 


### PR DESCRIPTION
## Summary

#309 报告 QCE 在导出历史增长后启动越来越慢。原因是 `DatabaseManager.loadIndexes()` 会全量解析 `messages.jsonl` 进入内存索引，而该文件在当前流式导出架构下已不再被任何调用方读取——`saveMessages` / `getUnprocessedMessages` / `markMessageProcessed` / `getTaskProgress` 在 `lib/` 内没有外部使用方，是早期非流式导出的遗留接口。从旧版本升级上来的用户会在该文件中累积大量历史导出消息，每次启动都要重新解析。

本 PR 不删任何任务、资源或导出文件，只处理这条已经废弃的中间日志：

- `loadIndexes`: 移除 `loadMessageIndex` 调用，剩余 5 个索引彼此独立，改为 `Promise.all` 并行加载。
- `initializeFiles`: 启动时如果 `messages.jsonl` 存在且非空，重命名为 `backups/legacy-messages-<timestamp>.jsonl`，再以空文件占位。需要回溯时仍可在备份目录中找回原始内容。
- `rebuildFiles`: 不再重写 `messages.jsonl`，避免删除任务时白做一次磁盘 I/O。
- `saveMessages` / `markMessageProcessed`: 保留方法签名以维持源代码兼容，仅维护内存索引、不再写盘。

### Performance impact

启动期 I/O 与 CPU 开销与 `messages.jsonl` 大小线性相关。对于报告中的大文件场景，本次改动相当于把“按行 JSON.parse → 写入 Map”完全省掉。归档发生在 `initializeFiles` 阶段，仅一次 `rename` 系统调用，常数时间。

### Compatibility

- `getStatistics().totalMessages` 在 `lib/` 内没有调用方，行为虽然变成 0 但不影响任何对外接口。
- 归档文件位于 `<dbDir>/backups/legacy-messages-<ISO>.jsonl`，永远不会被自动删除。

## Review & Testing Checklist for Human

- [ ] 在装有大体积 `messages.jsonl` 的环境上验证：插件启动耗时显著下降，备份目录里出现 `legacy-messages-*.jsonl`，原文件大小为 0。
- [ ] 验证 `tasks.jsonl` / `resources.jsonl` 的去重与压缩行为不变（`performStartupMaintenance` 流程未触动）。

### Notes

新增三条单元测试覆盖归档、缺失、空文件三种情况，跑在 `npm test` 中。完整测试套件 28 / 28 通过。