### PR TITLE
fix(sticker): normalize sticker extension by magic bytes (#313)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/StickerPackExtension.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/StickerPackExtension.test.ts
@@ -1,0 +1,124 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { StickerPackExporter } from '../../lib/core/sticker/StickerPackExporter.js';
+
+/**
+ * Issue #313 — QQ 收藏 / 商城表情包导出时按 magic bytes 校正扩展名。
+ *
+ * QQ 客户端把收藏表情统一以 `.jpg` 落到本地缓存，但里面可能是 GIF / PNG / WebP，
+ * 早期实现直接把 `.jpg` 当作输出扩展名，导致下游软件按 jpg 解码后显示「损坏」。
+ * 这里只测两个内部纯函数（不依赖 NapCat 运行时）：
+ *   - detectFileExtensionByMagic：按头 12 字节识别
+ *   - normalizeStickerExtension：识别成功且不一致时改名
+ */
+
+function tmpDir(prefix: string): { dir: string; cleanup: () => void } {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    return { dir, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
+}
+
+function newExporter(): any {
+    // 这里不需要 NapCatCore 的真实功能，只用 prototype 方法即可。
+    return Object.create(StickerPackExporter.prototype);
+}
+
+test('detectFileExtensionByMagic 把 GIF87a 识别为 .gif', () => {
+    const t = tmpDir('qce-sticker-ext-gif-');
+    try {
+        const file = path.join(t.dir, 'a.jpg');
+        fs.writeFileSync(file, Buffer.from([0x47, 0x49, 0x46, 0x38, 0x37, 0x61, 0x00, 0x00]));
+        const exp = newExporter();
+        assert.equal(exp.detectFileExtensionByMagic(file), '.gif');
+    } finally {
+        t.cleanup();
+    }
+});
+
+test('detectFileExtensionByMagic 把 PNG 识别为 .png', () => {
+    const t = tmpDir('qce-sticker-ext-png-');
+    try {
+        const file = path.join(t.dir, 'a.bin');
+        fs.writeFileSync(file, Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]));
+        const exp = newExporter();
+        assert.equal(exp.detectFileExtensionByMagic(file), '.png');
+    } finally {
+        t.cleanup();
+    }
+});
+
+test('detectFileExtensionByMagic 把 JPEG 识别为 .jpg', () => {
+    const t = tmpDir('qce-sticker-ext-jpg-');
+    try {
+        const file = path.join(t.dir, 'a.gif');
+        fs.writeFileSync(file, Buffer.from([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10]));
+        const exp = newExporter();
+        assert.equal(exp.detectFileExtensionByMagic(file), '.jpg');
+    } finally {
+        t.cleanup();
+    }
+});
+
+test('detectFileExtensionByMagic 把 RIFF/WEBP 识别为 .webp', () => {
+    const t = tmpDir('qce-sticker-ext-webp-');
+    try {
+        const file = path.join(t.dir, 'a.jpg');
+        fs.writeFileSync(file, Buffer.from([
+            0x52, 0x49, 0x46, 0x46, 0x10, 0x00, 0x00, 0x00,
+            0x57, 0x45, 0x42, 0x50
+        ]));
+        const exp = newExporter();
+        assert.equal(exp.detectFileExtensionByMagic(file), '.webp');
+    } finally {
+        t.cleanup();
+    }
+});
+
+test('detectFileExtensionByMagic 对未知字节返回 null', () => {
+    const t = tmpDir('qce-sticker-ext-unknown-');
+    try {
+        const file = path.join(t.dir, 'a.bin');
+        fs.writeFileSync(file, Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]));
+        const exp = newExporter();
+        assert.equal(exp.detectFileExtensionByMagic(file), null);
+    } finally {
+        t.cleanup();
+    }
+});
+
+test('normalizeStickerExtension 把误标为 .jpg 的 GIF 改名为 .gif', async () => {
+    const t = tmpDir('qce-sticker-norm-');
+    try {
+        const wrongPath = path.join(t.dir, 'sticker_001.jpg');
+        // 写入 GIF89a magic
+        fs.writeFileSync(wrongPath, Buffer.from([
+            0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00
+        ]));
+        const exp = newExporter();
+        const finalPath: string = await exp.normalizeStickerExtension(wrongPath);
+        assert.equal(path.extname(finalPath), '.gif');
+        assert.ok(fs.existsSync(finalPath));
+        assert.equal(fs.existsSync(wrongPath), false);
+    } finally {
+        t.cleanup();
+    }
+});
+
+test('normalizeStickerExtension 当扩展名已经正确时保持不变', async () => {
+    const t = tmpDir('qce-sticker-noop-');
+    try {
+        const correctPath = path.join(t.dir, 'sticker_002.png');
+        fs.writeFileSync(correctPath, Buffer.from([
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A
+        ]));
+        const exp = newExporter();
+        const finalPath: string = await exp.normalizeStickerExtension(correctPath);
+        assert.equal(finalPath, correctPath);
+        assert.ok(fs.existsSync(correctPath));
+    } finally {
+        t.cleanup();
+    }
+});

--- a/plugins/qq-chat-exporter/lib/core/sticker/StickerPackExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/sticker/StickerPackExporter.ts
@@ -210,6 +210,103 @@ export class StickerPackExporter {
         });
     }
 
+    /**
+     * issue #313：根据文件头 magic bytes 判定真实图片格式。
+     *
+     * QQ 收藏表情在本地缓存里常以 `.jfif` / 无扩展名 / 错的 `.jpg` 落盘，但实际
+     * 字节是 GIF/PNG/WebP。直接拿源路径的 `path.extname` 作为目标扩展名会把
+     * 动图误标成 `.jpg`，下游软件按 jpg 解码就显示为「损坏」。
+     *
+     * 这里只读前 12 个字节即可覆盖 GIF / PNG / JPEG / WebP / BMP / APNG 等
+     * QQ 表情常用格式，识别失败时返回 null，调用侧再回退原扩展名或 `.gif`。
+     */
+    private detectFileExtensionByMagic(filePath: string): string | null {
+        let fd: number | null = null;
+        try {
+            fd = fs.openSync(filePath, 'r');
+            const buf = Buffer.alloc(12);
+            const n = fs.readSync(fd, buf, 0, 12, 0);
+            if (n < 4) return null;
+
+            // GIF87a / GIF89a：47 49 46 38
+            if (buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x38) {
+                return '.gif';
+            }
+            // PNG：89 50 4E 47
+            if (buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4E && buf[3] === 0x47) {
+                return '.png';
+            }
+            // JPEG：FF D8 FF
+            if (buf[0] === 0xFF && buf[1] === 0xD8 && buf[2] === 0xFF) {
+                return '.jpg';
+            }
+            // WebP：RIFF .... WEBP
+            if (
+                n >= 12 &&
+                buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
+                buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50
+            ) {
+                return '.webp';
+            }
+            // BMP：42 4D
+            if (buf[0] === 0x42 && buf[1] === 0x4D) {
+                return '.bmp';
+            }
+            return null;
+        } catch {
+            return null;
+        } finally {
+            if (fd !== null) {
+                try { fs.closeSync(fd); } catch {}
+            }
+        }
+    }
+
+    /**
+     * issue #313：把已经下载/复制好的 sticker 文件按真实格式重命名扩展名。
+     * 仅当真实扩展名与当前扩展名不一致时才 rename，且会把同名目标先删除以
+     * 避免 Windows 下 EEXIST。
+     */
+    private async normalizeStickerExtension(currentPath: string): Promise<string> {
+        if (!fs.existsSync(currentPath)) return currentPath;
+        const detected = this.detectFileExtensionByMagic(currentPath);
+        if (!detected) return currentPath;
+        const currentExt = path.extname(currentPath).toLowerCase();
+        if (currentExt === detected) return currentPath;
+        const baseNoExt = currentPath.slice(0, currentPath.length - currentExt.length);
+        const targetPath = `${baseNoExt}${detected}`;
+        try {
+            if (fs.existsSync(targetPath)) {
+                fs.unlinkSync(targetPath);
+            }
+            fs.renameSync(currentPath, targetPath);
+            return targetPath;
+        } catch (err) {
+            console.warn(`[StickerPackExporter] 修正扩展名失败 ${currentPath} → ${targetPath}:`, err);
+            return currentPath;
+        }
+    }
+
+    /**
+     * issue #313：先按源路径或 URL 推一个候选扩展名（仅用作临时落盘文件名），
+     * 真正的扩展名在文件就绪后由 normalizeStickerExtension 校正。
+     */
+    private guessInitialStickerExtension(source: string): string {
+        try {
+            if (source.startsWith('http://') || source.startsWith('https://')) {
+                const u = new URL(source);
+                const ext = path.extname(u.pathname);
+                if (ext) return ext;
+            } else {
+                const ext = path.extname(source);
+                if (ext) return ext;
+            }
+        } catch {
+            // ignore
+        }
+        return '.gif';
+    }
+
     private getMsgService(): any {
         return this.core.context.session.getMsgService();
     }
@@ -621,19 +718,25 @@ export class StickerPackExporter {
                     try {
                         if (!sticker.path) return false;
 
-                        const ext = path.extname(sticker.path) || '.gif';
+                        // issue #313：先用源路径/URL 推一个临时扩展名，落盘后再
+                        // 按真实 magic bytes 校正，避免动图被误标为 .jpg 而损坏。
+                        const initialExt = this.guessInitialStickerExtension(sticker.path);
                         const destPath = path.join(
                             stickersDir,
-                            `${sticker.stickerId}_${sticker.name.replace(/[\/\\:*?"<>|]/g, '_')}${ext}`
+                            `${sticker.stickerId}_${sticker.name.replace(/[\/\\:*?"<>|]/g, '_')}${initialExt}`
                         );
-                        
+
+                        let ok = false;
                         if (sticker.path.startsWith('http://') || sticker.path.startsWith('https://')) {
-                            return await this.downloadFile(sticker.path, destPath);
+                            ok = await this.downloadFile(sticker.path, destPath);
                         } else if (fs.existsSync(sticker.path)) {
                             fs.copyFileSync(sticker.path, destPath);
-                            return true;
+                            ok = true;
                         }
-                        return false;
+                        if (ok) {
+                            await this.normalizeStickerExtension(destPath);
+                        }
+                        return ok;
                     } catch (error) {
                         return false;
                     }
@@ -737,19 +840,25 @@ export class StickerPackExporter {
                             try {
                                 if (!sticker.path) return false;
 
-                                const ext = path.extname(sticker.path) || '.gif';
+                                // issue #313：先用源路径/URL 推个临时扩展名，落盘后由
+                                // normalizeStickerExtension 按真实 magic bytes 校正。
+                                const initialExt = this.guessInitialStickerExtension(sticker.path);
                                 const destPath = path.join(
                                     stickersDir,
-                                    `${sticker.stickerId}_${sticker.name.replace(/[\/\\:*?"<>|]/g, '_')}${ext}`
+                                    `${sticker.stickerId}_${sticker.name.replace(/[\/\\:*?"<>|]/g, '_')}${initialExt}`
                                 );
-                                
+
+                                let ok = false;
                                 if (sticker.path.startsWith('http://') || sticker.path.startsWith('https://')) {
-                                    return await this.downloadFile(sticker.path, destPath);
+                                    ok = await this.downloadFile(sticker.path, destPath);
                                 } else if (fs.existsSync(sticker.path)) {
                                     fs.copyFileSync(sticker.path, destPath);
-                                    return true;
+                                    ok = true;
                                 }
-                                return false;
+                                if (ok) {
+                                    await this.normalizeStickerExtension(destPath);
+                                }
+                                return ok;
                             } catch (error) {
                                 return false;
                             }


### PR DESCRIPTION
## Summary

Fix issue #313: 导出 QQ 收藏的表情包时，原本是动图（GIF / WebP / APNG）的表情会被误标成 `.jpg` 落盘，下游软件按 jpg 解码后显示「损坏」。

Root cause: `StickerPackExporter` 在两个导出分支都用 `path.extname(sticker.path) || '.gif'` 决定目标扩展名。但 NTQQ 的本地缓存里 emoji 文件常常没扩展名或是 `.jfif` / `.jpg`，与文件实际格式不一致；HTTP 兜底分支会从 URL 取扩展名，更容易踩到 `.jpg`。所以最终生成的文件扩展名错位，并不是文件内容本身坏了。

Changes in `lib/core/sticker/StickerPackExporter.ts`：
- 新增三个内部方法：
  - `detectFileExtensionByMagic(filePath)` — 读前 12 字节按 GIF / PNG / JPEG / WebP / BMP 的 magic 头识别真实格式，未知返回 null。
  - `normalizeStickerExtension(currentPath)` — 文件落盘后用 magic 校正扩展名，仅当与当前不一致时改名，目标已存在时先 unlink，避免 Windows 下 EEXIST。
  - `guessInitialStickerExtension(source)` — 仅用作临时落盘文件名的初始扩展名（依赖 path / URL 的扩展名，无则回落 `.gif`），最终扩展名以 magic 检测为准。
- `exportStickerPack` 与 `exportAllStickerPacks` 的写盘循环改用上述三件套：先按初始扩展名落盘，下载或拷贝完成后立即调用 `normalizeStickerExtension`。

New unit tests: `__tests__/unit/StickerPackExtension.test.ts` 覆盖 GIF / PNG / JPEG / WebP / 未知字节 + 误标扩展名的修正与正确扩展名的 no-op 行为。

Backward compatible：原扩展名已正确的表情会走 no-op；不会改动表情包元数据（`pack_info.json`）的 `path` 字段，只改实际写到 `stickers/` 目录下的文件名。

## Review & Testing Checklist for Human

- [ ] 在「表情包」页选「收藏的表情」导出，确认 `<exportDir>/stickers/` 下原本是 GIF 的动图扩展名为 `.gif`，能在资源管理器、浏览器、Telegram 等位置正常预览。
- [ ] 同样流程对市场表情包导出一遍（含 GIF + 静态 PNG），扩展名分别为 `.gif` / `.png`，无误标。
- [ ] 运行 `npm test`，确认新增的 7 个 magic-bytes 测试与原有用例全部通过（本地共 49/49）。

### Notes

- `pack_info.json` 内 `stickers[].path` 仍记录 NTQQ 的原始路径，仅最终落盘的文件名做扩展名校正。
- 检测仅读 12 字节，I/O 开销可忽略。
- 如未来要再支持 APNG / AVIF / HEIC 这类带 ftyp/box 的容器，可在 `detectFileExtensionByMagic` 里增量补 magic 表。