### PR TITLE
feat(exporter): self-contained HTML with embedded resources (#311)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/ModernHtmlExporter.embedDataUri.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/ModernHtmlExporter.embedDataUri.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Issue #311: 自包含 HTML 导出测试。
+ *
+ * 验证 `embedResourcesAsDataUri=true` 时：
+ *   1. 不创建 `resources/` 目录
+ *   2. <img>/<audio>/<video>/<a> 的 src/href 改为 `data:<mime>;base64,...`
+ *   3. 超过 `maxEmbedFileSizeBytes` 的资源回退为相对路径
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { ModernHtmlExporter } from '../../lib/core/exporter/ModernHtmlExporter.js';
+import { createTempDir } from '../helpers/tempDir.js';
+import { silenceConsole } from '../helpers/silenceConsole.js';
+
+// 1×1 透明 PNG
+const PNG_BYTES = Buffer.from(
+    '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4' +
+    '890000000d49444154789c63600000000200015e2bb1f80000000049454e44ae' +
+    '426082',
+    'hex'
+);
+
+let console_!: ReturnType<typeof silenceConsole>;
+let tmp!: ReturnType<typeof createTempDir>;
+let originalUserProfile: string | undefined;
+
+test.beforeEach(() => {
+    console_ = silenceConsole();
+    tmp = createTempDir();
+    originalUserProfile = process.env['USERPROFILE'];
+    process.env['USERPROFILE'] = tmp.path;
+});
+
+test.afterEach(() => {
+    if (originalUserProfile === undefined) {
+        delete process.env['USERPROFILE'];
+    } else {
+        process.env['USERPROFILE'] = originalUserProfile;
+    }
+    tmp.cleanup();
+    console_.restore();
+});
+
+interface ScenarioOptions {
+    fileBytes: Buffer;
+    fileName: string;
+    typeDir: 'images' | 'audios' | 'videos' | 'files';
+    embed: boolean;
+    maxEmbedFileSizeBytes?: number;
+}
+
+async function runEmbedScenario(opts: ScenarioOptions): Promise<{ html: string; outputDir: string }> {
+    // 把资源写到 ResourceHandler 默认目录
+    const resourceDir = path.join(tmp.path, '.qq-chat-exporter', 'resources', opts.typeDir);
+    fs.mkdirSync(resourceDir, { recursive: true });
+    const onDiskName = `abc123_${opts.fileName}`;
+    fs.writeFileSync(path.join(resourceDir, onDiskName), opts.fileBytes);
+
+    const outputDir = path.join(tmp.path, 'out');
+    fs.mkdirSync(outputDir, { recursive: true });
+    const outputPath = path.join(outputDir, 'chat.html');
+
+    const elementType = opts.typeDir === 'images'
+        ? 'image'
+        : opts.typeDir === 'audios'
+            ? 'audio'
+            : opts.typeDir === 'videos'
+                ? 'video'
+                : 'file';
+
+    const message: any = {
+        id: 'm_1',
+        timestamp: Date.now(),
+        sender: { id: 'u_alice', uin: '11111', name: 'Alice' },
+        chatType: 1,
+        peer: { peerUid: 'u_alice' },
+        content: {
+            elements: [
+                {
+                    type: elementType,
+                    data: { filename: opts.fileName, url: '' }
+                }
+            ]
+        }
+    };
+
+    const exporter = new ModernHtmlExporter({
+        outputPath,
+        includeResourceLinks: true,
+        includeSystemMessages: true,
+        embedResourcesAsDataUri: opts.embed,
+        ...(opts.maxEmbedFileSizeBytes !== undefined
+            ? { maxEmbedFileSizeBytes: opts.maxEmbedFileSizeBytes }
+            : {})
+    });
+
+    async function* iter() {
+        yield message;
+    }
+
+    await exporter.exportFromIterable(iter(), { name: 'Alice', type: 'private' });
+
+    const html = fs.readFileSync(outputPath, 'utf8');
+    return { html, outputDir };
+}
+
+test('embedResourcesAsDataUri=true: image is inlined as data URI and resources/ dir is not created', async () => {
+    const { html, outputDir } = await runEmbedScenario({
+        fileBytes: PNG_BYTES,
+        fileName: 'screenshot.png',
+        typeDir: 'images',
+        embed: true
+    });
+
+    assert.match(html, /src="data:image\/png;base64,[A-Za-z0-9+/=]+"/);
+    assert.ok(!html.includes('./resources/images/screenshot.png'),
+        'inlined HTML should not reference external resources/');
+    assert.ok(!fs.existsSync(path.join(outputDir, 'resources')),
+        'resources/ directory should not be created in inline mode');
+});
+
+test('embedResourcesAsDataUri=false: image stays as external relative path', async () => {
+    const { html, outputDir } = await runEmbedScenario({
+        fileBytes: PNG_BYTES,
+        fileName: 'screenshot.png',
+        typeDir: 'images',
+        embed: false
+    });
+
+    assert.ok(!/src="data:image\/png;base64,/.test(html),
+        'plain mode must not produce data URIs');
+    assert.match(html, /src="\.\/resources\/images\/screenshot\.png"/);
+    assert.ok(fs.existsSync(path.join(outputDir, 'resources', 'images', 'screenshot.png')),
+        'resources/images/screenshot.png should be copied');
+});
+
+test('embedResourcesAsDataUri=true with size limit smaller than file falls back to relative path', async () => {
+    const { html } = await runEmbedScenario({
+        fileBytes: PNG_BYTES,
+        fileName: 'screenshot.png',
+        typeDir: 'images',
+        embed: true,
+        // 单个资源上限 10 字节，小于真实 PNG 大小
+        maxEmbedFileSizeBytes: 10
+    });
+
+    assert.ok(!/src="data:image\/png;base64,/.test(html),
+        'oversize file should fall back to external link, not inline');
+    assert.match(html, /src="\.\/resources\/images\/screenshot\.png"/);
+});
+
+test('embedResourcesAsDataUri=true: audio file is inlined as data URI with audio MIME', async () => {
+    const silkBytes = Buffer.from('SILK_FAKE_BYTES_FOR_TEST_PURPOSES', 'utf8');
+    const { html } = await runEmbedScenario({
+        fileBytes: silkBytes,
+        fileName: 'voice.silk',
+        typeDir: 'audios',
+        embed: true
+    });
+
+    assert.match(html, /<audio src="data:audio\/silk;base64,[A-Za-z0-9+/=]+"/);
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -3840,7 +3840,12 @@ export class QQChatExporterApiServer {
                         outputPath: filePath,
                         includeResourceLinks: exportOptions.includeResourceLinks,
                         includeSystemMessages: exportOptions.includeSystemMessages,
-                        encoding: exportOptions.encoding
+                        encoding: exportOptions.encoding,
+                        // Issue #311: 自包含 HTML（资源以 base64 内联）。
+                        embedResourcesAsDataUri: options?.embedResourcesAsDataUri === true,
+                        ...(typeof options?.maxEmbedFileSizeBytes === 'number'
+                            ? { maxEmbedFileSizeBytes: options.maxEmbedFileSizeBytes }
+                            : {})
                     });
                     
                     // 使用流式API：逐条解析、更新资源路径、写入HTML，全程低内存

--- a/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
@@ -25,6 +25,19 @@ export interface HtmlExportOptions {
     includeResourceLinks?: boolean;
     includeSystemMessages?: boolean;
     encoding?: string; // 建议使用 'utf8'
+    /**
+     * Issue #311: 自包含 HTML 模式。开启后不再生成同级 `resources/`
+     * 目录，所有图片 / 语音 / 视频 / 文件改为以 base64 data URI 内联到
+     * 单个 HTML 文件中，便于单独发送或在没有附属文件夹的环境下查看。
+     */
+    embedResourcesAsDataUri?: boolean;
+    /**
+     * Issue #311: 当 `embedResourcesAsDataUri` 启用时，单个资源若超过此
+     * 大小（字节）则不内联，仍按外链 / 文件名占位渲染。默认 50 MB；可设
+     * 为 0 关闭单文件上限。聚合 HTML 在桌面浏览器与移动端 WebView 上都会
+     * 因为体积过大而崩溃，因此默认值偏保守。
+     */
+    maxEmbedFileSizeBytes?: number;
 }
 
 /**
@@ -129,6 +142,15 @@ export class ModernHtmlExporter {
     private lastRenderedDate?: string;
 
     /**
+     * Issue #311: data URI 缓存。key 为 `<typeDir>/<basename>`，value 为完整
+     * `data:<mime>;base64,...` 字符串。仅当 `embedResourcesAsDataUri=true`
+     * 时被填充，否则始终为空，渲染路径走原有的 `./resources/...`。
+     */
+    private dataUriCache: Map<string, string> = new Map();
+    /** Issue #311: 已尝试过、确认不可内联的资源 key，避免重复磁盘探测。 */
+    private dataUriMisses: Set<string> = new Set();
+
+    /**
      * 资源引用基础路径（URL 相对前缀）
      * - 单文件导出使用 './resources'（资源目录与 HTML 同级，便于独立移动）
      * - Chunked 方案使用 'resources'（无 ./ 前缀）
@@ -144,6 +166,8 @@ export class ModernHtmlExporter {
             includeResourceLinks: true,
             includeSystemMessages: true,
             encoding: 'utf8', // 更稳妥的 Node 编码常量
+            embedResourcesAsDataUri: false,
+            maxEmbedFileSizeBytes: 50 * 1024 * 1024,
             ...options
         };
     }
@@ -687,7 +711,10 @@ export class ModernHtmlExporter {
         };
 
         // 若需要资源目录，预先创建
-        if (this.options.includeResourceLinks) {
+        // Issue #311: 在 embedResourcesAsDataUri 模式下跳过资源目录创建与拷贝，资源直接以
+        // base64 内联。
+        const useDataUri = this.options.includeResourceLinks === true && this.options.embedResourcesAsDataUri === true;
+        if (this.options.includeResourceLinks && !useDataUri) {
             const resourceTypes = ['images', 'videos', 'audios', 'files'];
             await Promise.all(
                 resourceTypes.map(type =>
@@ -731,13 +758,22 @@ export class ModernHtmlExporter {
                     continue;
                 }
 
+                // Issue #311: 内联模式下，为当前消息预加载所有资源为 data URI。顺序
+                // await 以保证随后的同步 renderMessage 可从缓存中取到；同一资源 key
+                // 二次出现时会命中缓存不重复读盘。
+                if (useDataUri) {
+                    for (const res of this.iterResources(message)) {
+                        await this.preloadDataUri(res);
+                    }
+                }
+
                 // 渲染并写入单条消息（小字符串，立即写出，避免累积）
                 const chunk = this.renderMessage(message);
                 await this.writeChunk(ws, chunk + '\n');
                 totalMessages++;
 
-                // 并发受限地复制资源（仅当启用本地资源）
-                if (this.options.includeResourceLinks) {
+                // 并发受限地复制资源（仅当启用本地资源且不在内联模式下）
+                if (this.options.includeResourceLinks && !useDataUri) {
                     for (const res of this.iterResources(message)) {
                         // 控制并发：超出并发上限时，等待任一任务完成
                         while (running.length >= concurrency) {
@@ -989,6 +1025,146 @@ export class ModernHtmlExporter {
         }
     }
 
+    /**
+     * Issue #311: 解析资源在磁盘上的真实路径，规则与 `copyResourceFileStream`
+     * 保持一致：先认 `localPath`，再退回到 ResourceHandler 默认资源目录按文件
+     * 名匹配。返回 `null` 表示未找到。
+     */
+    private async resolveResourceSourcePath(resource: ResourceTask): Promise<string | null> {
+        try {
+            if (resource.localPath && resource.localPath.trim() !== '') {
+                const candidate = this.resolveResourcePath(resource.localPath);
+                if (await this.fileExists(candidate)) {
+                    const stat = await fsp.stat(candidate);
+                    if (!stat.isDirectory()) return candidate;
+                }
+            }
+            if (resource.fileName) {
+                const typeDir = this.normalizeTypeDir(resource.type);
+                const resourceHandlerDir = path.join(
+                    process.env['USERPROFILE'] || process.cwd(),
+                    '.qq-chat-exporter',
+                    'resources',
+                    typeDir
+                );
+                if (await this.fileExists(resourceHandlerDir)) {
+                    const files = await fsp.readdir(resourceHandlerDir);
+                    const baseName = resource.fileName.toLowerCase();
+                    const matchedFile = files.find(f => {
+                        const fLower = f.toLowerCase();
+                        return fLower === baseName || fLower.endsWith('_' + baseName);
+                    });
+                    if (matchedFile) {
+                        const fullPath = path.join(resourceHandlerDir, matchedFile);
+                        if (await this.fileExists(fullPath)) return fullPath;
+                    }
+                }
+            }
+        } catch {
+            // 静默
+        }
+        return null;
+    }
+
+    /**
+     * Issue #311: 把单个资源读入内存并缓存为 data URI。命中以下任一情况则跳
+     * 过：缓存已存在、之前已记录过 miss、文件超过 `maxEmbedFileSizeBytes`。
+     */
+    private async preloadDataUri(resource: ResourceTask): Promise<void> {
+        const key = this.dataUriCacheKey(resource);
+        if (!key) return;
+        if (this.dataUriCache.has(key) || this.dataUriMisses.has(key)) return;
+
+        const sourcePath = await this.resolveResourceSourcePath(resource);
+        if (!sourcePath) {
+            this.dataUriMisses.add(key);
+            return;
+        }
+
+        try {
+            const stat = await fsp.stat(sourcePath);
+            const limit = this.options.maxEmbedFileSizeBytes ?? 0;
+            if (limit > 0 && stat.size > limit) {
+                this.dataUriMisses.add(key);
+                return;
+            }
+            const buf = await fsp.readFile(sourcePath);
+            const mime = this.guessMimeType(resource, sourcePath);
+            const dataUri = `data:${mime};base64,${buf.toString('base64')}`;
+            this.dataUriCache.set(key, dataUri);
+        } catch (error) {
+            console.error('[ModernHtmlExporter] 读取资源用于内联失败:', {
+                resource,
+                error: error instanceof Error ? error.message : String(error)
+            });
+            this.dataUriMisses.add(key);
+        }
+    }
+
+    /**
+     * Issue #311: 生成稳定的资源 key，与 `renderImageElement` 等渲染路径中
+     * 计算的 key 形状一致：`<typeDir>/<basename>`。
+     */
+    private dataUriCacheKey(resource: { type: string; localPath?: string; fileName?: string }): string {
+        const typeDir = this.normalizeTypeDir(resource.type);
+        const base = resource.localPath && resource.localPath.trim()
+            ? path.basename(resource.localPath)
+            : (resource.fileName || '');
+        if (!base) return '';
+        return `${typeDir}/${base}`;
+    }
+
+    /** Issue #311: 渲染期通过 `<typeDir>/<basename>` 查询已加载的 data URI。 */
+    private lookupDataUri(typeDir: string, fileName: string): string | undefined {
+        if (!typeDir || !fileName) return undefined;
+        return this.dataUriCache.get(`${typeDir}/${fileName}`);
+    }
+
+    /**
+     * Issue #311: 根据资源类型与文件扩展名推断 MIME。未识别的扩展名退回到
+     * `application/octet-stream`，浏览器可在下载链接里正确处理。
+     */
+    private guessMimeType(resource: ResourceTask, sourcePath: string): string {
+        const ext = path.extname(sourcePath || resource.fileName || '').toLowerCase();
+        const map: Record<string, string> = {
+            '.png': 'image/png',
+            '.jpg': 'image/jpeg',
+            '.jpeg': 'image/jpeg',
+            '.gif': 'image/gif',
+            '.webp': 'image/webp',
+            '.bmp': 'image/bmp',
+            '.svg': 'image/svg+xml',
+            '.ico': 'image/x-icon',
+            '.heic': 'image/heic',
+            '.heif': 'image/heif',
+            '.mp4': 'video/mp4',
+            '.webm': 'video/webm',
+            '.mov': 'video/quicktime',
+            '.mkv': 'video/x-matroska',
+            '.avi': 'video/x-msvideo',
+            '.mp3': 'audio/mpeg',
+            '.m4a': 'audio/mp4',
+            '.aac': 'audio/aac',
+            '.wav': 'audio/wav',
+            '.ogg': 'audio/ogg',
+            '.flac': 'audio/flac',
+            '.amr': 'audio/amr',
+            '.silk': 'audio/silk',
+            '.pdf': 'application/pdf',
+            '.zip': 'application/zip',
+            '.json': 'application/json',
+            '.txt': 'text/plain',
+            '.html': 'text/html'
+        };
+        if (ext && map[ext]) return map[ext];
+        switch (resource.type) {
+            case 'image': return 'image/jpeg';
+            case 'video': return 'video/mp4';
+            case 'audio': return 'audio/mpeg';
+            default: return 'application/octet-stream';
+        }
+    }
+
     private async fileExists(p: string): Promise<boolean> {
         try {
             await fsp.access(p);
@@ -1196,11 +1372,15 @@ export class ModernHtmlExporter {
 
         // 优先使用localPath（导出后的本地资源）
         if (data?.localPath && this.isValidResourcePath(data.localPath)) {
-            src = `${this.resourceBaseHref}/images/${path.basename(data.localPath)}`;
+            const baseName = path.basename(data.localPath);
+            // Issue #311: 自包含模式下优先取内联 data URI，未命中才退回相对路径。
+            const dataUri = this.lookupDataUri('images', baseName);
+            src = dataUri || `${this.resourceBaseHref}/images/${baseName}`;
         }
         // 如果有 filename，尝试使用本地资源路径（用于分块导出模式）
         else if (data?.filename && this.options.includeResourceLinks) {
-            src = `${this.resourceBaseHref}/images/${data.filename}`;
+            const dataUri = this.lookupDataUri('images', data.filename);
+            src = dataUri || `${this.resourceBaseHref}/images/${data.filename}`;
         }
         // 其次使用url，但要过滤掉无效的file://协议路径
         else if (data?.url) {
@@ -1215,7 +1395,10 @@ export class ModernHtmlExporter {
         }
 
         if (src) {
-            return `<div class="image-content"><img src="${src}" alt="${this.escapeHtml(filename)}" loading="lazy" onclick="showImageModal('${src}')"></div>`;
+            // Issue #311: 当 src 为 data URI 时直接传入会让 HTML 体积翻倍，
+            // 并可能造成 onclick 字符串字面量超长引发解析问题。改为从 this.src
+            // 读取，对外链与 data URI 行为一致。
+            return `<div class="image-content"><img src="${src}" alt="${this.escapeHtml(filename)}" loading="lazy" onclick="showImageModal(this.src)"></div>`;
         }
         return `<span class="text-content">📷 ${this.escapeHtml(filename)}</span>`;
     }
@@ -1227,11 +1410,14 @@ export class ModernHtmlExporter {
 
         // 优先使用localPath（导出后的本地资源，使用相对路径）
         if (data?.localPath && this.isValidResourcePath(data.localPath)) {
-            src = `${this.resourceBaseHref}/audios/${path.basename(data.localPath)}`;
+            const baseName = path.basename(data.localPath);
+            const dataUri = this.lookupDataUri('audios', baseName);
+            src = dataUri || `${this.resourceBaseHref}/audios/${baseName}`;
         }
         // 如果有 filename，尝试使用本地资源路径（用于分块导出模式）
         else if (data?.filename && this.options.includeResourceLinks) {
-            src = `${this.resourceBaseHref}/audios/${data.filename}`;
+            const dataUri = this.lookupDataUri('audios', data.filename);
+            src = dataUri || `${this.resourceBaseHref}/audios/${data.filename}`;
         }
         // 其次使用url，但要过滤掉本地文件系统路径
         else if (data?.url) {
@@ -1247,7 +1433,10 @@ export class ModernHtmlExporter {
 
         if (src) {
             // AMR格式浏览器可能不支持，同时提供下载链接
-            const isAmr = src.toLowerCase().endsWith('.amr');
+            // Issue #311: 内联模式下 src 为 data URI，需从文件名而非 src 判断是否为 AMR。
+            const isAmr = src.startsWith('data:')
+                ? (filename.toLowerCase().endsWith('.amr'))
+                : src.toLowerCase().endsWith('.amr');
             const audioTag = `<audio src="${src}" controls class="message-audio" preload="metadata">[语音:${duration}秒]</audio>`;
             const downloadLink = isAmr
                 ? `<a href="${src}" download="${this.escapeHtml(filename)}" class="audio-download-link" title="浏览器可能不支持AMR格式，点击下载">下载语音</a>`
@@ -1264,11 +1453,14 @@ export class ModernHtmlExporter {
 
         // 优先使用localPath（导出后的本地资源，使用相对路径）
         if (data?.localPath && this.isValidResourcePath(data.localPath)) {
-            src = `${this.resourceBaseHref}/videos/${path.basename(data.localPath)}`;
+            const baseName = path.basename(data.localPath);
+            const dataUri = this.lookupDataUri('videos', baseName);
+            src = dataUri || `${this.resourceBaseHref}/videos/${baseName}`;
         }
         // 如果有 filename，尝试使用本地资源路径（用于分块导出模式）
         else if (data?.filename && this.options.includeResourceLinks) {
-            src = `${this.resourceBaseHref}/videos/${data.filename}`;
+            const dataUri = this.lookupDataUri('videos', data.filename);
+            src = dataUri || `${this.resourceBaseHref}/videos/${data.filename}`;
         }
         // 其次使用url，但要过滤掉本地文件系统路径
         else if (data?.url) {
@@ -1294,11 +1486,14 @@ export class ModernHtmlExporter {
 
         // 优先使用localPath（导出后的本地资源）
         if (data?.localPath && this.isValidResourcePath(data.localPath)) {
-            href = `${this.resourceBaseHref}/files/${path.basename(data.localPath)}`;
+            const baseName = path.basename(data.localPath);
+            const dataUri = this.lookupDataUri('files', baseName);
+            href = dataUri || `${this.resourceBaseHref}/files/${baseName}`;
         }
         // 如果有 filename，尝试使用本地资源路径（用于分块导出模式）
         else if (data?.filename && this.options.includeResourceLinks) {
-            href = `${this.resourceBaseHref}/files/${data.filename}`;
+            const dataUri = this.lookupDataUri('files', data.filename);
+            href = dataUri || `${this.resourceBaseHref}/files/${data.filename}`;
         }
         // 其次使用url，但要过滤掉无效的file://协议路径
         else if (data?.url) {
@@ -1431,7 +1626,9 @@ export class ModernHtmlExporter {
             // 尝试从elements中找到图片
             const imgElement = data.elements.find((el: any) => el?.type === 'image');
             if (imgElement?.data?.localPath) {
-                const imgSrc = `${this.resourceBaseHref}/images/${path.basename(imgElement.data.localPath)}`;
+                const baseName = path.basename(imgElement.data.localPath);
+                const dataUri = this.lookupDataUri('images', baseName);
+                const imgSrc = dataUri || `${this.resourceBaseHref}/images/${baseName}`;
                 imageHtml = `<img src="${imgSrc}" class="reply-content-image" alt="引用图片" loading="lazy">`;
             }
         }

--- a/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
+++ b/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
@@ -154,6 +154,10 @@ export interface ScheduledExportConfig {
         skipDownloadResourceTypes?: Array<'image' | 'video' | 'audio' | 'file'>;
         /** Issue #341: 兼容字段，等价于 skipDownloadResourceTypes: ['file']。 */
         skipFileDownload?: boolean;
+        /** Issue #311: 仅对 HTML 格式生效，启用后资源以 base64 内联。 */
+        embedResourcesAsDataUri?: boolean;
+        /** Issue #311: 单个资源内联上限（字节）。 */
+        maxEmbedFileSizeBytes?: number;
     };
     /** 备份模式（新增） */
     backupMode?: BackupMode;
@@ -601,7 +605,12 @@ export class ScheduledExportManager {
                     const htmlExporter = new ModernHtmlExporter({
                         outputPath: filePath,
                         includeResourceLinks: task.options.includeResourceLinks ?? true,
-                        includeSystemMessages: task.options.includeSystemMessages ?? true
+                        includeSystemMessages: task.options.includeSystemMessages ?? true,
+                        // Issue #311: 自包含 HTML（资源 base64 内联）
+                        embedResourcesAsDataUri: task.options.embedResourcesAsDataUri === true,
+                        ...(typeof task.options.maxEmbedFileSizeBytes === 'number'
+                            ? { maxEmbedFileSizeBytes: task.options.maxEmbedFileSizeBytes }
+                            : {})
                     });
                     const htmlMessageStream = parser.parseMessagesStream(allMessages, resourceMap);
                     await htmlExporter.exportFromIterable(htmlMessageStream, chatInfo);

--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -821,6 +821,8 @@ export default function QCEDashboard() {
           streamingZipMode: config.streamingZipMode,
           exportAsZip: config.exportAsZip,
           embedAvatarsAsBase64: config.embedAvatarsAsBase64,
+          // Issue #311: 自包含 HTML
+          embedResourcesAsDataUri: config.embedResourcesAsDataUri,
           preferGroupMemberName: config.preferGroupMemberName,
           outputDir: config.outputDir,
           keywords: config.keywords,

--- a/qce-v4-tool/components/ui/batch-export-dialog.tsx
+++ b/qce-v4-tool/components/ui/batch-export-dialog.tsx
@@ -36,6 +36,8 @@ export interface BatchExportConfig {
   streamingZipMode: boolean
   exportAsZip: boolean
   embedAvatarsAsBase64: boolean
+  /** Issue #311: 自包含 HTML（资源 base64 内联）。 */
+  embedResourcesAsDataUri: boolean
   includeSystemMessages: boolean
   filterPureImageMessages: boolean
   preferGroupMemberName: boolean
@@ -72,6 +74,8 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
   const [streamingZipMode, setStreamingZipMode] = useState(false)
   const [exportAsZip, setExportAsZip] = useState(false)
   const [embedAvatarsAsBase64, setEmbedAvatarsAsBase64] = useState(false)
+  // Issue #311: 自包含 HTML
+  const [embedResourcesAsDataUri, setEmbedResourcesAsDataUri] = useState(false)
   const [includeSystemMessages, setIncludeSystemMessages] = useState(true)
   const [filterPureImageMessages, setFilterPureImageMessages] = useState(false) // HTML默认false
   const [preferGroupMemberName, setPreferGroupMemberName] = useState(true)
@@ -101,6 +105,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
       setStreamingZipMode(false)
       setExportAsZip(false)
       setEmbedAvatarsAsBase64(false)
+      setEmbedResourcesAsDataUri(false) // Issue #311
       setIncludeSystemMessages(true)
       setFilterPureImageMessages(false)
       setPreferGroupMemberName(true)
@@ -129,6 +134,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
     // 重置格式专有选项
     if (format !== 'HTML') {
       setExportAsZip(false)
+      setEmbedResourcesAsDataUri(false) // Issue #311: 仅 HTML 可用
       if (format !== 'JSON') {
         setStreamingZipMode(false)
       }
@@ -189,6 +195,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
       streamingZipMode,
       exportAsZip,
       embedAvatarsAsBase64,
+      embedResourcesAsDataUri,
       includeSystemMessages,
       filterPureImageMessages,
       preferGroupMemberName,
@@ -426,7 +433,9 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
                     { id: "preferGroupMemberName", checked: preferGroupMemberName, set: setPreferGroupMemberName, title: "优先使用群成员名称", desc: "群聊导出时优先使用群名片或群内名称。关闭后会改用 QQ 昵称或 QQ 号。这个选项仅对群聊生效。", visible: true, highlight: false },
                     { id: "exportAsZip", checked: exportAsZip, set: setExportAsZip, title: "导出为ZIP压缩包", desc: "将HTML文件和资源文件打包为ZIP格式（仅HTML格式可用）", visible: format === "HTML" && !streamingZipMode, highlight: false },
                     { id: "useNameInFileName", checked: useNameInFileName, set: setUseNameInFileName, title: "文件名包含聊天名称", desc: "导出文件名中包含聊天对象的名称，方便识别", visible: true, highlight: false },
-                    { id: "embedAvatarsAsBase64", checked: embedAvatarsAsBase64, set: setEmbedAvatarsAsBase64, title: "嵌入头像为Base64", desc: "将发送者头像以Base64格式嵌入JSON文件（仅JSON格式可用，会增加文件大小）", visible: format === "JSON", highlight: false }
+                    { id: "embedAvatarsAsBase64", checked: embedAvatarsAsBase64, set: setEmbedAvatarsAsBase64, title: "嵌入头像为Base64", desc: "将发送者头像以Base64格式嵌入JSON文件（仅JSON格式可用，会增加文件大小）", visible: format === "JSON", highlight: false },
+                    // Issue #311: 自包含 HTML
+                    { id: "embedResourcesAsDataUri", checked: embedResourcesAsDataUri, set: setEmbedResourcesAsDataUri, title: "生成自包含 HTML", desc: "将图片、语音、视频、小于 50 MB 的文件以 base64 内联到单个 HTML中，不再产出 resources 目录。适合需要单独发送的场景。", visible: format === "HTML" && !exportAsZip && !streamingZipMode, highlight: false }
                   ].filter((opt) => opt.visible).map((opt) => (
                     <div key={opt.id} className={["relative cursor-pointer rounded-2xl border p-4 transition-all", opt.highlight && opt.checked ? "border-orange-400 dark:border-orange-600 bg-orange-50/50 dark:bg-orange-950/30 ring-1 ring-orange-200 dark:ring-orange-800" : opt.highlight ? "border-orange-200 dark:border-orange-800 bg-orange-50/30 dark:bg-orange-950/20 hover:border-orange-300 dark:hover:border-orange-700" : opt.checked ? "border-black/[0.08] dark:border-white/[0.08] bg-muted/30" : "border-black/[0.06] dark:border-white/[0.06] hover:border-black/[0.08] dark:hover:border-white/[0.08]", isExporting ? "opacity-50 cursor-not-allowed" : ""].join(" ")} onClick={() => !isExporting && opt.set(!opt.checked)}>
                       <div className="flex items-start gap-4">

--- a/qce-v4-tool/components/ui/task-wizard.tsx
+++ b/qce-v4-tool/components/ui/task-wizard.tsx
@@ -79,6 +79,7 @@ export function TaskWizard({
     filterPureImageMessages: true, // JSON/TXT默认启用
     exportAsZip: false,
     embedAvatarsAsBase64: false,
+    embedResourcesAsDataUri: false, // Issue #311: 自包含 HTML
     streamingZipMode: false, // 流式ZIP导出模式
     outputDir: "", // Issue #192: 自定义导出路径
     useNameInFileName: false, // Issue #216: 文件名包含聊天名称
@@ -120,6 +121,7 @@ export function TaskWizard({
           : defaultFilter,
         exportAsZip: prefilledData.exportAsZip || false,
         embedAvatarsAsBase64: prefilledData.embedAvatarsAsBase64 || false,
+        embedResourcesAsDataUri: prefilledData.embedResourcesAsDataUri || false, // Issue #311
         streamingZipMode: prefilledData.streamingZipMode || false,
         outputDir: prefilledData.outputDir || "",  // Issue #192
         useNameInFileName: prefilledData.useNameInFileName || false,  // Issue #216
@@ -196,6 +198,7 @@ export function TaskWizard({
         filterPureImageMessages: true, // JSON默认启用
         exportAsZip: false,
         embedAvatarsAsBase64: false,
+        embedResourcesAsDataUri: false, // Issue #311
         streamingZipMode: false,
         outputDir: "", // Issue #192: 重置自定义导出路径
         useNameInFileName: false, // Issue #216: 重置文件名包含聊天名称
@@ -1048,6 +1051,15 @@ export function TaskWizard({
                 title: "嵌入头像为Base64",
                 desc: "将发送者头像以Base64格式嵌入JSON文件（仅JSON格式可用，会增加文件大小）",
                 visible: form.format === "JSON"
+              },
+              {
+                // Issue #311: 自包含 HTML
+                id: "embedResourcesAsDataUri",
+                checked: form.embedResourcesAsDataUri || false,
+                set: (v: boolean) => setForm((p) => ({ ...p, embedResourcesAsDataUri: v })),
+                title: "生成自包含 HTML",
+                desc: "将图片、语音、视频、小于 50 MB 的文件以 base64 内联到单个 HTML文件中，不再产出 resources 目录。适合需要单独发送 / 在手机上丢进文件传输查看的场景。资源较多时 HTML 体积会明显增大。",
+                visible: form.format === "HTML" && !form.exportAsZip && !form.streamingZipMode
               }
             ].filter((opt) => opt.visible).map((opt) => (
               <div

--- a/qce-v4-tool/hooks/use-export-tasks.ts
+++ b/qce-v4-tool/hooks/use-export-tasks.ts
@@ -444,6 +444,8 @@ export function useExportTasks(_props?: UseExportTasksProps) {
           prettyFormat: true,
           exportAsZip: form.exportAsZip,
           embedAvatarsAsBase64: form.embedAvatarsAsBase64,
+          // Issue #311: 自包含 HTML（资源 base64 内联）。
+          embedResourcesAsDataUri: form.embedResourcesAsDataUri,
           preferGroupMemberName: form.preferGroupMemberName ?? true,
           ...(form.outputDir?.trim() && { outputDir: form.outputDir.trim() }),
           ...(form.useNameInFileName && { useNameInFileName: true }),

--- a/qce-v4-tool/types/api.ts
+++ b/qce-v4-tool/types/api.ts
@@ -182,6 +182,11 @@ export interface CreateTaskForm {
   exportAsZip?: boolean
   excludeUserUins?: string
   embedAvatarsAsBase64?: boolean
+  /**
+   * Issue #311: HTML 格式专用 — 资源以 base64 内联生成单个自包含 HTML。
+   * 启用后不再导出同级 `resources/` 目录。
+   */
+  embedResourcesAsDataUri?: boolean
   /** 流式ZIP导出模式（专为超大消息量设计，>50万消息推荐使用） */
   streamingZipMode?: boolean
   /** 自定义导出路径（Issue #192） */
@@ -220,6 +225,8 @@ export interface CreateTaskRequest {
     exportAsZip?: boolean
     /** 嵌入头像为Base64 */
     embedAvatarsAsBase64?: boolean
+    /** Issue #311: 自包含 HTML（资源 base64 内联）。 */
+    embedResourcesAsDataUri?: boolean
     /** 自定义导出路径（Issue #192） */
     outputDir?: string
     /** 在文件名中包含聊天名称（Issue #216） */
@@ -318,6 +325,8 @@ export interface ScheduledExport {
     preferGroupMemberName?: boolean
     /** Issue #341: 仅保留元数据、跳过下载的资源类型 */
     skipDownloadResourceTypes?: Array<'image' | 'video' | 'audio' | 'file'>
+    /** Issue #311: 自包含 HTML（资源 base64 内联）。 */
+    embedResourcesAsDataUri?: boolean
   }
   outputDir?: string
   enabled: boolean


### PR DESCRIPTION
## Summary

Issue #311：导出的 HTML 现在可以以单文件形式产出，把图片 / 语音 / 视频 / 文件以 base64 data URI 内联到 HTML 自身，不再带同级 `resources/` 目录。适合在没有附属文件夹的场景（直接发文件、群文件下发、临时分享）下查看。

`ModernHtmlExporter`：
- `HtmlExportOptions` 新增 `embedResourcesAsDataUri`、`maxEmbedFileSizeBytes` 两个字段，默认分别为 `false`、`50 * 1024 * 1024`。
- 新增 `preloadDataUri` / `resolveResourceSourcePath` / `lookupDataUri` / `guessMimeType` 四个私有方法。流程上：开启内联模式后，`exportFromIterable` 不再创建 `resources/` 目录，也不再 `copyResourceFileStream`；改为按消息预加载所有资源并以 `<typeDir>/<basename>` 作为缓存 key 写入 `dataUriCache`。
- `renderImageElement` / `renderAudioElement` / `renderVideoElement` / `renderFileElement` 渲染时优先从 `dataUriCache` 取 data URI，未命中才退回到原 `./resources/<typeDir>/<basename>` 相对路径。这样大于 `maxEmbedFileSizeBytes` 的文件能自然回退为外链而不是丢失。
- `showImageModal` 在内联模式下若直接把 data URI 拼进 `onclick` 属性会让 HTML 体积翻倍，改为 `onclick="showImageModal(this.src)"`，外链 / 内联行为一致。

`ApiServer.ts` / `ScheduledExportManager.ts`：
- 普通导出与定时导出都接受 `embedResourcesAsDataUri` 字段并透传给 `ModernHtmlExporter`。`maxEmbedFileSizeBytes` 仅在请求显式给出时透传，否则使用导出器默认值。

前端：
- `task-wizard.tsx`、`batch-export-dialog.tsx` 在 HTML 格式且未启用 ZIP 模式时显示「生成自包含 HTML」开关，描述说明 50 MB 单资源上限。
- `useExportTasks.createTask` 与批量导出入口 `handleBatchExport` 把开关值带到 `options.embedResourcesAsDataUri`。
- `types/api.ts` 的 `CreateTaskForm` / `CreateTaskRequest` / `ScheduledExport.options` 同步加上字段。

## Review & Testing Checklist for Human

- [ ] 选择一个含少量图片 / 表情 / 短语音的私聊或小群，HTML 格式开启「生成自包含 HTML」导出，确认产物只有一个 `.html` 文件，没有 `resources/` 目录，浏览器中图片 / 语音 / 视频可正常显示与播放。
- [ ] 开启该选项导出含较大文件（如 60 MB 以上的视频或附件）的会话，确认大资源退化为相对路径外链而不是把 HTML 撑爆。
- [ ] 关闭该选项时行为与之前完全一致：仍生成 `resources/` 目录，HTML 中以相对路径引用资源。
- [ ] 定时导出表单 / API（如有自定义客户端）传入 `embedResourcesAsDataUri: true` 时，调度产出的 HTML 能正确内联资源。

测试计划：
1. `npm test` 在 `plugins/qq-chat-exporter` 下运行，包含本 PR 新增的 4 项 `ModernHtmlExporter.embedDataUri.test.ts` 用例。
2. 手动场景：开关开 / 关 各导出一份小聊天，对比 HTML 源码 `data:image/png;base64,` 与 `./resources/images/...` 两种引用是否符合预期。

### Notes
- 不会改变默认行为，未开启选项的所有现有导出（包括分块 HTML、ZIP 打包）行为不动。
- 分块 HTML（多 part 导出）结构上由独立 viewer 组装，本 PR 没有为它启用内联模式，避免与既有架构冲突。