### PR TITLE
feat(chat-list): expose QQ Bot / service / temp sessions for export (#364)

### DIFF
--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -735,7 +735,8 @@ export class QQChatExporterApiServer {
                     ],
                     '好友管理': [
                         'GET /api/friends?page=1&limit=999 - 获取所有好友（支持分页）',
-                        'GET /api/friends/:uid?no_cache=false - 获取好友详情'
+                        'GET /api/friends/:uid?no_cache=false - 获取好友详情',
+                        'GET /api/recent-contacts?limit=100&includeAll=false - 获取最近联系人中不属于好友/群聊的会话（QQ Bot、服务号等）'
                     ],
                     '消息处理': [
                         'POST /api/messages/fetch - 批量获取消息',
@@ -1528,6 +1529,110 @@ export class QQChatExporterApiServer {
                 
                 const friendDetail = await this.core.apis.UserApi.getUserDetailInfo(uid, no_cache);
                 this.sendSuccessResponse(res, friendDetail, (req as any).requestId);
+            } catch (error) {
+                this.sendErrorResponse(res, error, (req as any).requestId);
+            }
+        });
+
+        // 获取最近联系人中不属于好友 / 群聊的会话（QQ 官方 Bot、服务号、临时会话等，Issue #364）。
+        this.app.get('/api/recent-contacts', async (req, res) => {
+            try {
+                const limit = Math.min(parseInt(req.query['limit'] as string) || 100, 500);
+                const includeAll = req.query['includeAll'] === 'true';
+
+                const userApi = this.core.apis.UserApi as any;
+                if (typeof userApi?.getRecentContactListSnapShot !== 'function') {
+                    throw new SystemError(
+                        ErrorType.API_ERROR,
+                        '当前 NapCat 版本未提供 getRecentContactListSnapShot，无法读取最近联系人',
+                        'API_UNAVAILABLE'
+                    );
+                }
+
+                const recentResult = await userApi.getRecentContactListSnapShot(limit);
+                const errCode = recentResult?.info?.errCode;
+                if (errCode !== undefined && errCode !== 0) {
+                    throw new SystemError(
+                        ErrorType.API_ERROR,
+                        `获取最近联系人失败: ${recentResult?.info?.errMsg || 'unknown'}`,
+                        'RECENT_CONTACTS_FAILED'
+                    );
+                }
+
+                const changedList: any[] = recentResult?.info?.changedList || [];
+
+                let friendUidSet = new Set<string>();
+                let groupCodeSet = new Set<string>();
+                if (!includeAll) {
+                    try {
+                        const categories = await this.core.apis.FriendApi.getBuddyV2ExWithCate();
+                        const allFriends = categories.flatMap((cat: any) => cat.buddyList);
+                        friendUidSet = new Set<string>(
+                            allFriends
+                                .map((f: any) => String(f.uid || f.coreInfo?.uid || ''))
+                                .filter((s: string) => s.length > 0)
+                        );
+                    } catch (e) {
+                        this.core.context.logger.logWarn(
+                            '[ApiServer] /api/recent-contacts: 获取好友列表失败，跳过去重',
+                            e
+                        );
+                    }
+                    try {
+                        const groups = await this.core.apis.GroupApi.getGroups(false);
+                        groupCodeSet = new Set<string>(
+                            (groups || []).map((g: any) => String(g.groupCode || ''))
+                        );
+                    } catch (e) {
+                        this.core.context.logger.logWarn(
+                            '[ApiServer] /api/recent-contacts: 获取群组列表失败，跳过去重',
+                            e
+                        );
+                    }
+                }
+
+                const contacts = changedList
+                    .filter(c => c?.peerUid && c?.chatType !== undefined && c?.chatType !== null)
+                    .map(c => {
+                        const chatType = Number(c.chatType);
+                        const peerUid = String(c.peerUid);
+                        const isFriend = chatType === 1 && friendUidSet.has(peerUid);
+                        const isGroup = chatType === 2 && groupCodeSet.has(peerUid);
+                        return {
+                            chatType,
+                            peerUid,
+                            peerUin: c.peerUin ? String(c.peerUin) : undefined,
+                            name: c.peerName || c.sendNickName || c.sendMemberName || `${peerUid}`,
+                            sendNickName: c.sendNickName || undefined,
+                            sendMemberName: c.sendMemberName || undefined,
+                            avatarUrl: c.peerUin
+                                ? `https://q1.qlogo.cn/g?b=qq&nk=${c.peerUin}&s=640`
+                                : undefined,
+                            lastMsgId: c.msgId ? String(c.msgId) : undefined,
+                            lastMsgTime: c.msgTime
+                                ? new Date(parseInt(c.msgTime, 10) * 1000).toISOString()
+                                : undefined,
+                            classification: isFriend
+                                ? 'friend'
+                                : isGroup
+                                ? 'group'
+                                : chatType === 1
+                                ? 'private'
+                                : chatType === 2
+                                ? 'group'
+                                : 'special'
+                        };
+                    });
+
+                const filtered = includeAll
+                    ? contacts
+                    : contacts.filter(c => c.classification === 'special' || c.classification === 'private');
+
+                this.sendSuccessResponse(res, {
+                    contacts: filtered,
+                    totalCount: filtered.length,
+                    rawCount: changedList.length
+                }, (req as any).requestId);
             } catch (error) {
                 this.sendErrorResponse(res, error, (req as any).requestId);
             }

--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -761,11 +761,13 @@ export default function QCEDashboard() {
       } else if (type === 'friend') {
         const friend = friends.find(f => f.uid === id)
         if (friend) {
+          // Issue #364: 合并自最近联系人的特殊会话（QQ Bot / 服务号 / 临时会话）
+          // 会带上原始 chatType，避免在导出请求里被强制覆写为 1。
           items.push({
             type: 'friend',
             id: friend.uid,
             name: friend.remark || friend.nick,
-            chatType: 1,
+            chatType: friend.chatType ?? 1,
             peerUid: friend.uid
           })
         }

--- a/qce-v4-tool/components/ui/scheduled-export-wizard.tsx
+++ b/qce-v4-tool/components/ui/scheduled-export-wizard.tsx
@@ -271,12 +271,15 @@ export function ScheduledExportWizard({
     const isGroup = "groupCode" in target
     const id = isGroup ? target.groupCode : target.uid
     const name = isGroup ? target.groupName : target.remark || target.nick
-    
+
+    // Issue #364: 来自最近联系人合并的特殊会话（QQ Bot / 服务号 / 临时会话）
+    // 携带原始 chatType，按其透传，避免被覆写为普通好友（chatType=1）。
+    const friendChatType = !isGroup ? (target as Friend).chatType ?? 1 : 1
     const selectedTarget: SelectedTarget = {
       type: isGroup ? 'group' : 'friend',
       id,
       name,
-      chatType: isGroup ? 2 : 1,
+      chatType: isGroup ? 2 : friendChatType,
       peerUid: id,
       avatarUrl: target.avatarUrl,
     }
@@ -492,6 +495,21 @@ export function ScheduledExportWizard({
                               <>
                                 <Users className="w-3 h-3" />
                                 <span>{(target as Group).memberCount} 成员</span>
+                              </>
+                            ) : (target as Friend).isSpecial ? (
+                              <>
+                                <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+                                  {(target as Friend).specialKind === "service"
+                                    ? "服务号"
+                                    : (target as Friend).specialKind === "temp"
+                                      ? "临时会话"
+                                      : (target as Friend).specialKind === "notify"
+                                        ? "通知"
+                                        : "其他"}
+                                </span>
+                                <span className="text-muted-foreground/70">
+                                  chatType={(target as Friend).chatType}
+                                </span>
                               </>
                             ) : (
                               <>

--- a/qce-v4-tool/components/ui/task-wizard.tsx
+++ b/qce-v4-tool/components/ui/task-wizard.tsx
@@ -210,7 +210,14 @@ export function TaskWizard({
     if ("groupCode" in target) {
       setForm((p) => ({ ...p, chatType: 2, peerUid: target.groupCode, sessionName: target.groupName }))
     } else {
-      setForm((p) => ({ ...p, chatType: 1, peerUid: target.uid, sessionName: target.remark || target.nick }))
+      // Issue #364: 合并自最近联系人的特殊会话（QQ Bot / 服务号 / 临时会话）会
+      // 携带原始 chatType，按其透传，避免被覆写为普通好友（chatType=1）。
+      setForm((p) => ({
+        ...p,
+        chatType: target.chatType ?? 1,
+        peerUid: target.uid,
+        sessionName: target.remark || target.nick,
+      }))
     }
   }
 
@@ -560,6 +567,21 @@ export function TaskWizard({
                       <>
                         <Users className="w-3 h-3" />
                         <span>{(target as Group).memberCount} 成员</span>
+                      </>
+                    ) : (target as Friend).isSpecial ? (
+                      <>
+                        <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+                          {(target as Friend).specialKind === "service"
+                            ? "服务号"
+                            : (target as Friend).specialKind === "temp"
+                              ? "临时会话"
+                              : (target as Friend).specialKind === "notify"
+                                ? "通知"
+                                : "其他"}
+                        </span>
+                        <span className="text-muted-foreground/70">
+                          chatType={(target as Friend).chatType}
+                        </span>
                       </>
                     ) : (
                       <>

--- a/qce-v4-tool/hooks/use-chat-data.ts
+++ b/qce-v4-tool/hooks/use-chat-data.ts
@@ -1,6 +1,36 @@
 import { useState, useCallback } from "react"
-import type { Group, Friend, GroupsResponse, FriendsResponse } from "@/types/api"
+import type { Group, Friend, GroupsResponse, FriendsResponse, RecentContactsResponse } from "@/types/api"
 import { useApi } from "./use-api"
+
+/**
+ * 将 NTQQ ChatType 数值映射为人类可读的细分类别（Issue #364）。
+ * 仅覆盖最近联系人列表里常见的非好友 / 非群聊会话。
+ */
+function classifySpecialChatType(chatType: number): string {
+  switch (chatType) {
+    case 99:
+    case 100:
+    case 101:
+    case 102:
+    case 103:
+    case 111:
+    case 117:
+    case 119:
+      return "temp"
+    case 118:
+    case 201:
+      return "service"
+    case 132:
+    case 133:
+    case 134:
+      return "notify"
+    case 9:
+    case 16:
+      return "guild"
+    default:
+      return "other"
+  }
+}
 
 export interface AvatarExportResult {
   success: boolean
@@ -102,6 +132,39 @@ export function useChatData() {
         } else {
           break
         }
+      }
+
+      // Issue #364: 把最近联系人中既不在好友列表也不在群组列表的会话（QQ Bot、
+      // 服务号、临时会话等）合并到 friends 数组里。这些会话保留原始 chatType，
+      // 上层导出 / 定时任务在选中时会把 chatType 透传给后端，避免被强制归为
+      // 普通好友（chatType=1）。失败时静默跳过，不影响普通好友加载。
+      try {
+        const recentResp = await apiCall<RecentContactsResponse>("/api/recent-contacts?limit=200")
+        if (recentResp.success && recentResp.data) {
+          const existingUids = new Set(allFriends.map((f) => f.uid))
+          const specialFriends: Friend[] = recentResp.data.contacts
+            .filter((c) => c.classification === "special" && !existingUids.has(c.peerUid))
+            .map((c) => ({
+              uid: c.peerUid,
+              uin: c.peerUin ? Number(c.peerUin) : 0,
+              nick: c.name,
+              remark: undefined,
+              avatarUrl: c.avatarUrl,
+              isOnline: false,
+              status: 0,
+              categoryId: 0,
+              chatType: c.chatType,
+              isSpecial: true,
+              specialKind: classifySpecialChatType(c.chatType),
+            }))
+
+          if (specialFriends.length > 0) {
+            allFriends.push(...specialFriends)
+            console.log(`[QCE] 合并 ${specialFriends.length} 个特殊会话（Bot / 服务号 / 临时会话）`)
+          }
+        }
+      } catch (recentErr) {
+        console.warn("[QCE] 加载最近联系人失败，跳过特殊会话合并:", recentErr)
       }
 
       setFriends(allFriends)

--- a/qce-v4-tool/types/api.ts
+++ b/qce-v4-tool/types/api.ts
@@ -92,6 +92,15 @@ export interface Friend {
   isOnline?: boolean
   status?: number
   categoryId?: number
+  /**
+   * NTQQ ChatType（默认 1=好友）。来自最近联系人合并的会话（QQ Bot、服务号、临时会话等）
+   * 会保留原始 chatType（例如 118），导出时直接传给后端，避免被错误归类为普通好友。
+   */
+  chatType?: number
+  /** 来自 /api/recent-contacts 合并的特殊会话标记（Issue #364） */
+  isSpecial?: boolean
+  /** 当 isSpecial 为 true 时的细分（service / temp / public_account / unknown 等） */
+  specialKind?: string
 }
 
 export interface FriendsResponse {
@@ -101,6 +110,30 @@ export interface FriendsResponse {
   totalPages: number
   hasNext: boolean
   hasPrev: boolean
+}
+
+/** 最近联系人中无法归类为好友 / 群聊的会话（QQ Bot、服务号、临时会话等，Issue #364） */
+export interface RecentContact {
+  /** NTQQ ChatType 原值（1=好友, 2=群聊, 100=临时, 118=服务助手等） */
+  chatType: number
+  peerUid: string
+  peerUin?: string
+  /** 显示名（peerName / sendNickName / sendMemberName，按可用性回退） */
+  name: string
+  sendNickName?: string
+  sendMemberName?: string
+  avatarUrl?: string
+  lastMsgId?: string
+  /** ISO 时间戳 */
+  lastMsgTime?: string
+  /** 后端分类：special 表示既不在好友列表也不在群组列表 */
+  classification: 'friend' | 'group' | 'private' | 'special'
+}
+
+export interface RecentContactsResponse {
+  contacts: RecentContact[]
+  totalCount: number
+  rawCount: number
 }
 
 // Task Types


### PR DESCRIPTION
## Summary

Issue #364: 用户无法在 QQ Chat Exporter 中导出 QQ Bot（如 PenClaw、小AI 等）的聊天记录。原因是后端只暴露了 `/api/friends` 与 `/api/groups`，前端的会话选择面板仅渲染好友和群聊；而 QQ Bot、服务号、临时会话等的 NTQQ ChatType（118 / 100 / 103 等）虽然出现在 `getRecentContactListSnapShot` 返回的最近联系人快照里，却既不在好友列表中也不在群组列表中，因此在 UI 中完全不可见。

## 后端

- 新增 `GET /api/recent-contacts?limit=&includeAll=` 端点：
  - 调用 `UserApi.getRecentContactListSnapShot(limit)` 拉取最近联系人。
  - 与 `getBuddyV2ExWithCate()` 与 `getGroups()` 的结果去重，给每条联系人打上 `classification`：`friend` / `group` / `private`（chatType=1 但不在好友列表）/ `special`（其余 chatType，例如 118、100、103）。
  - 返回字段：`{ chatType, peerUid, peerUin, name, avatarUrl, lastMsgId, lastMsgTime, classification, ... }`。
- 当目标 NapCat 实例没有 `getRecentContactListSnapShot` 时返回结构化错误 `API_UNAVAILABLE`，前端可降级为只展示常规好友与群组，不影响主流程。

## 前端

- `Friend` 类型新增三个可选字段：`chatType` / `isSpecial` / `specialKind`。
- `useChatData.loadFriends` 在加载好友列表后追加调用 `/api/recent-contacts`，把 `classification === 'special'` 的条目合并到 `friends` 数组里并标记 `isSpecial`。最近联系人接口失败时静默降级，与旧行为兼容。
- `TaskWizard`、`ScheduledExportWizard` 的目标列表对特殊会话渲染琥珀色徽章（服务号 / 临时会话 / 通知 / 其他）并显示 `chatType` 数值；选中时保持原始 `chatType` 透传给后端导出接口，避免被强制归一化为 `chatType=1`。
- 主页 `getBatchExportItems` 同步使用 `friend.chatType ?? 1`，让批量导出也能正确处理特殊会话。

## 兼容性

- 旧版 NapCat 没有 `getRecentContactListSnapShot` 时端点返回 `API_UNAVAILABLE`，前端降级为仅显示好友与群组，与改动前等价。
- 现有定时任务、批量任务、单次导出在普通好友 / 群聊场景下行为完全不变（`chatType` 默认仍为 1 / 2）。

## 测试

- 现有 30 个 plugin 测试全部通过（节点 unit + integration）。
- 后端 / 前端 TypeScript 在本次改动范围内无新增类型错误。