### PR TITLE
feat(export): allow skipping file downloads while keeping metadata (#341)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/ResourceHandler.skipDownload.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/ResourceHandler.skipDownload.test.ts
@@ -1,0 +1,127 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { DatabaseManager } from '../../lib/core/storage/DatabaseManager.js';
+import { ResourceHandler } from '../../lib/core/resource/ResourceHandler.js';
+import { ResourceStatus } from '../../lib/types/index.js';
+import { createMockCore } from '../helpers/MockNapCatCore.js';
+import { msg } from '../fixtures/builders.js';
+
+/**
+ * Issue #341 — 仅保留文件元数据、跳过下载。
+ *
+ * 验证 ResourceHandler 在 setSkipDownloadTypes(['file']) 之后：
+ *   - 文件类资源会被解析、入库，但不会触发实际下载（FileApi.downloadMedia 不被调用）
+ *   - 该资源在返回的 resourceMap 中状态为 SKIPPED
+ *   - 图片等其他类型默认不受影响（这里仅断言文件类被跳过；图片的真实下载链路需要更复杂的 mock，
+ *     由 ApiServer 集成层覆盖）
+ */
+function tmpDir(prefix: string): { dir: string; cleanup: () => void } {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    return { dir, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
+}
+
+test('setSkipDownloadTypes(["file"]) 命中文件资源时仅保留元数据，状态为 SKIPPED', async () => {
+    const dbHome = tmpDir('qce-rh-db-');
+    const resHome = tmpDir('qce-rh-res-');
+    const prevUserProfile = process.env['USERPROFILE'];
+    process.env['USERPROFILE'] = resHome.dir;
+
+    try {
+        const dbPath = path.join(dbHome.dir, 'qce.sqlite');
+        const db = new DatabaseManager(dbPath);
+        await db.initialize();
+
+        const core = createMockCore();
+
+        const handler = new ResourceHandler(core as any, db, {
+            // 走默认存储根路径，但 USERPROFILE 已被指向临时目录
+            downloadTimeout: 200,
+            maxConcurrentDownloads: 1,
+            maxRetries: 0,
+            healthCheckInterval: 60_000,
+        });
+        handler.setSkipDownloadTypes(['file']);
+
+        const message = msg({
+            peerUid: 'peer_test',
+            chatType: 1,
+            senderUid: 'u_other',
+        }).file({ filename: 'spec.pdf', size: 4096, md5: 'cafebabe' }).build();
+
+        const resourceMap = await handler.processMessageResources([message]);
+
+        const resources = resourceMap.get(message.msgId);
+        assert.ok(resources, '应当返回该消息的资源数组');
+        assert.equal(resources.length, 1, '应当解析出 1 个资源');
+        const [info] = resources;
+        assert.equal(info.type, 'file');
+        assert.equal(info.fileName, 'spec.pdf');
+        assert.equal(info.status, ResourceStatus.SKIPPED, '文件资源应被标记为 SKIPPED');
+
+        const calls = core.__getCallLog().filter((c) => c.api === 'FileApi.downloadMedia');
+        assert.equal(calls.length, 0, '跳过类型的资源不应触发 FileApi.downloadMedia');
+
+        await handler.cleanup();
+        await db.close();
+    } finally {
+        if (prevUserProfile === undefined) {
+            delete process.env['USERPROFILE'];
+        } else {
+            process.env['USERPROFILE'] = prevUserProfile;
+        }
+        dbHome.cleanup();
+        resHome.cleanup();
+    }
+});
+
+test('setSkipDownloadTypes([]) 恢复默认行为，文件资源不再被强制跳过', async () => {
+    const dbHome = tmpDir('qce-rh-db-');
+    const resHome = tmpDir('qce-rh-res-');
+    const prevUserProfile = process.env['USERPROFILE'];
+    process.env['USERPROFILE'] = resHome.dir;
+
+    try {
+        const dbPath = path.join(dbHome.dir, 'qce.sqlite');
+        const db = new DatabaseManager(dbPath);
+        await db.initialize();
+
+        const core = createMockCore();
+
+        const handler = new ResourceHandler(core as any, db, {
+            downloadTimeout: 200,
+            maxConcurrentDownloads: 1,
+            maxRetries: 0,
+            healthCheckInterval: 60_000,
+        });
+        handler.setSkipDownloadTypes(['file']);
+        handler.setSkipDownloadTypes([]); // 重置
+
+        const message = msg({
+            peerUid: 'peer_test',
+            chatType: 1,
+            senderUid: 'u_other',
+        }).file({ filename: 'spec.pdf', size: 4096, md5: 'cafebabe2' }).build();
+
+        const resourceMap = await handler.processMessageResources([message]);
+        const resources = resourceMap.get(message.msgId)!;
+        assert.equal(resources.length, 1);
+        // 默认行为下不会进入 SKIPPED 路径；这里不强约束最终状态
+        // （实际状态依赖健康检查与下载结果），只断言不是 SKIPPED。
+        assert.notEqual(resources[0].status, ResourceStatus.SKIPPED);
+
+        await handler.cleanup();
+        await db.close();
+    } finally {
+        if (prevUserProfile === undefined) {
+            delete process.env['USERPROFILE'];
+        } else {
+            process.env['USERPROFILE'] = prevUserProfile;
+        }
+        dbHome.cleanup();
+        resHome.cleanup();
+    }
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -40,10 +40,11 @@ import { resolvePeerUid } from './peerResolution.js';
 
 // 导入类型定义
 import type { RawMessage } from 'NapCatQQ/src/core/types.js';
-import type { 
+import type {
     SystemErrorData,
     ExportTaskConfig,
-    ExportTaskState
+    ExportTaskState,
+    ResourceType
 } from '../types/index.js';
 import { 
     ErrorType,
@@ -3697,6 +3698,21 @@ export class QQChatExporterApiServer {
                     });
                 });
 
+                // Issue #341: 用户可指定跳过下载的资源类型（仅保留元数据），
+                // 优先读取细粒度的 skipDownloadResourceTypes，未提供时再回退到
+                // 旧的 skipFileDownload 布尔开关。
+                const requestedSkipTypes: string[] = Array.isArray(options?.skipDownloadResourceTypes)
+                    ? options!.skipDownloadResourceTypes!
+                    : (options?.skipFileDownload ? ['file'] : []);
+                const allowedSkipTypes: ResourceType[] = ['image', 'video', 'audio', 'file'];
+                const normalizedSkipTypes = requestedSkipTypes
+                    .map(t => String(t).toLowerCase())
+                    .filter((t): t is ResourceType => allowedSkipTypes.includes(t as ResourceType));
+                if (normalizedSkipTypes.length > 0) {
+                    taskResourceHandler.setSkipDownloadTypes(normalizedSkipTypes);
+                    console.info(`[ApiServer] 跳过下载的资源类型: ${normalizedSkipTypes.join(', ')}`);
+                }
+
                 // 下载和处理资源（使用过滤后的消息列表）
                 resourceMap = await taskResourceHandler.processMessageResources(filteredMessages);
                 
@@ -4153,7 +4169,20 @@ export class QQChatExporterApiServer {
         // 为此任务创建独立的 ResourceHandler
         const taskResourceHandler = new ResourceHandler(this.core, this.dbManager);
         this.taskResourceHandlers.set(taskId, taskResourceHandler);
-        
+
+        // Issue #341: 流式分块导出路径同样支持按资源类型跳过下载。
+        const requestedSkipTypes: string[] = Array.isArray(options?.skipDownloadResourceTypes)
+            ? options!.skipDownloadResourceTypes!
+            : (options?.skipFileDownload ? ['file'] : []);
+        const allowedSkipTypes: ResourceType[] = ['image', 'video', 'audio', 'file'];
+        const normalizedSkipTypes = requestedSkipTypes
+            .map((t: string) => String(t).toLowerCase())
+            .filter((t: string): t is ResourceType => allowedSkipTypes.includes(t as ResourceType));
+        if (normalizedSkipTypes.length > 0) {
+            taskResourceHandler.setSkipDownloadTypes(normalizedSkipTypes);
+            console.info(`[ApiServer] (流式) 跳过下载的资源类型: ${normalizedSkipTypes.join(', ')}`);
+        }
+
         try {
 
             // 更新任务状态

--- a/plugins/qq-chat-exporter/lib/core/resource/ResourceHandler.ts
+++ b/plugins/qq-chat-exporter/lib/core/resource/ResourceHandler.ts
@@ -301,12 +301,19 @@ export class ResourceHandler {
     private isProcessing: boolean = false;
     private isHealthCheckRunning: boolean = false;
     private healthCheckTimer: NodeJS.Timeout | null = null;
-    
+
     // 进度回调
     private progressCallback: ResourceProgressCallback | null = null;
     private totalResourcesForProgress: number = 0;
     private completedResourcesForProgress: number = 0;
     private failedResourcesForProgress: number = 0;
+
+    /**
+     * 跳过下载的资源类型集合（Issue #341）。
+     * 命中的资源仍会保留元数据（fileName / fileSize / md5 / mimeType / 可恢复的 originalUrl）
+     * 写入数据库与导出结果，但不会被加入下载队列，状态被标记为 SKIPPED。
+     */
+    private skipDownloadTypes: Set<ResourceType> = new Set();
 
     constructor(core: NapCatCore, dbManager: DatabaseManager, config: Partial<ResourceHandlerConfig> = {}) {
         this.core = core;
@@ -341,6 +348,19 @@ export class ResourceHandler {
      */
     setProgressCallback(callback: ResourceProgressCallback | null): void {
         this.progressCallback = callback;
+    }
+
+    /**
+     * 配置需要跳过下载的资源类型（Issue #341）。
+     *
+     * 适用场景：导出聊天记录时仅需要文件名 / 大小等元数据，不需要本地副本，
+     * 例如群文件下载占用磁盘大且 QQ 自身已缓存的场景。命中的资源仍会被解析、
+     * 写入数据库并出现在导出文件中，只是不会触发实际网络下载。
+     *
+     * 传入 null 或空数组即恢复默认行为（不跳过任何类型）。
+     */
+    setSkipDownloadTypes(types: ResourceType[] | null | undefined): void {
+        this.skipDownloadTypes = new Set(types || []);
     }
 
     /**
@@ -386,7 +406,8 @@ export class ResourceHandler {
                         if (resourceInfo) {
                             resources.push(resourceInfo);
                             totalResources++;
-                            if (!resourceInfo.accessible) {
+                            // Issue #341: 被跳过下载的资源不计入下载进度，避免进度永远卡住。
+                            if (!resourceInfo.accessible && resourceInfo.status !== ResourceStatus.SKIPPED) {
                                 resourcesNeedingDownload++;
                             }
                         }
@@ -449,10 +470,17 @@ export class ResourceHandler {
         
         // 如果资源不健康或不存在，添加到下载队列并等待下载完成
         if (!isHealthy) {
-            resourceInfo.status = ResourceStatus.PENDING;
-            await this.enqueueDownload(message, element, resourceInfo);
-            // 注意：enqueueDownload只是添加到队列，实际下载是异步的
-            // 我们在processMessageResources的最后统一等待所有下载完成
+            // Issue #341: 命中跳过类型的资源不入下载队列，仅保留元数据。
+            if (this.skipDownloadTypes.has(resourceInfo.type)) {
+                resourceInfo.status = ResourceStatus.SKIPPED;
+                resourceInfo.accessible = false;
+                resourceInfo.localPath = '';
+            } else {
+                resourceInfo.status = ResourceStatus.PENDING;
+                await this.enqueueDownload(message, element, resourceInfo);
+                // 注意：enqueueDownload只是添加到队列，实际下载是异步的
+                // 我们在processMessageResources的最后统一等待所有下载完成
+            }
         }
         
         // 更新数据库

--- a/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
+++ b/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
@@ -150,6 +150,10 @@ export interface ScheduledExportConfig {
         filterPureImageMessages?: boolean;
         prettyFormat?: boolean;
         preferGroupMemberName?: boolean;
+        /** Issue #341: 仅保留元数据、跳过下载的资源类型（'image' | 'video' | 'audio' | 'file'）。 */
+        skipDownloadResourceTypes?: Array<'image' | 'video' | 'audio' | 'file'>;
+        /** Issue #341: 兼容字段，等价于 skipDownloadResourceTypes: ['file']。 */
+        skipFileDownload?: boolean;
     };
     /** 备份模式（新增） */
     backupMode?: BackupMode;
@@ -539,8 +543,31 @@ export class ScheduledExportManager {
                 return timeA - timeB;
             });
 
-            // 下载资源
+            // Issue #341: 定时任务也支持按资源类型跳过下载，仅保留元数据。
+            const requestedSkipTypes = Array.isArray(task.options.skipDownloadResourceTypes)
+                ? task.options.skipDownloadResourceTypes
+                : (task.options.skipFileDownload ? ['file' as const] : []);
+            const allowedSkipTypes = ['image', 'video', 'audio', 'file'] as const;
+            const normalizedSkipTypes = requestedSkipTypes
+                .map(t => String(t).toLowerCase())
+                .filter((t): t is typeof allowedSkipTypes[number] =>
+                    (allowedSkipTypes as readonly string[]).includes(t)
+                );
+            try {
+                this.resourceHandler.setSkipDownloadTypes(normalizedSkipTypes);
+            } catch {
+                // older ResourceHandler 没有该方法时忽略
+            }
+
+            // 下载资源（受 skipDownloadResourceTypes 影响）
             const resourceMap = await this.resourceHandler.processMessageResources(allMessages);
+
+            // 重置共享 ResourceHandler 的状态，避免影响后续任务
+            try {
+                this.resourceHandler.setSkipDownloadTypes([]);
+            } catch {
+                // ignore
+            }
 
             // 生成文件名
             const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);

--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -826,6 +826,10 @@ export default function QCEDashboard() {
           keywords: config.keywords,
           excludeUserUins: config.excludeUserUins,
           useNameInFileName: config.useNameInFileName,
+          // Issue #341
+          ...(Array.isArray(config.skipDownloadResourceTypes) && config.skipDownloadResourceTypes.length > 0 && {
+            skipDownloadResourceTypes: config.skipDownloadResourceTypes,
+          }),
         }
 
         // 调用单个导出 API

--- a/qce-v4-tool/components/ui/batch-export-dialog.tsx
+++ b/qce-v4-tool/components/ui/batch-export-dialog.tsx
@@ -39,6 +39,8 @@ export interface BatchExportConfig {
   includeSystemMessages: boolean
   filterPureImageMessages: boolean
   preferGroupMemberName: boolean
+  /** Issue #341: 仅保留元数据、跳过下载的资源类型 */
+  skipDownloadResourceTypes?: Array<'image' | 'video' | 'audio' | 'file'>
   outputDir: string
   keywords: string
   excludeUserUins: string
@@ -73,6 +75,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
   const [includeSystemMessages, setIncludeSystemMessages] = useState(true)
   const [filterPureImageMessages, setFilterPureImageMessages] = useState(false) // HTML默认false
   const [preferGroupMemberName, setPreferGroupMemberName] = useState(true)
+  const [skipFileDownloadOnly, setSkipFileDownloadOnly] = useState(false)
   const [outputDir, setOutputDir] = useState('')
   const [keywords, setKeywords] = useState('')
   const [excludeUserUins, setExcludeUserUins] = useState('')
@@ -101,6 +104,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
       setIncludeSystemMessages(true)
       setFilterPureImageMessages(false)
       setPreferGroupMemberName(true)
+      setSkipFileDownloadOnly(false)
       setOutputDir('')
       setKeywords('')
       setExcludeUserUins('')
@@ -188,6 +192,9 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
       includeSystemMessages,
       filterPureImageMessages,
       preferGroupMemberName,
+      ...(skipFileDownloadOnly && !filterPureImageMessages && {
+        skipDownloadResourceTypes: ['file' as const]
+      }),
       outputDir,
       keywords,
       excludeUserUins,
@@ -415,6 +422,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
                     { id: "streamingZipMode", checked: streamingZipMode, set: setStreamingZipMode, title: "流式导出（超大消息量专用）", desc: format === "HTML" ? "专为50万+消息量设计，全程流式处理防止内存溢出。输出ZIP格式。" : "专为50万+消息量设计，全程流式处理防止内存溢出。输出分块JSONL格式。", visible: format === "HTML" || format === "JSON", highlight: true },
                     { id: "includeSystemMessages", checked: includeSystemMessages, set: setIncludeSystemMessages, title: "包含系统消息", desc: "包含入群通知、撤回提示等系统提示消息", visible: true, highlight: false },
                     { id: "filterPureImageMessages", checked: filterPureImageMessages, set: setFilterPureImageMessages, title: "快速导出（跳过资源下载）", desc: "保留所有消息记录，但不下载图片/视频/音频等资源文件，大幅加快导出速度", visible: true, highlight: false },
+                    { id: "skipFileDownloadOnly", checked: skipFileDownloadOnly, set: setSkipFileDownloadOnly, title: "仅保留文件元数据，不下载文件", desc: "图片 / 视频 / 音频仍正常下载；只有文件类资源（群文件、聊天发送的文档等）只保留文件名、大小、MD5 等元信息。", visible: !filterPureImageMessages, highlight: false },
                     { id: "preferGroupMemberName", checked: preferGroupMemberName, set: setPreferGroupMemberName, title: "优先使用群成员名称", desc: "群聊导出时优先使用群名片或群内名称。关闭后会改用 QQ 昵称或 QQ 号。这个选项仅对群聊生效。", visible: true, highlight: false },
                     { id: "exportAsZip", checked: exportAsZip, set: setExportAsZip, title: "导出为ZIP压缩包", desc: "将HTML文件和资源文件打包为ZIP格式（仅HTML格式可用）", visible: format === "HTML" && !streamingZipMode, highlight: false },
                     { id: "useNameInFileName", checked: useNameInFileName, set: setUseNameInFileName, title: "文件名包含聊天名称", desc: "导出文件名中包含聊天对象的名称，方便识别", visible: true, highlight: false },

--- a/qce-v4-tool/components/ui/scheduled-export-wizard.tsx
+++ b/qce-v4-tool/components/ui/scheduled-export-wizard.tsx
@@ -63,6 +63,7 @@ export function ScheduledExportWizard({
     includeSystemMessages: true,
     filterPureImageMessages: false,
     preferGroupMemberName: true,
+    skipFileDownloadOnly: false,
   })
 
   // 选中的目标
@@ -118,6 +119,9 @@ export function ScheduledExportWizard({
           ? prefilledData.filterPureImageMessages 
           : defaultFilter,
         preferGroupMemberName: prefilledData.preferGroupMemberName !== undefined ? prefilledData.preferGroupMemberName : true,
+        skipFileDownloadOnly: Array.isArray(prefilledData.skipDownloadResourceTypes)
+          ? prefilledData.skipDownloadResourceTypes.includes('file')
+          : false,
       })
 
       // 如果有预填充的目标，添加到选中列表
@@ -152,6 +156,7 @@ export function ScheduledExportWizard({
         includeSystemMessages: true,
         filterPureImageMessages: false,
         preferGroupMemberName: true,
+        skipFileDownloadOnly: false,
       })
       setSelectedTargets([])
       setSearchTerm("")
@@ -205,6 +210,9 @@ export function ScheduledExportWizard({
         includeSystemMessages: baseForm.includeSystemMessages,
         filterPureImageMessages: baseForm.filterPureImageMessages,
         preferGroupMemberName: baseForm.preferGroupMemberName,
+        ...(baseForm.skipFileDownloadOnly && !baseForm.filterPureImageMessages && {
+          skipDownloadResourceTypes: ['file' as const],
+        }),
       }
       
       try {
@@ -838,16 +846,26 @@ export function ScheduledExportWizard({
                       checked: baseForm.filterPureImageMessages,
                       set: (v: boolean) => setBaseForm(p => ({ ...p, filterPureImageMessages: v })),
                       title: "快速导出（跳过资源下载）",
-                      desc: "保留所有消息记录，但不下载图片/视频/音频等资源文件，大幅加快导出速度"
+                      desc: "保留所有消息记录，但不下载图片/视频/音频等资源文件，大幅加快导出速度",
+                      visible: true,
+                    },
+                    {
+                      id: "skipFileDownloadOnly",
+                      checked: baseForm.skipFileDownloadOnly,
+                      set: (v: boolean) => setBaseForm(p => ({ ...p, skipFileDownloadOnly: v })),
+                      title: "仅保留文件元数据，不下载文件",
+                      desc: "图片 / 视频 / 音频仍正常下载；只有文件类资源（群文件、聊天发送的文档等）只保留文件名、大小、MD5 等元信息。",
+                      visible: !baseForm.filterPureImageMessages,
                     },
                     {
                       id: "preferGroupMemberName",
                       checked: baseForm.preferGroupMemberName,
                       set: (v: boolean) => setBaseForm(p => ({ ...p, preferGroupMemberName: v })),
                       title: "优先使用群成员名称",
-                      desc: "群聊导出时优先使用群名片或群内名称。关闭后会改用 QQ 昵称或 QQ 号。这个选项仅对群聊生效。"
+                      desc: "群聊导出时优先使用群名片或群内名称。关闭后会改用 QQ 昵称或 QQ 号。这个选项仅对群聊生效。",
+                      visible: true,
                     }
-                  ].map((opt) => (
+                  ].filter((opt) => (opt as any).visible !== false).map((opt) => (
                     <div
                       key={opt.id}
                       className={[

--- a/qce-v4-tool/components/ui/task-wizard.tsx
+++ b/qce-v4-tool/components/ui/task-wizard.tsx
@@ -1002,6 +1002,22 @@ export function TaskWizard({
                 visible: true
               },
               {
+                id: "skipFileDownloadOnly",
+                checked: !!form.skipDownloadResourceTypes?.includes('file'),
+                set: (v: boolean) => setForm((p) => {
+                  const current = new Set(p.skipDownloadResourceTypes || []);
+                  if (v) {
+                    current.add('file');
+                  } else {
+                    current.delete('file');
+                  }
+                  return { ...p, skipDownloadResourceTypes: Array.from(current) };
+                }),
+                title: "仅保留文件元数据，不下载文件",
+                desc: "图片 / 视频 / 音频仍正常下载；只有文件类资源（群文件、聊天发送的文档等）只保留文件名、大小、MD5 等元信息。适合不需要本地副本的备份场景。",
+                visible: !form.filterPureImageMessages
+              },
+              {
                 id: "preferGroupMemberName",
                 checked: form.preferGroupMemberName ?? true,
                 set: (v: boolean) => setForm((p) => ({ ...p, preferGroupMemberName: v })),

--- a/qce-v4-tool/hooks/use-export-tasks.ts
+++ b/qce-v4-tool/hooks/use-export-tasks.ts
@@ -447,6 +447,9 @@ export function useExportTasks(_props?: UseExportTasksProps) {
           preferGroupMemberName: form.preferGroupMemberName ?? true,
           ...(form.outputDir?.trim() && { outputDir: form.outputDir.trim() }),
           ...(form.useNameInFileName && { useNameInFileName: true }),
+          ...(Array.isArray(form.skipDownloadResourceTypes) && form.skipDownloadResourceTypes.length > 0 && {
+            skipDownloadResourceTypes: form.skipDownloadResourceTypes,
+          }),
         },
       }
 

--- a/qce-v4-tool/hooks/use-scheduled-exports.ts
+++ b/qce-v4-tool/hooks/use-scheduled-exports.ts
@@ -103,6 +103,9 @@ export function useScheduledExports() {
                     filterPureImageMessages: formData.filterPureImageMessages ?? false,
                     prettyFormat: true,
                     preferGroupMemberName: formData.preferGroupMemberName ?? true,
+                    ...(Array.isArray(formData.skipDownloadResourceTypes) && formData.skipDownloadResourceTypes.length > 0 && {
+                        skipDownloadResourceTypes: formData.skipDownloadResourceTypes,
+                    }),
                 },
                 ...(formData.outputDir?.trim() && { outputDir: formData.outputDir.trim() }),
                 enabled: formData.enabled,

--- a/qce-v4-tool/types/api.ts
+++ b/qce-v4-tool/types/api.ts
@@ -190,6 +190,11 @@ export interface CreateTaskForm {
   useNameInFileName?: boolean
   /** 群聊导出时优先使用群成员名称（Issue #358） */
   preferGroupMemberName?: boolean
+  /**
+   * 仅保留元数据、跳过下载的资源类型（Issue #341）。
+   * 'image' | 'video' | 'audio' | 'file'
+   */
+  skipDownloadResourceTypes?: Array<'image' | 'video' | 'audio' | 'file'>
 }
 
 export interface CreateTaskRequest {
@@ -221,6 +226,8 @@ export interface CreateTaskRequest {
     useNameInFileName?: boolean
     /** 群聊导出时优先使用群成员名称（Issue #358） */
     preferGroupMemberName?: boolean
+    /** 仅保留元数据、跳过下载的资源类型（Issue #341） */
+    skipDownloadResourceTypes?: Array<'image' | 'video' | 'audio' | 'file'>
   }
 }
 
@@ -309,6 +316,8 @@ export interface ScheduledExport {
     filterPureImageMessages?: boolean
     prettyFormat?: boolean
     preferGroupMemberName?: boolean
+    /** Issue #341: 仅保留元数据、跳过下载的资源类型 */
+    skipDownloadResourceTypes?: Array<'image' | 'video' | 'audio' | 'file'>
   }
   outputDir?: string
   enabled: boolean
@@ -351,6 +360,8 @@ export interface CreateScheduledExportForm {
   includeSystemMessages?: boolean
   filterPureImageMessages?: boolean
   preferGroupMemberName?: boolean
+  /** Issue #341: 仅保留元数据、跳过下载的资源类型 */
+  skipDownloadResourceTypes?: Array<'image' | 'video' | 'audio' | 'file'>
 }
 
 export interface ScheduledExportsResponse {


### PR DESCRIPTION
## Summary

#341 提出的需求是：导出聊天记录时，能够只保留文件元数据（文件名、大小、MD5、来源等），跳过实际下载，避免大量文件占用磁盘和带宽。本 PR 为整条导出链路加上该开关。

### 实现要点

ResourceHandler 新增 `setSkipDownloadTypes(types: ResourceType[])`：
- 命中类型的资源仍会被解析、合并缓存命中、写入数据库；
- 不再加入下载队列，状态置为 `ResourceStatus.SKIPPED`；
- 下载进度计数也跳过这些条目，避免出现"卡在 99%"的情况；
- 传入 `null` / `[]` 即恢复默认行为。

ApiServer（普通导出 + 流式分块导出两条路径）接收新的请求字段：
- `options.skipDownloadResourceTypes: ('image' | 'video' | 'audio' | 'file')[]`
- 兼容字段 `options.skipFileDownload: boolean`，等价于 `['file']`

ScheduledExportManager 同样支持上述选项；执行前后会显式重置共享 `ResourceHandler` 的跳过集合，避免影响其它任务。

前端在 TaskWizard / ScheduledExportWizard / BatchExportDialog 三处导出向导中各加一个开关 **"仅保留文件元数据，不下载文件"**，与已有的 **"快速导出（跳过资源下载）"** 互斥可见，避免语义重叠。

### 测试

新增 `__tests__/unit/ResourceHandler.skipDownload.test.ts`：
- `setSkipDownloadTypes(['file'])` 命中文件资源时，状态为 `SKIPPED`，`FileApi.downloadMedia` 不被调用；
- `setSkipDownloadTypes([])` 恢复默认行为，资源不会被强制 `SKIPPED`。

`npm test` 全部通过（32/32）。