### PR TITLE
fix(json): copy downloaded resources and write resource paths into JSON / JSONL exports (#277)

### DIFF
--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -3772,7 +3772,10 @@ export class QQChatExporterApiServer {
                 preferGroupMemberName: options?.preferGroupMemberName ?? true,
                 timeFormat: 'YYYY-MM-DD HH:mm:ss',
                 encoding: 'utf-8',
-                senderTitleResolver
+                senderTitleResolver,
+                // issue #277：把已下载资源的映射传给 JSON / JSONL / TXT / Excel 导出器，
+                // 让它们既能写入正确的资源相对路径，也能把资源文件复制到 <outputDir>/resources/。
+                resourceMap
             };
 
             // 对消息按时间戳排序，确保时间顺序正确

--- a/plugins/qq-chat-exporter/lib/core/exporter/BaseExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/BaseExporter.ts
@@ -46,6 +46,14 @@ export interface ExportOptions {
      * 仅在群聊（chatType=2）上被调用。返回空字符串或 undefined 代表“无头衔”。
      */
     senderTitleResolver?: SenderTitleResolver;
+    /**
+     * issue #277：消息资源映射 (msgId → resources[])，由 ApiServer 在导出前
+     * 通过 ResourceHandler.processMessageResources 预先下载资源后构造。
+     * JSON / JSONL / Excel / TXT 等导出器据此把每条消息引用的资源路径写到
+     * 输出里，并在导出完成后把资源文件复制到 `<outputDir>/resources/<type>/`。
+     * 不传或传空 Map 时回退到原有行为（不写资源路径，不拷贝资源）。
+     */
+    resourceMap?: Map<string, any[]>;
 }
 
 /**
@@ -89,7 +97,8 @@ export abstract class BaseExporter {
             customCss: options.customCss,
             chunkSize: options.chunkSize,
             preferGroupMemberName: options.preferGroupMemberName ?? true,
-            senderTitleResolver: options.senderTitleResolver
+            senderTitleResolver: options.senderTitleResolver,
+            resourceMap: options.resourceMap
         };
         
         this.cancelled = false;
@@ -180,6 +189,75 @@ export abstract class BaseExporter {
         if (!fs.existsSync(dir)) {
             fs.mkdirSync(dir, { recursive: true });
         }
+    }
+
+    /**
+     * issue #277：把 resourceMap 中已下载的资源文件复制到导出目录的
+     * `resources/<typeDir>/<fileName>` 下，与 HTML 导出器保持目录布局一致，
+     * 这样 JSON / JSONL / TXT / Excel 输出引用的相对路径都能落地到真实文件。
+     *
+     * - 重复文件按目标路径存在性跳过；
+     * - 单个资源拷贝失败仅 logWarn，不中断导出；
+     * - resourceMap 为空 / 未配置时直接 no-op。
+     */
+    protected async copyResourcesAlongsideExport(outputDir: string): Promise<number> {
+        const map = this.options.resourceMap;
+        if (!map || map.size === 0) return 0;
+
+        const stream = await import('stream/promises');
+        const typeOf = (t: string) => {
+            switch (t) {
+                case 'image': return 'images';
+                case 'video': return 'videos';
+                case 'audio': return 'audios';
+                case 'file':  return 'files';
+                default:      return 'files';
+            }
+        };
+
+        let copied = 0;
+        const seen = new Set<string>();
+        for (const resources of map.values()) {
+            if (!Array.isArray(resources)) continue;
+            for (const r of resources) {
+                if (!r || typeof r !== 'object') continue;
+                const localPath: string | undefined = r.localPath;
+                if (!localPath || typeof localPath !== 'string' || localPath.trim() === '') continue;
+                if (!fs.existsSync(localPath)) continue;
+                try {
+                    const stat = fs.statSync(localPath);
+                    if (!stat.isFile()) continue;
+                } catch {
+                    continue;
+                }
+
+                const fileName = path.basename(localPath);
+                const typeDir = typeOf(String(r.type || 'file'));
+                const targetDir = path.join(outputDir, 'resources', typeDir);
+                const targetPath = path.join(targetDir, fileName);
+                if (seen.has(targetPath)) continue;
+                seen.add(targetPath);
+
+                if (fs.existsSync(targetPath)) {
+                    copied++;
+                    continue;
+                }
+                try {
+                    fs.mkdirSync(targetDir, { recursive: true });
+                    await stream.pipeline(
+                        fs.createReadStream(localPath),
+                        fs.createWriteStream(targetPath)
+                    );
+                    copied++;
+                } catch (err) {
+                    console.warn(`[${this.format}Exporter] 拷贝资源失败 ${localPath} → ${targetPath}:`, err);
+                }
+            }
+        }
+        if (copied > 0) {
+            console.log(`[${this.format}Exporter] 已复制 ${copied} 个资源文件到 ${path.join(outputDir, 'resources')}`);
+        }
+        return copied;
     }
 
     /**

--- a/plugins/qq-chat-exporter/lib/core/exporter/JsonExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/JsonExporter.ts
@@ -331,6 +331,15 @@ export class JsonExporter extends BaseExporter {
                 avatarMap = await this.preDownloadAvatars(filteredMessages);
             }
 
+            // issue #277：如果 ApiServer 传入了 resourceMap（已下载的资源），
+            // 用一个临时的 SimpleMessageParser 实例复用它的资源路径覆写逻辑，
+            // 避免 JSON 输出里 content.resources[].localPath 为空、
+            // content.elements[].data.url 仍指向远程 url 的问题。
+            const resourceMap = this.options.resourceMap;
+            const resourcePathHelper = (resourceMap && resourceMap.size > 0)
+                ? new SimpleMessageParser({ html: 'none' })
+                : null;
+
             // 使用正确的 parseMessagesStream API（带 onBatch 回调）
             const batchSize = 20000;
 
@@ -357,6 +366,14 @@ export class JsonExporter extends BaseExporter {
 
                         // 转换为 CleanMessage 格式以保持字段一致性 (Issue #218)
                         const cleanMsg = this.convertParsedToClean(pm);
+
+                        // issue #277：把已下载资源的相对路径写到 cleanMsg
+                        if (resourcePathHelper && resourceMap) {
+                            const resources = resourceMap.get(cleanMsg.id);
+                            if (resources && resources.length > 0) {
+                                resourcePathHelper.updateSingleMessageResourcePaths(cleanMsg, resources);
+                            }
+                        }
 
                         // 写NDJSON：一条消息一行
                         await ndWrite(JSON.stringify(cleanMsg) + '\n');
@@ -455,6 +472,14 @@ export class JsonExporter extends BaseExporter {
                     fs.unlinkSync(tmpFile);
                 } catch {}
                 tmpFile = null;
+            }
+
+            // issue #277：把已下载的资源文件复制到 <outputDir>/resources/<typeDir>/，
+            // 与 JSON 里写入的相对路径对齐，让 Chatlab 等下游工具能加载到媒体。
+            try {
+                await this.copyResourcesAlongsideExport(path.dirname(this.options.outputPath));
+            } catch (copyErr) {
+                console.warn(`[JsonExporter] 拷贝资源到导出目录失败:`, copyErr);
             }
 
             console.log(`[JsonExporter] ========== 流式导出完成 ==========`); 
@@ -565,6 +590,12 @@ export class JsonExporter extends BaseExporter {
 
             let processed = 0;
 
+            // issue #277：chunked-jsonl 的资源路径覆写器（与单文件分支同源）
+            const resourceMap = this.options.resourceMap;
+            const resourcePathHelper = (resourceMap && resourceMap.size > 0)
+                ? new SimpleMessageParser({ html: 'none' })
+                : null;
+
             await parser.parseMessagesStream(filteredMessages, {
                 batchSize: chunkedOptions.parseBatchSize,
                 onBatch: async (batch: any[], batchIndex: number, batchCount: number) => {
@@ -584,6 +615,15 @@ export class JsonExporter extends BaseExporter {
 
                         // 转换为 CleanMessage 格式以保持字段一致性 (Issue #218)
                         const cleanMsg = this.convertParsedToClean(pm);
+
+                        // issue #277：把已下载资源的相对路径写到 cleanMsg
+                        if (resourcePathHelper && resourceMap) {
+                            const resources = resourceMap.get(cleanMsg.id);
+                            if (resources && resources.length > 0) {
+                                resourcePathHelper.updateSingleMessageResourcePaths(cleanMsg, resources);
+                            }
+                        }
+
                         const tsMs = cleanMsg.timestamp;
                         const line = JSON.stringify(cleanMsg);
 
@@ -657,6 +697,14 @@ export class JsonExporter extends BaseExporter {
                 try {
                     totalSize += fs.statSync(path.join(outputDir, avatarsRef.file)).size;
                 } catch {}
+            }
+
+            // issue #277：把已下载资源拷贝到 chunked-jsonl 输出目录的
+            // resources/<typeDir>/，让 manifest+chunks 的相对路径可定位
+            try {
+                await this.copyResourcesAlongsideExport(outputDir);
+            } catch (copyErr) {
+                console.warn(`[JsonExporter] [chunked-jsonl] 拷贝资源到导出目录失败:`, copyErr);
             }
 
             console.log(`[JsonExporter] ========== chunked-jsonl 导出完成 ==========`); 

--- a/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
@@ -1260,9 +1260,10 @@ export class SimpleMessageParser {
   }
 
   /**
-   * 更新单条消息的资源路径（私有方法，供批量和流式使用）
+   * 更新单条消息的资源路径（供批量、流式以及 JSON / TXT / Excel 等
+   * 非 HTML 导出器逐条调用）。issue #277。
    */
-  private updateSingleMessageResourcePaths(message: CleanMessage, resources: any[]): void {
+  public updateSingleMessageResourcePaths(message: CleanMessage, resources: any[]): void {
     console.log(`[SimpleMessageParser] 更新消息 ${message.id} 的资源路径，资源数量: ${resources.length}`);
     
     // 更新 message.content.resources


### PR DESCRIPTION
## Summary

Fix issue #277: JSON / JSONL exports do not include media files, and `content.resources[].localPath` / `content.elements[].data.url` are left empty even though the resources have already been downloaded by `ResourceHandler`.

Root cause: `JsonExporter`（`exportSingleJsonStreaming` 与 `exportChunkedJsonl` 两条路径）只把 `ParsedMessage` 转成 `CleanMessage` 然后写 JSON，从未消费 `ResourceHandler.processMessageResources` 产出的 `resourceMap`，因此 JSON 里写出的 `resources/<typeDir>/<file>` 相对路径并没有真实文件。HTML 导出同时做了「写路径」和「拷贝文件」两步，所以工作正常。

Changes:
- `BaseExporter`：
  - `ExportOptions` 新增 `resourceMap?: Map<string, any[]>`，构造函数透传。
  - 新增 `copyResourcesAlongsideExport(outputDir)`：用 `stream/promises.pipeline` 把 `resourceMap` 里每条资源拷到 `<outputDir>/resources/<typeDir>/<fileName>`，目录命名与 HTML 导出器（`images` / `videos` / `audios` / `files`）保持一致；按目标路径去重，源不存在或不是常规文件时跳过，单个拷贝失败仅 warn 不中断导出。
- `SimpleMessageParser.updateSingleMessageResourcePaths` 由 `private` 升为 `public`，让非 HTML 的导出器复用同一份单条消息资源路径覆写逻辑。
- `JsonExporter`：
  - 两条导出路径在 `options.resourceMap` 非空时新建一个 `SimpleMessageParser({ html: 'none' })`，在 `onBatch` 里写盘前对每条 `cleanMsg` 调用 `updateSingleMessageResourcePaths`，把 `content.resources[].localPath/url` 与 `content.elements[].data.url` 修正到 `resources/<typeDir>/<file>`。
  - 导出收尾处分别调用 `copyResourcesAlongsideExport(outputDir)`，让 JSON / manifest 里写的相对路径都能落到实际文件。
- `ApiServer.exportMessages` 把已有的 `resourceMap` 透传到 `exportOptions`，所有导出器按需消费。

Backward compatible：`resourceMap` 未传或为空时直接跳过覆写与拷贝，输出与改动前保持一致。

## Review & Testing Checklist for Human

- [ ] 在含图片 / 视频 / 语音的群聊里跑一次 JSON 导出，确认 `<name>.json` 中 `content.resources[].localPath` 与 `url` 非空，并且 `<outputDir>/resources/images|videos|audios/...` 下有实际文件。
- [ ] 在同一群聊跑 JSONL（`chunked-jsonl`）导出，确认 `manifest.json`、`chunks/*.jsonl` 与同级 `resources/` 目录齐备且引用的相对路径一致。
- [ ] 把开关 `filterPureImageMessages` 设为 true 再次导出（此时不下载资源、`resourceMap` 为空），确认输出与旧版相同且不生成 `resources/` 目录。
- [ ] 把产物导入 Chatlab，确认图片 / 视频可以正常显示。

### Notes

- `TextExporter` 与 `ExcelExporter` 当前不引用资源文件，本 PR 暂不变更它们；后续若需要可直接复用同一接口。
- 拷贝走 `stream/promises.pipeline`，处理大附件时内存占用平稳。
- 本地 `npm test` 42/42 通过。