### PR TITLE
fix(parser): resolve reply sender name without falling back to u_xxx (#289)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/fixtures/builders.ts
+++ b/plugins/qq-chat-exporter/__tests__/fixtures/builders.ts
@@ -201,22 +201,31 @@ export class MessageBuilder {
     reply(opts: {
         sourceMsgId: string;
         senderUin?: string;
+        senderUid?: string;
+        senderUidStr?: string;
+        senderNick?: string;
+        senderMemberName?: string;
         senderName?: string;
         content?: string;
         msgSeq?: string;
         msgTime?: number;
     }): this {
+        const replyElement: Record<string, unknown> = {
+            sourceMsgIdInRecords: opts.sourceMsgId,
+            replayMsgId: opts.sourceMsgId,
+            senderUin: opts.senderUin ?? '11111',
+            senderUinStr: opts.senderUin ?? '11111',
+            replayMsgSeq: opts.msgSeq ?? '999',
+            replyMsgTime: String(opts.msgTime ?? 1704067100),
+            sourceMsgTextElems: [{ textElemContent: opts.content ?? '' }]
+        };
+        if (opts.senderUid !== undefined) replyElement.senderUid = opts.senderUid;
+        if (opts.senderUidStr !== undefined) replyElement.senderUidStr = opts.senderUidStr;
+        if (opts.senderNick !== undefined) replyElement.senderNick = opts.senderNick;
+        if (opts.senderMemberName !== undefined) replyElement.senderMemberName = opts.senderMemberName;
         this.elements.push({
             elementType: 7,
-            replyElement: {
-                sourceMsgIdInRecords: opts.sourceMsgId,
-                replayMsgId: opts.sourceMsgId,
-                senderUin: opts.senderUin ?? '11111',
-                senderUinStr: opts.senderUin ?? '11111',
-                replayMsgSeq: opts.msgSeq ?? '999',
-                replyMsgTime: String(opts.msgTime ?? 1704067100),
-                sourceMsgTextElems: [{ textElemContent: opts.content ?? '' }]
-            }
+            replyElement
         } as unknown as MessageElement);
         this.msg.msgType = 9;
         return this;

--- a/plugins/qq-chat-exporter/__tests__/unit/SimpleMessageParser.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/SimpleMessageParser.test.ts
@@ -223,6 +223,105 @@ test('reply element resolves referenced content via global map', async () => {
     assert.equal(replyEl!.data.senderName, 'Bob');
 });
 
+test('reply falls back to senderUin (QQ number) when referenced message is outside the batch (#289)', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const reply = msg({ chatType: 2 })
+        .sender({ uid: 'u_alice', uin: '11111', nick: 'Alice' })
+        .reply({
+            sourceMsgId: '7777777777777777777',
+            senderUin: '22222',
+            senderUid: 'u_bob',
+            senderUidStr: 'u_bob',
+            msgSeq: '999',
+            content: '原消息文本'
+        })
+        .text('回复一下')
+        .at_time(T + 60)
+        .build();
+    const [parsed] = await parser.parseMessages([reply]);
+    const replyEl = parsed.content.elements.find((e) => e.type === 'reply');
+    assert.ok(replyEl, 'expected a reply element');
+    assert.equal(replyEl!.data.senderName, '22222');
+    assert.notEqual(replyEl!.data.senderName, 'u_bob');
+});
+
+test('reply uses replyElement.senderMemberName before senderNick in group chats (#289)', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const reply = msg({ chatType: 2 })
+        .sender({ uid: 'u_alice', uin: '11111', nick: 'Alice' })
+        .reply({
+            sourceMsgId: '7777777777777777777',
+            senderUin: '22222',
+            senderUid: 'u_bob',
+            senderUidStr: 'u_bob',
+            senderNick: 'Bob',
+            senderMemberName: 'Bob (PM)',
+            content: '原消息文本'
+        })
+        .text('收到')
+        .at_time(T + 60)
+        .build();
+    const [parsed] = await parser.parseMessages([reply]);
+    const replyEl = parsed.content.elements.find((e) => e.type === 'reply');
+    assert.ok(replyEl);
+    assert.equal(replyEl!.data.senderName, 'Bob (PM)');
+});
+
+test('reply borrows cached sender name from sibling messages when reply element is bare (#289)', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const sibling = msg({ chatType: 2 })
+        .sender({ uid: 'u_bob', uin: '22222', nick: 'Bob', card: 'Bob (PM)' })
+        .text('上一条 Bob 自己发的')
+        .at_time(T + 0)
+        .build();
+    const reply = msg({ chatType: 2 })
+        .sender({ uid: 'u_alice', uin: '11111', nick: 'Alice' })
+        .reply({
+            sourceMsgId: '7777777777777777777',
+            senderUin: '22222',
+            senderUid: 'u_bob',
+            senderUidStr: 'u_bob',
+            content: '原消息文本'
+        })
+        .text('谢谢')
+        .at_time(T + 60)
+        .build();
+    const parsed = await parser.parseMessages([sibling, reply]);
+    const replyEl = parsed[1].content.elements.find((e) => e.type === 'reply');
+    assert.ok(replyEl);
+    assert.equal(replyEl!.data.senderName, 'Bob (PM)');
+});
+
+test('reply uses group card from referenced message even when replyElement carries only nickname (#289)', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const original = msg({ chatType: 2 })
+        .sender({ uid: 'u_bob', uin: '22222', nick: 'Bob', card: 'Bob (PM)' })
+        .text('the question')
+        .at_time(T + 0)
+        .build();
+    const reply = msg({ chatType: 2 })
+        .sender({ uid: 'u_alice', uin: '11111', nick: 'Alice', card: 'Alice (Lead)' })
+        .reply({
+            sourceMsgId: original.msgId,
+            senderUin: '22222',
+            senderUid: 'u_bob',
+            senderNick: 'Bob',
+            msgSeq: original.msgSeq,
+            msgTime: Number(original.msgTime)
+        })
+        .text('the answer')
+        .at_time(T + 60)
+        .build();
+    const parsed = await parser.parseMessages([original, reply]);
+    const replyEl = parsed[1].content.elements.find((e) => e.type === 'reply');
+    assert.ok(replyEl);
+    assert.equal(replyEl!.data.senderName, 'Bob (PM)');
+});
+
 test('forward element preserves resId and surfaces records via map', async () => {
     const { SimpleMessageParser } = await loadParser();
     const parser = new SimpleMessageParser({ html: 'none' });

--- a/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
@@ -1374,11 +1374,19 @@ export class SimpleMessageParser {
       }
     }
 
+    // #289：被引用消息发件人显示名解析。
+    // 历史上这里在很多分支会落到 senderUidStr (`u_xxxxxxxx` 形式) 或 senderUin（QQ 号）。
+    // 现在统一走 resolveReplySenderName：
+    //   - 找得到原消息：套用 getSenderDisplayInfo 的群名片 / 备注 / 昵称优先级；
+    //   - 找不到原消息：先用 replyElement 自带的字段，再回退到本批消息里同一发件人
+    //     已被 cacheSenderInfo 收录的可读名字；
+    //   - 全部失败时优先用 senderUin（QQ 号）而不是 senderUidStr（u_xxx）。
+    const senderName = this.resolveReplySenderName(replyElement, message, referencedMessage);
     const result = {
       messageId: sourceMsgId || replyElement.replayMsgId || replyElement.replayMsgSeq || '0',
       referencedMessageId: referencedMessageId || undefined,  // 确保不会是 "0"
-      senderUin: replyElement.senderUin || '',
-      senderName: replyElement.senderUidStr || '',
+      senderUin: replyElement.senderUin || (referencedMessage?.senderUin ?? ''),
+      senderName,
       content: '原消息',
       timestamp: 0
     };
@@ -1387,8 +1395,7 @@ export class SimpleMessageParser {
     if (referencedMessage) {
       // 保持messageId为sourceMsgId，referencedMessageId已经在前面设置
       result.senderUin = referencedMessage.senderUin;
-      result.senderName = referencedMessage.sendNickName || referencedMessage.senderUin;
-      
+
       // 提取被引用消息的文本内容
       if (referencedMessage.elements && referencedMessage.elements.length > 0) {
         const parts = [];
@@ -1439,10 +1446,58 @@ export class SimpleMessageParser {
       }
     }
 
-    if (replyElement.senderNick) result.senderName = replyElement.senderNick;
     if (replyElement.replayMsgTime) result.timestamp = replyElement.replayMsgTime;
 
     return result;
+  }
+
+  /**
+   * 把被引用消息（reply）发件人解析成一个尽量可读的名字。
+   *
+   * 解析顺序：
+   *  1. 命中 messageMap / records 的原消息：复用 getSenderDisplayInfo（群名片 > 备注 > 昵称）。
+   *  2. 否则用 replyElement 自带的 senderMemberName / senderNick 字段。
+   *  3. 否则按 senderUid / senderUin 查 senderInfoCache，取本批消息里同发件人的可读名字。
+   *  4. 最后退回 senderUin（QQ 号），再退回 senderUidStr（`u_xxx` 形式）。
+   *
+   * 历史代码会先把 senderName 设为 `replyElement.senderUidStr`，再有条件覆盖；当原消息
+   * 不在导出范围内、且 replyElement 也没有 senderNick 字段时就直接显示 `u_xxx`，
+   * 即 #289 报告的情况。
+   */
+  private resolveReplySenderName(
+    replyElement: any,
+    message: RawMessage,
+    referencedMessage: RawMessage | undefined
+  ): string {
+    if (referencedMessage) {
+      const display = this.getSenderDisplayInfo(referencedMessage);
+      if (display.name && display.name !== '未知用户') return display.name;
+    }
+
+    const senderMemberName = this.getTrimmedText(replyElement.senderMemberName);
+    const senderNick = this.getTrimmedText(replyElement.senderNick);
+    const isGroupChat = message.chatType === 2;
+    const preferGroupMemberName = isGroupChat && this.options.preferGroupMemberName !== false;
+    if (preferGroupMemberName && senderMemberName) return senderMemberName;
+    if (senderNick) return senderNick;
+    if (senderMemberName) return senderMemberName;
+
+    const cached = this.lookupCachedSenderInfo({
+      senderUid: replyElement.senderUid,
+      senderUin: replyElement.senderUin
+    } as RawMessage);
+    if (cached) {
+      const fromCache = preferGroupMemberName
+        ? (cached.groupCard || cached.remark || cached.nickname)
+        : (cached.remark || cached.nickname || cached.groupCard);
+      if (fromCache) return fromCache;
+    }
+
+    const senderUin = this.getTrimmedText(replyElement.senderUin);
+    if (senderUin) return senderUin;
+    const senderUidStr = this.getTrimmedText(replyElement.senderUidStr);
+    if (senderUidStr) return senderUidStr;
+    return '';
   }
 
   private generateMarketFaceUrl(emojiId: string): string {


### PR DESCRIPTION
## Summary

#289 截图里被引用消息的发件人显示成了 `u_xxxxxxxxxxxxxxxx`（NTQQ 不透明 uid），而不是群名片或昵称。

排查 `SimpleMessageParser.extractReplyContent` 后定位到三个问题：

1. `result.senderName` 初始值是 `replyElement.senderUidStr || ''`，也就是 `u_xxx` 形式。
2. 找到 `referencedMessage` 时只取 `sendNickName || senderUin`，群名片 / 备注被忽略。
3. 第 1442 行无条件用 `replyElement.senderNick` 覆盖前面解析出来的名字，结果即使 `referencedMessage` 上有群名片，最终输出仍然是裸昵称。

生产里两条路径都会触发：
- 被引消息在导出批次之外、且 `replyElement.senderNick` 为空 → 直接显示 `u_xxx`。
- 被引消息存在 → 群名片被覆盖回昵称。

### 实现

抽出 `resolveReplySenderName(replyElement, message, referencedMessage)`，按以下顺序解析：

1. `referencedMessage` 找得到：复用现有的 `getSenderDisplayInfo`，套用群聊群名片 > 备注 > 昵称、私聊备注 > 昵称的优先级（与正文消息一致）。
2. `replyElement.senderMemberName` / `senderNick`：群聊优先群名片，私聊或群名片为空时退到昵称。
3. `senderInfoCache`：使用 #274 已落地的发件人显示名缓存，按 `senderUid` / `senderUin` 查同一发件人在本批其他消息上出现过的可读名字。
4. 最后才是 `senderUin`（QQ 号），再最后是 `senderUidStr`（`u_xxx`）。

附带一处历史 bug 修复：删除原来无条件覆盖 `senderName` 的 `if (replyElement.senderNick) result.senderName = replyElement.senderNick;`。

### 测试

`__tests__/unit/SimpleMessageParser.test.ts` 新增四个用例覆盖四类失败场景：

- 被引消息不在批次内、`replyElement` 没有任何名字字段 → senderName 解析为 QQ 号 `22222`，明确断言不等于 `u_bob`。
- `replyElement.senderMemberName` 与 `senderNick` 同时存在的群聊场景 → 优先取群名片 `Bob (PM)`。
- `replyElement` 上只有 `senderUid` / `senderUin`，但同批次有 Bob 自己发的另一条带群名片的消息 → 缓存命中，senderName = `Bob (PM)`。
- 被引消息存在且有群名片，`replyElement` 只有昵称 → 取被引消息的群名片，不被昵称覆盖。

`reply()` fixture builder 同步加了 `senderUid` / `senderUidStr` / `senderNick` / `senderMemberName` 几个 opt-in 字段，不影响既有用例。

`npm test` 本地 38/38 通过。

### 兼容性

- 仅修改 `SimpleMessageParser` 内部解析逻辑，不改动导出格式或 `CleanMessage` 的字段定义。
- 已有携带完整 `senderNick` / `senderMemberName` 的回复消息行为不变。
- 群聊里被引消息有群名片时，输出由「裸昵称」升级为「群名片」，与正文消息显示一致。

关联 issue #289。