### PR TITLE
fix(parser): preserve group sender display name across messages with empty fields (#274)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/SimpleMessageParser.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/SimpleMessageParser.test.ts
@@ -80,6 +80,55 @@ test('group chat with preferGroupMemberName=false falls back to nickname', async
     assert.equal(parsed.sender.name, 'Alice');
 });
 
+test('group chat falls back to cached sender name when later message lacks all name fields (#274)', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const named = msg({ chatType: 2 })
+        .sender({ uid: 'u_bob', uin: '22222', nick: 'Bob', card: 'Bob (PM)' })
+        .text('hello')
+        .at_time(T + 0)
+        .build();
+    const stripped = msg({
+        chatType: 2,
+        senderUid: 'u_bob',
+        senderUin: '22222',
+        sendNickName: '',
+        sendMemberName: '',
+        sendRemarkName: ''
+    })
+        .text('still me')
+        .at_time(T + 60)
+        .build();
+    const parsed = await parser.parseMessages([named, stripped]);
+    assert.equal(parsed[0].sender.name, 'Bob (PM)');
+    assert.equal(parsed[1].sender.name, 'Bob (PM)');
+    assert.equal(parsed[1].sender.groupCard, 'Bob (PM)');
+});
+
+test('group chat sender cache prefers earlier-seen group card over nickname-only later occurrence', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const withCard = msg({ chatType: 2 })
+        .sender({ uid: 'u_carol', uin: '33333', nick: 'Carol', card: 'Carol (Lead)' })
+        .text('first')
+        .at_time(T + 0)
+        .build();
+    const stripped = msg({
+        chatType: 2,
+        senderUid: 'u_carol',
+        senderUin: '33333',
+        sendNickName: '',
+        sendMemberName: '',
+        sendRemarkName: ''
+    })
+        .text('second')
+        .at_time(T + 120)
+        .build();
+    const [m1, m2] = await parser.parseMessages([withCard, stripped]);
+    assert.equal(m1.sender.name, 'Carol (Lead)');
+    assert.equal(m2.sender.name, 'Carol (Lead)');
+});
+
 test('parses @everyone and @user mentions', async () => {
     const { SimpleMessageParser } = await loadParser();
     const parser = new SimpleMessageParser({ html: 'none' });

--- a/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
@@ -251,7 +251,15 @@ export class SimpleMessageParser {
 
   // 全局消息映射，用于查找被引用的消息
   private messageMap: Map<string, RawMessage> = new Map();
-  
+
+  // 发件人显示信息缓存：senderUid / senderUin → { groupCard, remark, nickname }
+  // 用于在某条消息缺失全部昵称字段时，回退到同一发件人在其他消息上出现过的可读名字。
+  private senderInfoCache: Map<string, {
+    groupCard?: string;
+    remark?: string;
+    nickname?: string;
+  }> = new Map();
+
   // QQ表情映射表
   private faceMap: Map<string, string> = new Map();
 
@@ -271,14 +279,17 @@ export class SimpleMessageParser {
 
     // 先建立全局消息映射
     this.messageMap.clear();
+    this.senderInfoCache.clear();
     for (const msg of messages) {
       if (msg && msg.msgId) {
         this.messageMap.set(msg.msgId, msg);
+        this.cacheSenderInfo(msg);
         // 同时将 records 数组中的消息也添加到映射中
         if (msg.records && msg.records.length > 0) {
           for (const record of msg.records) {
             if (record && record.msgId) {
               this.messageMap.set(record.msgId, record);
+              this.cacheSenderInfo(record);
             }
           }
         }
@@ -309,8 +320,60 @@ export class SimpleMessageParser {
     
     // 清理映射
     this.messageMap.clear();
-    
+    this.senderInfoCache.clear();
+
     return results;
+  }
+
+  /**
+   * 把消息上的群名片 / 备注 / 昵称写入按 senderUid 与 senderUin 索引的缓存。
+   *
+   * 同一群成员的不同消息中，往往只有一部分会携带 sendMemberName / sendNickName，
+   * 单条消息都可能因为底层数据漏字段而显示为 QQ 号。这里在解析前先把所有出现过的
+   * 名字按发件人聚合，后续 getSenderDisplayInfo 在本地字段全空时会回退到这里查表。
+   */
+  private cacheSenderInfo(message: RawMessage): void {
+    const groupCard = this.getTrimmedText(message.sendMemberName);
+    const remark = this.getTrimmedText(message.sendRemarkName);
+    const nickname = this.getTrimmedText(message.sendNickName);
+    if (!groupCard && !remark && !nickname) return;
+
+    const keys: string[] = [];
+    const uid = this.getTrimmedText(message.senderUid);
+    if (uid) keys.push(uid);
+    const uin = this.getTrimmedText(message.senderUin);
+    if (uin) keys.push(uin);
+
+    for (const key of keys) {
+      const existing = this.senderInfoCache.get(key) ?? {};
+      this.senderInfoCache.set(key, {
+        groupCard: existing.groupCard ?? groupCard,
+        remark: existing.remark ?? remark,
+        nickname: existing.nickname ?? nickname
+      });
+    }
+  }
+
+  /**
+   * 在按 senderUid → senderUin 顺序查表，命中即返回。供 getSenderDisplayInfo 在
+   * 本条消息字段全空时使用，避免出现把 QQ 号当昵称的情况（参见 #274）。
+   */
+  private lookupCachedSenderInfo(message: RawMessage): {
+    groupCard?: string;
+    remark?: string;
+    nickname?: string;
+  } | undefined {
+    const uid = this.getTrimmedText(message.senderUid);
+    if (uid) {
+      const hit = this.senderInfoCache.get(uid);
+      if (hit) return hit;
+    }
+    const uin = this.getTrimmedText(message.senderUin);
+    if (uin) {
+      const hit = this.senderInfoCache.get(uin);
+      if (hit) return hit;
+    }
+    return undefined;
   }
 
   /**
@@ -1009,11 +1072,21 @@ export class SimpleMessageParser {
     groupCard: string | undefined;
     remark: string | undefined;
   } {
-    const groupCard = this.getTrimmedText(message.sendMemberName);
-    const remark = this.getTrimmedText(message.sendRemarkName);
-    const nickname = this.getTrimmedText(message.sendNickName);
+    let groupCard = this.getTrimmedText(message.sendMemberName);
+    let remark = this.getTrimmedText(message.sendRemarkName);
+    let nickname = this.getTrimmedText(message.sendNickName);
     const isGroupChat = message.chatType === 2;
     const preferGroupMemberName = isGroupChat && this.options.preferGroupMemberName !== false;
+
+    // #274：当本条消息没有任何可读名字时，回退到同发件人在其他消息上出现过的名字。
+    if (!groupCard && !remark && !nickname) {
+      const cached = this.lookupCachedSenderInfo(message);
+      if (cached) {
+        groupCard = cached.groupCard;
+        remark = cached.remark;
+        nickname = cached.nickname;
+      }
+    }
 
     const name = (
       isGroupChat


### PR DESCRIPTION
## Summary

#274 报告导出群消息时部分群友的昵称偶发性丢失，截图里看到的是被替换成了 QQ 号。

排查后定位到 `SimpleMessageParser.getSenderDisplayInfo`：当一条消息的 `sendMemberName`、`sendRemarkName`、`sendNickName` 同时为空时，原逻辑直接落到 `senderUin` 兜底，因此输出就是 QQ 号。

实际上同一群成员的其它消息几乎总会带上群名片或昵称，本 PR 利用这一点做了一层进程内缓存：

### 实现

- `SimpleMessageParser` 新增 `senderInfoCache: Map<senderUid|senderUin, { groupCard, remark, nickname }>`。
- `parseMessages` 在构建 `messageMap` 的同一轮里调用 `cacheSenderInfo(message)`，把所有非空名字按 `senderUid` 与 `senderUin` 双键写入缓存（含 `records[]` 内的合并转发子消息）。
- `getSenderDisplayInfo` 在本条消息的三个名字字段全为空时，调用 `lookupCachedSenderInfo` 回退到缓存条目。命中的字段套用原本的优先级（群聊：群名片 > 备注 > 昵称；私聊：备注 > 昵称），不命中再退回 `senderUin`，最后才是 `senderUid` 与 `未知用户`。
- 解析结束后与 `messageMap` 一起清空，避免实例复用造成跨任务污染。

行为上对带有名字字段的消息完全无变化，只在原本会输出 QQ 号的场景生效。

### 测试

新增两个 unit 用例（`__tests__/unit/SimpleMessageParser.test.ts`）：

- 群聊场景里第二条消息三个名字字段都为空，仍能基于缓存解析出 `Bob (PM)`。
- 缓存命中时仍优先使用群名片而不是昵称，与现有 `preferGroupMemberName` 优先级一致。

`npm test` 在本地 34/34 通过，含新增用例。

### 兼容性

- 仅影响 `SimpleMessageParser` 的单次 `parseMessages` 调用范围，不跨实例。
- 不影响导出格式（TXT/JSON/HTML/JSONL）的字段定义，只是输出值在原本是 QQ 号的情况下会变成可读名字。

关联 issue #274。