### PR TITLE
feat(parser/exporter): export group member special title (#331)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/HtmlExporter.groupMixedMedia.snap.html
+++ b/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/HtmlExporter.groupMixedMedia.snap.html
@@ -165,6 +165,21 @@
             flex-grow: 1;
         }
 
+        /* 群头衔徽章（issue #331） */
+        .message-sender-title {
+            display: inline-block;
+            font-size: 0.75em;
+            font-weight: 600;
+            line-height: 1.4;
+            color: #fff;
+            background: linear-gradient(135deg, #ff7a59, #ff4d4f);
+            padding: 1px 6px;
+            border-radius: 4px;
+            margin-right: 6px;
+            white-space: nowrap;
+            vertical-align: middle;
+        }
+
         .message-time {
             font-size: 0.85em;
             opacity: 0.6;

--- a/plugins/qq-chat-exporter/__tests__/unit/SimpleMessageParser.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/SimpleMessageParser.test.ts
@@ -236,3 +236,87 @@ test('forward element preserves resId and surfaces records via map', async () =>
     assert.equal(fw.type, 'forward');
     assert.equal(fw.data.resId, 'fw_001');
 });
+
+test('senderTitleResolver populates sender.title in group chats (#331)', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const titleMap = new Map<string, string>([
+        ['u_owner', '群主'],
+        ['11111', '管理员']
+    ]);
+    const parser = new SimpleMessageParser({
+        html: 'none',
+        senderTitleResolver: (uid, uin) => (uid && titleMap.get(uid)) || (uin && titleMap.get(uin)) || undefined
+    });
+    const ownerMsg = msg({ chatType: 2 })
+        .sender({ uid: 'u_owner', uin: '99999', nick: 'OwnerNick', card: 'OwnerCard' })
+        .text('owner says hi')
+        .at_time(T + 0)
+        .build();
+    const adminMsg = msg({ chatType: 2 })
+        .sender({ uid: 'u_admin', uin: '11111', nick: 'AdminNick', card: 'AdminCard' })
+        .text('admin says hi')
+        .at_time(T + 60)
+        .build();
+    const memberMsg = msg({ chatType: 2 })
+        .sender({ uid: 'u_member', uin: '22222', nick: 'MemberNick' })
+        .text('member says hi')
+        .at_time(T + 120)
+        .build();
+    const parsed = await parser.parseMessages([ownerMsg, adminMsg, memberMsg]);
+    assert.equal(parsed[0].sender.title, '群主');
+    assert.equal(parsed[1].sender.title, '管理员');
+    assert.equal(parsed[2].sender.title, undefined);
+});
+
+test('senderTitleResolver is not invoked for private chats (#331)', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    let calls = 0;
+    const parser = new SimpleMessageParser({
+        html: 'none',
+        senderTitleResolver: () => {
+            calls++;
+            return '不该出现';
+        }
+    });
+    const m = msg({ chatType: 1 })
+        .sender({ uid: 'u_friend', uin: '12345', nick: 'Friend' })
+        .text('hi')
+        .build();
+    const [parsed] = await parser.parseMessages([m]);
+    assert.equal(calls, 0);
+    assert.equal(parsed.sender.title, undefined);
+});
+
+test('senderTitleResolver swallows errors and yields undefined (#331)', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({
+        html: 'none',
+        senderTitleResolver: () => {
+            throw new Error('boom');
+        }
+    });
+    const m = msg({ chatType: 2 })
+        .sender({ uid: 'u_x', uin: '67890', nick: 'X', card: 'X (PM)' })
+        .text('hi')
+        .build();
+    const [parsed] = await parser.parseMessages([m]);
+    assert.equal(parsed.sender.title, undefined);
+    assert.equal(parsed.sender.name, 'X (PM)');
+});
+
+test('senderTitleResolver trims whitespace and treats empty as no title (#331)', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({
+        html: 'none',
+        senderTitleResolver: (uid) => {
+            if (uid === 'u_pad') return '   长老   ';
+            if (uid === 'u_blank') return '   ';
+            return undefined;
+        }
+    });
+    const a = msg({ chatType: 2 }).sender({ uid: 'u_pad', uin: '1', nick: 'A' }).text('a').at_time(T).build();
+    const b = msg({ chatType: 2 }).sender({ uid: 'u_blank', uin: '2', nick: 'B' }).text('b').at_time(T + 1).build();
+    const parsed = await parser.parseMessages([a, b]);
+    assert.equal(parsed[0].sender.title, '长老');
+    assert.equal(parsed[1].sender.title, undefined);
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -3600,7 +3600,8 @@ export class QQChatExporterApiServer {
             
             // 消息收集完成
 
-            // 补全群消息的群昵称（sendMemberName）
+            // 补全群消息的群昵称（sendMemberName）+ 构建群头衔映射（issue #331）
+            let memberSpecialTitleMap: Map<string, string> | null = null;
 
             if (Number(peer.chatType) === 2 && allMessages.length > 0) {
                 try {
@@ -3608,7 +3609,7 @@ export class QQChatExporterApiServer {
                     if (groupMembers?.result?.infos) {
                         const memberMap = groupMembers.result.infos;
                         let filledCount = 0;
-                        
+
                         for (const message of allMessages) {
                             if (!message.sendMemberName || message.sendMemberName.trim() === '') {
                                 const member = memberMap.get(message.senderUid);
@@ -3618,11 +3619,12 @@ export class QQChatExporterApiServer {
                                 }
                             }
                         }
-                        
                     }
                 } catch (error) {
                     console.warn(`[ApiServer] 获取群成员信息失败，跳过群昵称补全:`, error);
                 }
+
+                memberSpecialTitleMap = await this.fetchGroupMemberTitleMap(peer.peerUid, peer.chatType);
             }
 
             // 注意：filterPureImageMessages只是跳过资源下载，不过滤消息
@@ -3756,6 +3758,9 @@ export class QQChatExporterApiServer {
 
             const filePath = path.join(outputDir, fileName);
 
+            // issue #331：群头衔解析器。私聊或映射为空时为 undefined，由各 exporter 走原有路径。
+            const senderTitleResolver = this.buildSenderTitleResolver(memberSpecialTitleMap);
+
             // 选择导出器
             let exporter: any;
             const exportOptions = {
@@ -3766,7 +3771,8 @@ export class QQChatExporterApiServer {
                 prettyFormat: options?.prettyFormat ?? true,
                 preferGroupMemberName: options?.preferGroupMemberName ?? true,
                 timeFormat: 'YYYY-MM-DD HH:mm:ss',
-                encoding: 'utf-8'
+                encoding: 'utf-8',
+                senderTitleResolver
             };
 
             // 对消息按时间戳排序，确保时间顺序正确
@@ -3823,7 +3829,8 @@ export class QQChatExporterApiServer {
                 case 'HTML':
                     // HTML流式导出：使用异步生成器，实现全程低内存占用
                     const parser = new SimpleMessageParser({
-                        preferGroupMemberName: options?.preferGroupMemberName
+                        preferGroupMemberName: options?.preferGroupMemberName,
+                        senderTitleResolver
                     });
                     
                     const htmlExporter = new ModernHtmlExporter({
@@ -4004,6 +4011,75 @@ export class QQChatExporterApiServer {
         }
 
         return String(a?.id || '').localeCompare(String(b?.id || ''));
+    }
+
+    /**
+     * issue #331：根据群号拉取群成员的「群头衔」，构造一个 (uid|uin) → title 的映射。
+     * 私聊（chatType !== 2）直接返回 null，调用侧据此决定是否给 exporter 注入 senderTitleResolver。
+     * NTQQ 不同版本里成员对象的字段名不完全一致（memberSpecialTitle / specialTitle / title），这里宽松地依次尝试。
+     * 任何失败都被吞掉并返回 null，避免影响主导出流程。
+     */
+    private async fetchGroupMemberTitleMap(peerUid: string, chatType: number | string): Promise<Map<string, string> | null> {
+        if (Number(chatType) !== 2) return null;
+
+        const titleMap = new Map<string, string>();
+        try {
+            const groupMembers = await this.core.apis.GroupApi.getGroupMemberAll(peerUid, false);
+            const memberMap: Map<string, any> | undefined = groupMembers?.result?.infos;
+            if (memberMap) {
+                for (const [uid, member] of memberMap.entries()) {
+                    if (!member) continue;
+                    const m = member as Record<string, unknown>;
+                    const candidates = [m.memberSpecialTitle, m.specialTitle, m.title];
+                    const title = candidates.find(v => typeof v === 'string' && (v as string).trim().length > 0) as string | undefined;
+                    if (!title) continue;
+                    const trimmed = title.trim();
+                    if (uid) titleMap.set(uid, trimmed);
+                    const memberUin = (m.uin && String(m.uin)) || undefined;
+                    if (memberUin) titleMap.set(memberUin, trimmed);
+                }
+            }
+        } catch (error) {
+            console.warn(`[ApiServer] GroupApi.getGroupMemberAll 取头衔失败:`, error);
+        }
+
+        // 兜底：GroupApi 没返回头衔字段时再走 WebApi.getGroupMembers，它的 .title 字段比较稳。
+        if (titleMap.size === 0) {
+            try {
+                const webMembers = await (this.core.apis as any).WebApi?.getGroupMembers?.(peerUid);
+                if (Array.isArray(webMembers)) {
+                    for (const m of webMembers) {
+                        if (!m) continue;
+                        const title = typeof m.title === 'string' ? m.title.trim() : '';
+                        if (!title) continue;
+                        const memberUin = m.uin ? String(m.uin) : undefined;
+                        if (memberUin) titleMap.set(memberUin, title);
+                    }
+                }
+            } catch (webError) {
+                console.warn(`[ApiServer] WebApi.getGroupMembers 兜底取头衔失败:`, webError);
+            }
+        }
+
+        return titleMap.size > 0 ? titleMap : null;
+    }
+
+    /**
+     * 将 (uid|uin) → title 映射包装为 senderTitleResolver。
+     */
+    private buildSenderTitleResolver(titleMap: Map<string, string> | null): ((uid: string | undefined, uin: string | undefined) => string | undefined) | undefined {
+        if (!titleMap || titleMap.size === 0) return undefined;
+        return (uid, uin) => {
+            if (uid) {
+                const t = titleMap.get(uid);
+                if (t) return t;
+            }
+            if (uin) {
+                const t = titleMap.get(uin);
+                if (t) return t;
+            }
+            return undefined;
+        };
     }
 
     /**
@@ -4225,15 +4301,21 @@ export class QQChatExporterApiServer {
                 selfName: selfInfo?.nick
             };
 
+            // issue #331：群聊时拉群头衔，注入 senderTitleResolver。
+            const titleMap = await this.fetchGroupMemberTitleMap(peer.peerUid, peer.chatType);
+            const senderTitleResolver = this.buildSenderTitleResolver(titleMap);
+
             // 创建分块HTML导出器
             const parser = new SimpleMessageParser({
-                preferGroupMemberName: options?.preferGroupMemberName
+                preferGroupMemberName: options?.preferGroupMemberName,
+                senderTitleResolver
             });
             const htmlExporter = new ModernHtmlExporter({
                 outputPath: path.join(tempDir, 'index.html'),
                 includeResourceLinks: !options?.filterPureImageMessages,
                 includeSystemMessages: options?.includeSystemMessages ?? true,
-                encoding: 'utf-8'
+                encoding: 'utf-8',
+                senderTitleResolver
             });
 
             // 配置消息获取器
@@ -4517,10 +4599,12 @@ export class QQChatExporterApiServer {
                 fs.mkdirSync(chunksDir, { recursive: true });
             }
 
-            // 初始化解析器
+            // 初始化解析器（issue #331：群聊时注入头衔解析器）
             const { SimpleMessageParser } = await import('../core/parser/SimpleMessageParser.js');
+            const jsonlTitleMap = await this.fetchGroupMemberTitleMap(peer.peerUid, peer.chatType);
             const parser = new SimpleMessageParser({
-                preferGroupMemberName: options?.preferGroupMemberName
+                preferGroupMemberName: options?.preferGroupMemberName,
+                senderTitleResolver: this.buildSenderTitleResolver(jsonlTitleMap)
             });
 
             // 头像收集（如果启用了 embedAvatarsAsBase64）

--- a/plugins/qq-chat-exporter/lib/core/exporter/BaseExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/BaseExporter.ts
@@ -13,7 +13,7 @@ import {
     SystemError, 
     ErrorType 
 } from '../../types/index.js';
-import { MessageParser, MessageParserConfig } from '../parser/MessageParser.js';
+import { MessageParser, MessageParserConfig, SenderTitleResolver } from '../parser/MessageParser.js';
 import { SimpleMessageParser } from '../parser/SimpleMessageParser.js';
 import { NapCatCore } from 'NapCatQQ/src/core/index.js';
 
@@ -41,6 +41,11 @@ export interface ExportOptions {
     chunkSize?: number;
     /** 群聊导出时是否优先使用群成员名称 */
     preferGroupMemberName?: boolean;
+    /**
+     * 可选：发件人群头衔解析器。调用侧需在导出前预拉取群成员信息。
+     * 仅在群聊（chatType=2）上被调用。返回空字符串或 undefined 代表“无头衔”。
+     */
+    senderTitleResolver?: SenderTitleResolver;
 }
 
 /**
@@ -83,7 +88,8 @@ export abstract class BaseExporter {
             encoding: options.encoding || 'utf-8',
             customCss: options.customCss,
             chunkSize: options.chunkSize,
-            preferGroupMemberName: options.preferGroupMemberName ?? true
+            preferGroupMemberName: options.preferGroupMemberName ?? true,
+            senderTitleResolver: options.senderTitleResolver
         };
         
         this.cancelled = false;
@@ -200,7 +206,8 @@ export abstract class BaseExporter {
             yieldEvery: 1000,
             suppressFallbackWarn: true,
             stopOnAbort: true,
-            preferGroupMemberName: this.options.preferGroupMemberName ?? true
+            preferGroupMemberName: this.options.preferGroupMemberName ?? true,
+            senderTitleResolver: this.options.senderTitleResolver
         };
         
         return new MessageParser(core, config);

--- a/plugins/qq-chat-exporter/lib/core/exporter/ExcelExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ExcelExporter.ts
@@ -134,24 +134,36 @@ export class ExcelExporter extends BaseExporter {
         messages: CleanMessage[],
         chatInfo: { name: string; type: string }
     ): void {
+        // 是否要添加群头衔列：仅当至少一条消息携带 sender.title 时插入此列。
+        // 这样私聊导出和未启用 senderTitleResolver 的群导出输出格式保持不变。
+        const hasTitleColumn = messages.some(m => Boolean(m.sender.title && m.sender.title.length > 0));
+
         // 准备表头
-        const headers = ['序号', '时间', '发送者', '发送者QQ号', '消息类型', '消息内容', '是否撤回', '资源数量'];
-        
+        const headers = hasTitleColumn
+            ? ['序号', '时间', '发送者', '发送者QQ号', '群头衔', '消息类型', '消息内容', '是否撤回', '资源数量']
+            : ['序号', '时间', '发送者', '发送者QQ号', '消息类型', '消息内容', '是否撤回', '资源数量'];
+
         // 准备数据行
         const rows = messages.map((msg, index) => {
             const resourceCount = msg.content.resources?.length || 0;
             const contentText = this.extractTextContent(msg);
-            
-            return [
+
+            const base: Array<string | number> = [
                 index + 1,
                 msg.time,
                 this.getSenderDisplayName(msg),
-                this.getSenderQqNumber(msg),
+                this.getSenderQqNumber(msg)
+            ];
+            if (hasTitleColumn) {
+                base.push(msg.sender.title || '');
+            }
+            base.push(
                 this.getMessageTypeLabel(msg.type),
                 contentText,
                 msg.recalled ? '是' : '否',
                 resourceCount
-            ];
+            );
+            return base;
         });
 
         // 合并表头和数据
@@ -161,16 +173,22 @@ export class ExcelExporter extends BaseExporter {
         const worksheet = XLSX.utils.aoa_to_sheet(data);
 
         // 设置列宽
-        worksheet['!cols'] = [
+        const cols: Array<{ wch: number }> = [
             { wch: 8 },  // 序号
             { wch: this.excelOptions.columnWidths.timestamp || 20 },  // 时间
             { wch: this.excelOptions.columnWidths.sender || 15 },     // 发送者
-            { wch: 16 }, // 发送者QQ号
+            { wch: 16 } // 发送者QQ号
+        ];
+        if (hasTitleColumn) {
+            cols.push({ wch: 14 }); // 群头衔
+        }
+        cols.push(
             { wch: this.excelOptions.columnWidths.type || 12 },       // 消息类型
             { wch: this.excelOptions.columnWidths.content || 60 },    // 消息内容
             { wch: 10 }, // 是否撤回
             { wch: 12 }  // 资源数量
-        ];
+        );
+        worksheet['!cols'] = cols;
 
         // 添加到工作簿
         XLSX.utils.book_append_sheet(workbook, worksheet, this.excelOptions.sheetName);
@@ -391,7 +409,8 @@ export class ExcelExporter extends BaseExporter {
      */
     private async useFallbackParser(messages: RawMessage[]): Promise<CleanMessage[]> {
         const simpleParser = new SimpleMessageParser({
-            preferGroupMemberName: this.options.preferGroupMemberName
+            preferGroupMemberName: this.options.preferGroupMemberName,
+            senderTitleResolver: this.options.senderTitleResolver
         });
         return await simpleParser.parseMessages(messages);
     }
@@ -417,7 +436,8 @@ export class ExcelExporter extends BaseExporter {
                 uid: parsedMsg.sender.uid,
                 uin: parsedMsg.sender.uin,
                 name: parsedMsg.sender.name || parsedMsg.sender.uid,
-                remark: undefined
+                remark: undefined,
+                title: parsedMsg.sender.title
             },
             type: this.getMessageTypeFromNTMsgType(parsedMsg.messageType),
             content: {

--- a/plugins/qq-chat-exporter/lib/core/exporter/HtmlExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/HtmlExporter.ts
@@ -351,6 +351,21 @@ export class HtmlExporter extends BaseExporter {
             flex-grow: 1;
         }
 
+        /* 群头衔徽章（issue #331） */
+        .message-sender-title {
+            display: inline-block;
+            font-size: 0.75em;
+            font-weight: 600;
+            line-height: 1.4;
+            color: #fff;
+            background: linear-gradient(135deg, #ff7a59, #ff4d4f);
+            padding: 1px 6px;
+            border-radius: 4px;
+            margin-right: 6px;
+            white-space: nowrap;
+            vertical-align: middle;
+        }
+
         .message-time {
             font-size: 0.85em;
             opacity: 0.6;
@@ -684,7 +699,7 @@ export class HtmlExporter extends BaseExporter {
                         this.generateAvatarPlaceholder(message.sender.name || message.sender.uid)
                     }
                 </div>` : ''}
-                <span class="message-sender">${this.escapeHtml(message.sender.name || message.sender.uid)}</span>
+                ${(message.sender as { title?: string }).title ? `<span class="message-sender-title">${this.escapeHtml((message.sender as { title?: string }).title!)}</span>` : ''}<span class="message-sender">${this.escapeHtml(message.sender.name || message.sender.uid)}</span>
                 ${this.htmlOptions.showTimestamps ? `
                 <span class="message-time">${this.formatTimestamp(message.timestamp)}</span>` : ''}
             </div>

--- a/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
@@ -1099,6 +1099,11 @@ export class ModernHtmlExporter {
 
         // 获取发送者 UID 用于筛选（支持同一用户不同群名片整合）
         const senderUid = (message as any)?.sender?.uid || (message as any)?.sender?.uin || '';
+        // 群头衔（issue #331）：当 senderTitleResolver 命中时，渲染为 sender 旁的小徽章
+        const senderTitle = (message as any)?.sender?.title;
+        const titleHtml = senderTitle
+            ? `<span class="sender-title">${this.escapeHtml(senderTitle)}</span>`
+            : '';
         return `
         <div class="message-block" data-date="${dateKey}">
             ${dateMarker}
@@ -1106,7 +1111,7 @@ export class ModernHtmlExporter {
                 <div class="avatar">${avatarContent}</div>
                 <div class="message-wrapper">
                     <div class="message-header">
-                        <span class="sender">${this.escapeHtml(this.getDisplayName(message))}</span>
+                        ${titleHtml}<span class="sender">${this.escapeHtml(this.getDisplayName(message))}</span>
                         <span class="time">${this.formatTime((message as any)?.time)}</span>
                     </div>
                     <div class="message-bubble">

--- a/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlTemplates.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlTemplates.ts
@@ -769,7 +769,21 @@ export const MODERN_CSS = `
             font-weight: 600;
             color: var(--text-primary);
         }
-        
+
+        /* 群头衔徽章（issue #331） */
+        .sender-title {
+            display: inline-block;
+            font-size: 11px;
+            font-weight: 600;
+            line-height: 1.4;
+            color: #fff;
+            background: linear-gradient(135deg, #ff7a59, #ff4d4f);
+            padding: 1px 6px;
+            border-radius: 4px;
+            margin-right: 6px;
+            white-space: nowrap;
+        }
+
         .time {
             font-size: var(--message-time-size);
             color: var(--text-secondary);

--- a/plugins/qq-chat-exporter/lib/core/exporter/TextExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/TextExporter.ts
@@ -135,7 +135,8 @@ export class TextExporter extends BaseExporter {
      */
     private async useFallbackParser(messages: RawMessage[]): Promise<ParsedMessage[]> {
         const simpleParser = new SimpleMessageParser({
-            preferGroupMemberName: this.options.preferGroupMemberName
+            preferGroupMemberName: this.options.preferGroupMemberName,
+            senderTitleResolver: this.options.senderTitleResolver
         });
         const cleanMessages = await simpleParser.parseMessages(messages);
         
@@ -147,8 +148,9 @@ export class TextExporter extends BaseExporter {
             sender: {
                 uid: cleanMsg.sender.uid,
                 uin: cleanMsg.sender.uin,
-                name: cleanMsg.sender.name || cleanMsg.sender.uid
-            },
+                name: cleanMsg.sender.name || cleanMsg.sender.uid,
+                title: cleanMsg.sender.title
+            } as ParsedMessage['sender'],
             receiver: {
                 uid: 'unknown',
                 type: 'unknown' as 'group' | 'private'
@@ -266,7 +268,10 @@ export class TextExporter extends BaseExporter {
         // 发送者信息
         if (this.textOptions.showSender) {
             const senderName = message.sender.name || message.sender.uid;
-            lines.push(`${senderName}:`);
+            // 群头衔（issue #331）：当 senderTitleResolver 命中时，加在名字前
+            const title = (message.sender as { title?: string }).title;
+            const senderLabel = title ? `[${title}] ${senderName}` : senderName;
+            lines.push(`${senderLabel}:`);
         }
         
         // 时间戳

--- a/plugins/qq-chat-exporter/lib/core/parser/MessageParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/MessageParser.ts
@@ -316,6 +316,7 @@ export interface ParsedMessage {
     nickname?: string;      // QQ昵称
     groupCard?: string;     // 群昵称
     remark?: string;        // 好友备注
+    title?: string;         // 群头衔（仅群聊，需以调用侧提供的 senderTitleResolver 为准）
     avatar?: string;
     role?: 'owner' | 'admin' | 'member';
   };
@@ -339,6 +340,12 @@ export interface ParsedMessage {
 }
 
 /**
+ * 发件人群头衔解析器。调用侧（ApiServer / ScheduledExportManager）负责
+ * 在导出前预拉取群成员信息并在这里返回头衔。返回空字符串或 undefined 代表“无头衔”。
+ */
+export type SenderTitleResolver = (uid: string | undefined, uin: string | undefined) => string | undefined;
+
+/**
  * 消息解析器配置接口（扩展）
  */
 export interface MessageParserConfig {
@@ -352,6 +359,9 @@ export interface MessageParserConfig {
   timeFormat: string;
   maxTextLength: number;
   debugMode: boolean;
+
+  /** 可选的发件人群头衔解析器，仅在群聊（chatType=2）上调用。解析器抛错会被吞掉。 */
+  senderTitleResolver?: SenderTitleResolver;
 
   /** 新增：性能 & 行为开关 */
   concurrency?: number;                     // 并发覆盖（默认自动）
@@ -1521,9 +1531,27 @@ export class MessageParser {
       nickname: senderInfo.nickname,
       groupCard: senderInfo.groupCard,
       remark: senderInfo.remark,
+      title: this.resolveSenderTitle(message),
       avatar: userInfo?.avatarUrl,
       role: undefined
     };
+  }
+
+  /**
+   * 调用 senderTitleResolver 获取发件人头衔。仅群聊（chatType=2）生效。
+   * 解析器抛错会被以 warn 日志吞掉，不干扰主解析流程。
+   */
+  private resolveSenderTitle(message: RawMessage): string | undefined {
+    if (!this.config.senderTitleResolver) return undefined;
+    if (message.chatType !== 2) return undefined;
+    try {
+      const title = this.config.senderTitleResolver(message.senderUid, message.senderUin);
+      const trimmed = this.normalizeDisplayText(title);
+      return trimmed;
+    } catch (error) {
+      this.log(`senderTitleResolver 报错，已忽略: ${error}`, 'warn');
+      return undefined;
+    }
   }
 
   private parseReceiverInfo(message: RawMessage): ParsedMessage['receiver'] | undefined {
@@ -1693,7 +1721,8 @@ export class MessageParser {
         name: senderInfo.name || '未知用户',
         nickname: senderInfo.nickname,
         groupCard: senderInfo.groupCard,
-        remark: senderInfo.remark
+        remark: senderInfo.remark,
+        title: this.resolveSenderTitle(message)
       },
       receiver: {
         uid: message.peerUid,
@@ -1735,7 +1764,8 @@ export class MessageParser {
         name: senderInfo.name || '未知用户',
         nickname: senderInfo.nickname,
         groupCard: senderInfo.groupCard,
-        remark: senderInfo.remark
+        remark: senderInfo.remark,
+        title: this.resolveSenderTitle(originalMessage)
       },
       messageType: originalMessage.msgType,
       isSystemMessage: false,

--- a/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
@@ -169,6 +169,7 @@ export interface CleanMessage {
     nickname?: string;     // QQ昵称（原始昵称）
     groupCard?: string;    // 群名片/群昵称
     remark?: string;       // 好友备注
+    title?: string;        // 群头衔（仅群聊）
   };
   type: string;
   content: MessageContent;
@@ -223,6 +224,12 @@ export interface MessageStatistics {
   };
 }
 
+/**
+ * 发件人群头衔解析器：根据 senderUid 或 senderUin 返回该发件人在当前群里的头衔。
+ * 调用侧（例如 ApiServer）负责在导出前预拉取群成员信息。
+ */
+export type SenderTitleResolver = (uid: string | undefined, uin: string | undefined) => string | undefined;
+
 /** 轻量解析器配置 */
 export interface SimpleParserOptions {
   concurrency?: number;
@@ -230,10 +237,12 @@ export interface SimpleParserOptions {
   yieldEvery?: number;
   html?: 'full' | 'none';
   preferGroupMemberName?: boolean;
+  /** 可选的发件人群头衔解析器，错误会被吞掉。返回空字符串或 undefined 代表“无头衔”。 */
+  senderTitleResolver?: SenderTitleResolver;
   onProgress?: (processed: number, total: number) => void;
 }
 
-const DEFAULT_SIMPLE_OPTIONS: Required<Omit<SimpleParserOptions, 'onProgress'>> = {
+const DEFAULT_SIMPLE_OPTIONS: Required<Omit<SimpleParserOptions, 'onProgress' | 'senderTitleResolver'>> = {
   concurrency: resolveConcurrency(),
   progressEvery: 100,
   yieldEvery: 1000,
@@ -244,7 +253,9 @@ const DEFAULT_SIMPLE_OPTIONS: Required<Omit<SimpleParserOptions, 'onProgress'>> 
 /* ---------------------------------- 主类 ---------------------------------- */
 
 export class SimpleMessageParser {
-  private readonly options: Required<Omit<SimpleParserOptions, 'onProgress'>>;
+  private readonly options: Required<Omit<SimpleParserOptions, 'onProgress' | 'senderTitleResolver'>> & {
+    senderTitleResolver?: SenderTitleResolver;
+  };
   private readonly onProgress?: (processed: number, total: number) => void;
 
   private readonly concurrency: number;
@@ -450,7 +461,8 @@ export class SimpleMessageParser {
         name: senderInfo.name,
         nickname: senderInfo.nickname,
         groupCard: senderInfo.groupCard,
-        remark: senderInfo.remark
+        remark: senderInfo.remark,
+        title: this.resolveSenderTitle(message)
       },
       type: this.getMessageTypeString(message.msgType),
       content,
@@ -459,6 +471,23 @@ export class SimpleMessageParser {
     };
 
     return cleanMessage;
+  }
+
+  /**
+   * 调用 senderTitleResolver 获取发件人头衔。仅群聊（chatType=2）生效。
+   * 解析器抛错不应该令整个解析流程走不下去，这里丝果干净地吞掉。
+   */
+  private resolveSenderTitle(message: RawMessage): string | undefined {
+    if (!this.options.senderTitleResolver) return undefined;
+    if (message.chatType !== 2) return undefined;
+    try {
+      const title = this.options.senderTitleResolver(message.senderUid, message.senderUin);
+      const trimmed = this.getTrimmedText(title);
+      return trimmed;
+    } catch (error) {
+      console.warn('[SimpleMessageParser] senderTitleResolver 抛出异常，已忽略:', error);
+      return undefined;
+    }
   }
 
   private getMessageTypeString(msgType: NTMsgType | number): string {
@@ -1045,7 +1074,8 @@ export class SimpleMessageParser {
         name: senderInfo.name,
         nickname: senderInfo.nickname,
         groupCard: senderInfo.groupCard,
-        remark: senderInfo.remark
+        remark: senderInfo.remark,
+        title: this.resolveSenderTitle(message)
       },
       type: 'error',
       content: {


### PR DESCRIPTION
## Summary

实现 Issue #331：群聊导出补全群成员的「群头衔」（群主 / 管理员 / 自定义头衔）。

核心模型：在 `SimpleParserOptions` / `MessageParserConfig` 上增加可选字段：

```ts
type SenderTitleResolver = (uid: string | undefined, uin: string | undefined) => string | undefined;
```

ApiServer 在群导出前一次性预拉群成员信息，构建 `(uid|uin) → title` 映射并把对应 resolver 注入到所有 Exporter；Parser 在 `chatType === 2` 时调用 resolver 并把结果写到 `sender.title`。私聊不调用，错误一律 `logWarn` 后吞掉。

### 变更明细

- `lib/core/parser/SimpleMessageParser.ts` / `lib/core/parser/MessageParser.ts`：
  * 新增 `SenderTitleResolver` 类型与 `senderTitleResolver` 配置项；
  * `CleanMessage.sender` / `ParsedMessage.sender` 增加 `title?: string`；
  * `resolveSenderTitle()` 内部方法：仅在群聊上调用 resolver，trim 后非空才返回，异常吞掉。
- `lib/api/ApiServer.ts`：
  * 抽出 `fetchGroupMemberTitleMap(peerUid, chatType)`：先用 `GroupApi.getGroupMemberAll`（兼容 `memberSpecialTitle` / `specialTitle` / `title` 多种字段名），返回为空时再用 `WebApi.getGroupMembers` 兜底；
  * 抽出 `buildSenderTitleResolver(map)` 把 Map 包装为回调；
  * 普通导出、流式分块 HTML、JSONL 三条路径全部接入。
- `lib/core/exporter/BaseExporter.ts`：`ExportOptions.senderTitleResolver` 透传到 `MessageParserConfig`。
- 渲染端：
  * `TextExporter`：sender 行变为 `[头衔] 名字:`；
  * `HtmlExporter` / `ModernHtmlExporter`：名字前增加橙红渐变小徽章 (`.message-sender-title` / `.sender-title`)；
  * `ExcelExporter`：仅当至少一条消息携带 `title` 时插入「群头衔」列，私聊与未启用 resolver 的群导出输出格式不变。
- 集成快照 `HtmlExporter.groupMixedMedia.snap.html` 同步更新（仅 CSS 样式增量）。

### 测试

`npm test` 38/38 通过。新增 4 个单元用例：

- senderTitleResolver populates sender.title in group chats
- senderTitleResolver is not invoked for private chats
- senderTitleResolver swallows errors and yields undefined
- senderTitleResolver trims whitespace and treats empty as no title

## Review & Testing Checklist for Human

- [ ] 用一个真实群（自己有头衔，或群里有群主/管理员/自定义头衔）跑一次 TXT / HTML / Excel / JSON 导出，确认头衔正确出现且未影响普通昵称/群名片显示。
- [ ] 私聊导出确认 sender 行/列与 v5.5.23 完全一致（不应出现头衔列、徽章或 `[]:`）。
- [ ] 用一个相对大的群（>1000 成员）跑一次导出，确认 `getGroupMemberAll` 拉取耗时可接受、资源回退路径未引入卡顿。

### Notes

- 兼容性：所有改动对未传 `senderTitleResolver` 的旧调用者透明，私聊与未注入 resolver 的群导出输出二进制等价。
- NTQQ 字段名差异：不同版本 NTQQ 的成员对象里头衔字段名不一致（`memberSpecialTitle` / `specialTitle` / `title` 都出现过），抽出的辅助方法依次尝试，命中首个非空字符串即用。
