### PR TITLE
fix(scheduler): include chat files in scheduled JSON / JSONL exports (#319)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/JsonExporter.copyResources.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/JsonExporter.copyResources.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Issue #319: 验证 JsonExporter 在拿到 resourceMap 时会把已下载的资源
+ * （包括聊天文件 type='file'）复制到导出目录的 resources/<typeDir>/，
+ * 与 HTML 导出保持一致。
+ *
+ * 这条用例覆盖的是底层契约：只要调用方传入正确的 resourceMap，导出器
+ * 就会把图片 / 视频 / 语音 / 文件落到 outputDir。`ScheduledExportManager`
+ * 之前就是漏传 resourceMap 才导致定时 JSON 不会带文件。
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { JsonExporter } from '../../lib/core/exporter/JsonExporter.js';
+import { createMockCore } from '../helpers/MockNapCatCore.js';
+import { installBridge, uninstallBridge } from '../helpers/installBridge.js';
+import { silenceConsole } from '../helpers/silenceConsole.js';
+import { createTempDir } from '../helpers/tempDir.js';
+
+let console_!: ReturnType<typeof silenceConsole>;
+let tmp!: ReturnType<typeof createTempDir>;
+
+test.beforeEach(() => {
+    console_ = silenceConsole();
+    tmp = createTempDir();
+});
+
+test.afterEach(() => {
+    uninstallBridge();
+    tmp.cleanup();
+    console_.restore();
+});
+
+test('JsonExporter with resourceMap copies file-type resources to <outputDir>/resources/files (#319)', async () => {
+    const core = createMockCore({});
+    installBridge({ core });
+
+    // 模拟 ResourceHandler 落盘的源文件
+    const sourceDir = path.join(tmp.path, 'source');
+    fs.mkdirSync(sourceDir, { recursive: true });
+    const sourceFile = path.join(sourceDir, 'group_doc.pdf');
+    fs.writeFileSync(sourceFile, Buffer.from('PDF-DATA-FOR-TEST'));
+
+    const sourceImage = path.join(sourceDir, 'group_pic.png');
+    fs.writeFileSync(sourceImage, Buffer.from('PNG-DATA-FOR-TEST'));
+
+    const outputDir = path.join(tmp.path, 'out');
+    fs.mkdirSync(outputDir, { recursive: true });
+    const outputPath = path.join(outputDir, 'chat.json');
+
+    const resourceMap = new Map<string, any[]>([
+        [
+            'msg_1',
+            [
+                {
+                    type: 'file',
+                    fileName: 'group_doc.pdf',
+                    localPath: sourceFile,
+                    fileSize: 17
+                },
+                {
+                    type: 'image',
+                    fileName: 'group_pic.png',
+                    localPath: sourceImage,
+                    fileSize: 17
+                }
+            ]
+        ]
+    ]);
+
+    const exporter = new JsonExporter(
+        {
+            outputPath,
+            includeResourceLinks: true,
+            includeSystemMessages: true,
+            filterPureImageMessages: false,
+            prettyFormat: true,
+            timeFormat: 'YYYY-MM-DD HH:mm:ss',
+            encoding: 'utf-8',
+            resourceMap
+        },
+        {},
+        core as any
+    );
+
+    // 没有真实消息也走得通：BaseExporter.copyResourcesAlongsideExport 只看 resourceMap。
+    await exporter.export([] as any, { name: 'Alice', type: 'private' } as any);
+
+    const copiedFile = path.join(outputDir, 'resources', 'files', 'group_doc.pdf');
+    const copiedImage = path.join(outputDir, 'resources', 'images', 'group_pic.png');
+    assert.ok(fs.existsSync(copiedFile), 'group_doc.pdf should be copied to resources/files/');
+    assert.ok(fs.existsSync(copiedImage), 'group_pic.png should be copied to resources/images/');
+    assert.equal(
+        fs.readFileSync(copiedFile, 'utf8'),
+        'PDF-DATA-FOR-TEST',
+        'copied file content matches source'
+    );
+});

--- a/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
+++ b/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
@@ -617,6 +617,10 @@ export class ScheduledExportManager {
                     break;
                 case 'JSON':
                     // JsonExporter 会自己处理消息解析（流式），直接传原始消息
+                    // Issue #319: 透传 resourceMap，让导出后的 JSON / JSONL 能引用到正确的
+                    // 资源相对路径，并把图片 / 视频 / 语音 / 文件复制到 <outputDir>/resources/。
+                    // 之前定时任务漏传 resourceMap，导致定时 JSON 不会落地聊天文件，用户需要
+                    // 同时勾选 HTML 才能拿到群文件等附件。
                     const jsonExporter = new JsonExporter({
                         outputPath: filePath,
                         includeResourceLinks: task.options.includeResourceLinks ?? true,
@@ -625,7 +629,8 @@ export class ScheduledExportManager {
                         prettyFormat: task.options.prettyFormat ?? true,
                         preferGroupMemberName: task.options.preferGroupMemberName ?? true,
                         timeFormat: 'YYYY-MM-DD HH:mm:ss',
-                        encoding: 'utf-8'
+                        encoding: 'utf-8',
+                        resourceMap
                     }, {}, this.core);
                     await jsonExporter.export(allMessages as any, chatInfo);
                     break;


### PR DESCRIPTION
## Summary

Issue #319：用户反馈定时导出 JSON 时拿不到聊天文件，需要同时勾选 HTML 才能附带群文件等附件。

根因：`ScheduledExportManager.executeScheduledExport` 在构造 `JsonExporter` 时漏传 `resourceMap`，于是 `BaseExporter.copyResourcesAlongsideExport` 拿不到任何资源映射，已下载的图片 / 视频 / 语音 / 群文件全部留在 `ResourceHandler` 的全局资源目录里，不会复制到本次导出目录下的 `resources/<typeDir>/`。普通 API 路径下 `ApiServer` 已经在 v5.5.26 (#277 / #391) 把 `resourceMap` 透传给 JSON / JSONL / TXT / Excel 导出器，定时任务一直没跟进。

这个 PR 把 `resourceMap` 透传到定时 JSON / JSONL 导出器（HTML 路径之前已经通过 `parser.parseMessagesStream(allMessages, resourceMap)` 拿到，无需改动）。修复后定时导出的 JSON 旁会自动出现：

```
<sessionName>_<timestamp>.json
resources/
  images/...
  videos/...
  audios/...
  files/...
```

## Review & Testing Checklist for Human

- [ ] 设置一个会话的定时 JSON 导出，覆盖一段含聊天文件 / 群文件 / 图片的时间窗口，触发执行后确认导出目录下出现 `resources/files/<群文件名>` 等子目录。
- [ ] JSON 内的 `localPath` / `resourcePath` 字段指向 `./resources/files/<群文件名>` 的相对路径能在 Chatlab 等下游工具中加载。
- [ ] 旧任务（`skipDownloadResourceTypes` 包含 `file` 或 `skipFileDownload=true`）行为保持不变：跳过的资源不会被下载也不会被复制。
- [ ] 普通（非定时）JSON 导出行为没有回归。

测试计划：
1. `npm test` 在 `plugins/qq-chat-exporter` 下，包含本 PR 新增的 `JsonExporter.copyResources.test.ts`，验证 `resourceMap` 中的 file / image 资源会被写入 `resources/files`、`resources/images`。
2. 手动定时任务回放：触发一次 JSON 定时导出，检查导出目录是否出现 `resources/` 子目录。

### Notes
- TextExporter 没有调用 `copyResourcesAlongsideExport`，本 PR 不动它，避免在文本格式下做没意义的资源复制。
- 与 #311 自包含 HTML 是两条独立通路：本 PR 只处理外链资源被漏复制的情况。