### PR TITLE
fix(audio): rename SILK-encoded .amr exports to .silk by magic bytes (#285)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/AudioExtensionNormalize.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/AudioExtensionNormalize.test.ts
@@ -1,0 +1,156 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { ResourceHandler } from '../../lib/core/resource/ResourceHandler.js';
+import { ResourceStatus } from '../../lib/types/index.js';
+
+/**
+ * Issue #285 — 导出语音 .amr 文件实际上是 SILK 编码，导致下游播放器解码失败。
+ *
+ * 这里只测内部纯函数 normalizeAudioFileExtension，不依赖 NapCatCore 运行时。
+ */
+
+function tmpDir(prefix: string): { dir: string; cleanup: () => void } {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    return { dir, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
+}
+
+function newHandler(): any {
+    return Object.create(ResourceHandler.prototype);
+}
+
+function makeResourceInfo(fileName: string, mime = 'audio/wav') {
+    return {
+        type: 'audio',
+        originalUrl: '',
+        fileName,
+        fileSize: 0,
+        mimeType: mime,
+        md5: '',
+        accessible: true,
+        checkedAt: new Date(),
+        status: ResourceStatus.DOWNLOADED,
+        downloadAttempts: 0,
+    };
+}
+
+test('SILK 文件以 .amr 扩展名落盘时被改为 .silk', () => {
+    const t = tmpDir('qce-audio-silk-');
+    try {
+        const wrongPath = path.join(t.dir, 'voice_001.amr');
+        // SILK_V3 magic
+        fs.writeFileSync(wrongPath, Buffer.concat([
+            Buffer.from('#!SILK_V3'),
+            Buffer.alloc(8, 0xAA),
+        ]));
+
+        const handler = newHandler();
+        const info = makeResourceInfo('voice_001.amr', 'audio/amr');
+        const finalPath: string = handler.normalizeAudioFileExtension(wrongPath, info);
+
+        assert.equal(path.extname(finalPath), '.silk');
+        assert.ok(fs.existsSync(finalPath));
+        assert.equal(fs.existsSync(wrongPath), false);
+        assert.equal(info.fileName, 'voice_001.silk');
+        assert.equal(info.mimeType, 'audio/silk');
+    } finally {
+        t.cleanup();
+    }
+});
+
+test('SILK 头带 0x02 前缀的也能识别', () => {
+    const t = tmpDir('qce-audio-silk2-');
+    try {
+        const wrongPath = path.join(t.dir, 'voice_002.amr');
+        fs.writeFileSync(wrongPath, Buffer.concat([
+            Buffer.from([0x02]),
+            Buffer.from('#!SILK_V3'),
+            Buffer.alloc(8, 0x55),
+        ]));
+
+        const handler = newHandler();
+        const info = makeResourceInfo('voice_002.amr');
+        const finalPath: string = handler.normalizeAudioFileExtension(wrongPath, info);
+        assert.equal(path.extname(finalPath), '.silk');
+        assert.equal(info.fileName, 'voice_002.silk');
+    } finally {
+        t.cleanup();
+    }
+});
+
+test('真正的 AMR 文件保持 .amr 扩展名不变', () => {
+    const t = tmpDir('qce-audio-amr-');
+    try {
+        const correctPath = path.join(t.dir, 'voice_003.amr');
+        fs.writeFileSync(correctPath, Buffer.concat([
+            Buffer.from('#!AMR\n'),
+            Buffer.alloc(16, 0x12),
+        ]));
+
+        const handler = newHandler();
+        const info = makeResourceInfo('voice_003.amr');
+        const finalPath: string = handler.normalizeAudioFileExtension(correctPath, info);
+        assert.equal(finalPath, correctPath);
+        assert.equal(info.fileName, 'voice_003.amr');
+        // mime 会被同步刷为 audio/amr
+        assert.equal(info.mimeType, 'audio/amr');
+    } finally {
+        t.cleanup();
+    }
+});
+
+test('AMR-WB 头识别为 .amr', () => {
+    const t = tmpDir('qce-audio-amrwb-');
+    try {
+        const correctPath = path.join(t.dir, 'voice_004.amr');
+        fs.writeFileSync(correctPath, Buffer.concat([
+            Buffer.from('#!AMR-WB\n'),
+            Buffer.alloc(16, 0x21),
+        ]));
+        const handler = newHandler();
+        const info = makeResourceInfo('voice_004.amr');
+        const finalPath: string = handler.normalizeAudioFileExtension(correctPath, info);
+        assert.equal(finalPath, correctPath);
+        assert.equal(info.mimeType, 'audio/amr');
+    } finally {
+        t.cleanup();
+    }
+});
+
+test('MP3 文件被错误命名为 .amr 时改为 .mp3', () => {
+    const t = tmpDir('qce-audio-mp3-');
+    try {
+        const wrongPath = path.join(t.dir, 'voice_005.amr');
+        // ID3 头
+        fs.writeFileSync(wrongPath, Buffer.concat([
+            Buffer.from('ID3'),
+            Buffer.alloc(16, 0),
+        ]));
+        const handler = newHandler();
+        const info = makeResourceInfo('voice_005.amr');
+        const finalPath: string = handler.normalizeAudioFileExtension(wrongPath, info);
+        assert.equal(path.extname(finalPath), '.mp3');
+        assert.equal(info.fileName, 'voice_005.mp3');
+        assert.equal(info.mimeType, 'audio/mpeg');
+    } finally {
+        t.cleanup();
+    }
+});
+
+test('未知字节保持原扩展名不变', () => {
+    const t = tmpDir('qce-audio-unknown-');
+    try {
+        const filePath = path.join(t.dir, 'voice_006.amr');
+        fs.writeFileSync(filePath, Buffer.alloc(16, 0));
+        const handler = newHandler();
+        const info = makeResourceInfo('voice_006.amr');
+        const finalPath: string = handler.normalizeAudioFileExtension(filePath, info);
+        assert.equal(finalPath, filePath);
+        assert.equal(info.fileName, 'voice_006.amr');
+    } finally {
+        t.cleanup();
+    }
+});

--- a/plugins/qq-chat-exporter/lib/core/resource/ResourceHandler.ts
+++ b/plugins/qq-chat-exporter/lib/core/resource/ResourceHandler.ts
@@ -795,13 +795,136 @@ export class ResourceHandler {
     }
 
     /**
+     * issue #285：根据 magic bytes 识别音频真实编码，必要时把已落盘的文件
+     * 扩展名规范化，并同步更新 resourceInfo.fileName / mimeType。
+     *
+     * 主要修正点：QQ 客户端把 SILK 编码语音以 `.amr` 扩展名缓存。把它改成
+     * `.silk` 后下游用户能直接用 silk-decoder / ffmpeg 转 mp3，而不会被
+     * AMR 解码器误判为「文件损坏」。
+     *
+     * 识别失败时返回原路径，保证旧行为。
+     */
+    private normalizeAudioFileExtension(filePath: string, resourceInfo: ResourceInfo): string {
+        try {
+            if (!fs.existsSync(filePath)) return filePath;
+            const stats = fs.statSync(filePath);
+            if (!stats.isFile() || stats.size < 4) return filePath;
+
+            const fd = fs.openSync(filePath, 'r');
+            const buf = Buffer.alloc(16);
+            let n = 0;
+            try {
+                n = fs.readSync(fd, buf, 0, 16, 0);
+            } finally {
+                try { fs.closeSync(fd); } catch {}
+            }
+            if (n < 4) return filePath;
+
+            // SILK：常见两种头
+            //   - `#!SILK_V3` (0x23 0x21 0x53 0x49 0x4C 0x4B 0x5F 0x56 0x33)
+            //   - 前置 0x02 字节后跟 `#!SILK_V3`
+            const silkSignature = Buffer.from('#!SILK_V3');
+            const isSilk =
+                (n >= silkSignature.length && buf.slice(0, silkSignature.length).equals(silkSignature)) ||
+                (n >= silkSignature.length + 1 && buf[0] === 0x02 &&
+                    buf.slice(1, 1 + silkSignature.length).equals(silkSignature));
+            // AMR：`#!AMR\n` (单声道) 或 `#!AMR-WB\n` (宽带)
+            const amrNbSig = Buffer.from('#!AMR\n');
+            const amrWbSig = Buffer.from('#!AMR-WB\n');
+            const isAmr =
+                (n >= amrNbSig.length && buf.slice(0, amrNbSig.length).equals(amrNbSig)) ||
+                (n >= amrWbSig.length && buf.slice(0, amrWbSig.length).equals(amrWbSig));
+            // WAV：RIFF .... WAVE
+            const isWav = n >= 12 &&
+                buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
+                buf[8] === 0x57 && buf[9] === 0x41 && buf[10] === 0x56 && buf[11] === 0x45;
+            // MP3：ID3 头 (49 44 33) 或同步字 (FF FB / FF F3 / FF F2)
+            const isMp3 =
+                (buf[0] === 0x49 && buf[1] === 0x44 && buf[2] === 0x33) ||
+                (buf[0] === 0xFF && (buf[1] === 0xFB || buf[1] === 0xF3 || buf[1] === 0xF2));
+            // OGG：OggS
+            const isOgg = buf[0] === 0x4F && buf[1] === 0x67 && buf[2] === 0x67 && buf[3] === 0x53;
+
+            let realExt: string | null = null;
+            let realMime: string | null = null;
+            if (isSilk) {
+                realExt = '.silk';
+                realMime = 'audio/silk';
+            } else if (isAmr) {
+                realExt = '.amr';
+                realMime = 'audio/amr';
+            } else if (isWav) {
+                realExt = '.wav';
+                realMime = 'audio/wav';
+            } else if (isMp3) {
+                realExt = '.mp3';
+                realMime = 'audio/mpeg';
+            } else if (isOgg) {
+                realExt = '.ogg';
+                realMime = 'audio/ogg';
+            }
+            if (!realExt) return filePath;
+
+            const currentExt = path.extname(filePath).toLowerCase();
+            if (currentExt === realExt) {
+                if (realMime) {
+                    resourceInfo.mimeType = realMime;
+                }
+                return filePath;
+            }
+
+            // rename 真正的物理文件
+            const baseNoExt = currentExt
+                ? filePath.slice(0, filePath.length - currentExt.length)
+                : filePath;
+            const newPath = `${baseNoExt}${realExt}`;
+            try {
+                if (fs.existsSync(newPath)) {
+                    // 同名目标若是同一份内容则直接复用，否则删除避免 EEXIST
+                    try { fs.unlinkSync(newPath); } catch {}
+                }
+                fs.renameSync(filePath, newPath);
+            } catch (renameErr) {
+                console.warn(`[ResourceHandler] 修正音频扩展名失败 ${filePath} → ${newPath}:`, renameErr);
+                return filePath;
+            }
+
+            // 同步更新 resourceInfo
+            if (resourceInfo.fileName) {
+                const fnExt = path.extname(resourceInfo.fileName).toLowerCase();
+                const fnBase = fnExt
+                    ? resourceInfo.fileName.slice(0, resourceInfo.fileName.length - fnExt.length)
+                    : resourceInfo.fileName;
+                resourceInfo.fileName = `${fnBase}${realExt}`;
+            } else {
+                resourceInfo.fileName = path.basename(newPath);
+            }
+            if (realMime) {
+                resourceInfo.mimeType = realMime;
+            }
+            return newPath;
+        } catch (err) {
+            console.warn(`[ResourceHandler] normalizeAudioFileExtension 异常 (${filePath}):`, err);
+            return filePath;
+        }
+    }
+
+    /**
      * 执行下载任务
      */
     private async executeDownload(task: DownloadTask): Promise<string> {
         try {
             return await this.circuitBreaker.execute(async () => {
-                const filePath = await this.downloadResource(task.message, task.element, task.resourceInfo);
-                
+                let filePath = await this.downloadResource(task.message, task.element, task.resourceInfo);
+
+                // issue #285：QQ 把 SILK 编码的语音以 `.amr` 扩展名落到本地缓存，
+                // 直接交给播放器会被当成 AMR 解码失败。在写库前先按 magic bytes
+                // 把音频扩展名规范化（SILK / AMR / WAV / MP3 / OGG），让 JSON、
+                // HTML、文件资源管理器看到一致的文件名。
+                if (filePath && task.resourceInfo.type === 'audio') {
+                    filePath = this.normalizeAudioFileExtension(filePath, task.resourceInfo);
+                }
+
                 // 更新资源状态
                 task.resourceInfo.localPath = filePath;
                 task.resourceInfo.accessible = true;


### PR DESCRIPTION
## Summary

Fix issue #285: 导出聊天记录后 `resources/audios/` 下的 `.amr` 文件无法被任何播放器或 amr→mp3 转换器打开。

Root cause：QQ 客户端把 SILK 编码的语音以 `.amr` 扩展名缓存（NTQQ 服务端用的就是 SILK V3，本地缓存只是沿用 .amr 后缀）。`ResourceHandler` 直接拿这个缓存文件透传到导出目录，最终扩展名与字节流编码不匹配。AMR 解码器读到 `#!SILK_V3` 头自然失败，用户看到「文件损坏」。

Changes in `lib/core/resource/ResourceHandler.ts`:
- 新增内部方法 `normalizeAudioFileExtension(filePath, resourceInfo)`：读前 16 字节，识别 SILK / AMR / AMR-WB / WAV / MP3 / OGG。SILK 头同时支持是否带 0x02 前缀。识别失败回原路径，保持旧行为。
- 识别成功时：
  - rename 物理文件到正确扩展名；
  - 同步更新 `resourceInfo.fileName` 与 `resourceInfo.mimeType`，让后续写库 / JSON / HTML 看到一致的文件名；
  - 仅当 SILK 字节被错误地标成 `.amr` 时改名为 `.silk`，对真正的 AMR 文件保持 `.amr` 不变。
- 在 `executeDownload` 成功路径调用一次该方法（仅 `type === 'audio'`），确保资源在写库前就已经规范化。

New unit tests `__tests__/unit/AudioExtensionNormalize.test.ts`：6 个用例覆盖 SILK / SILK-with-0x02 / AMR / AMR-WB / MP3 误标 / 未知字节。

Backward compatible：扩展名已正确的音频走 no-op；其它资源类型完全不受影响。

## Review & Testing Checklist for Human

- [ ] 任意一段语音消息所在的群 / 单聊导出一遍，确认 `<exportDir>/resources/audios/` 下原本是 SILK 的语音被写为 `.silk`，配合 silk-decoder / ffmpeg 能转成 mp3。
- [ ] 同样目录下若 NTQQ 真正生成的就是 AMR（旧版本群通话录音等），扩展名应保持 `.amr` 不被改动。
- [ ] JSON / JSONL / HTML 三种导出里 `content.resources[].fileName` / `localPath` / `data.url` 与磁盘上的实际文件名一致。
- [ ] `npm test` 本地共 55/55 通过。

### Notes

- 仍未做 SILK→MP3 的实际转码，只是把扩展名修正到能让 silk-decoder / ffmpeg 直接吃；后续若要内置转码可以在 BaseExporter 加可选 hook，但那部分依赖外部 codec，先不在本 PR 处理（issue #306 范畴）。
- 检测仅读 16 字节，I/O 开销可忽略。