### PR TITLE
feat(api): add friendly export filename format `<name>(<qq>).<ext>` (#134)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/exportFileName.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/exportFileName.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Issue #134: 导出文件名生成 / 友好命名 / 同名去重的单元测试。
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+
+import {
+    sanitizeChatNameForFileName,
+    buildExportFileName,
+    buildExportDirName,
+    disambiguateExportFileName,
+} from '../../lib/utils/exportFileName.js';
+
+test('sanitizeChatNameForFileName 移除非法字符并合并下划线', () => {
+    assert.equal(sanitizeChatNameForFileName('a/b\\c:d?e*f|g'), 'a_b_c_d_e_f_g');
+    assert.equal(sanitizeChatNameForFileName('   foo bar   '), 'foo_bar');
+    assert.equal(sanitizeChatNameForFileName('___leading_trailing___'), 'leading_trailing');
+});
+
+test('sanitizeChatNameForFileName 截断到指定长度且不以下划线结尾', () => {
+    const long = 'a'.repeat(60) + '_' + 'b'.repeat(60);
+    const out = sanitizeChatNameForFileName(long, 50);
+    assert.equal(out.length, 50);
+    assert.ok(!out.endsWith('_'));
+});
+
+test('buildExportFileName 默认使用 prefix_QQ_date_time.ext (#216 关闭时)', () => {
+    const fn = buildExportFileName({
+        chatTypePrefix: 'friend',
+        peerUid: '12345',
+        sessionName: 'Alice',
+        dateStr: '20260101',
+        timeStr: '120000',
+        extension: 'html',
+    });
+    assert.equal(fn, 'friend_12345_20260101_120000.html');
+});
+
+test('buildExportFileName useNameInFileName 走 #216 旧格式', () => {
+    const fn = buildExportFileName({
+        chatTypePrefix: 'group',
+        peerUid: '99887766',
+        sessionName: '我的群聊',
+        dateStr: '20260101',
+        timeStr: '120000',
+        extension: 'html',
+        useNameInFileName: true,
+    });
+    assert.equal(fn, 'group_我的群聊_99887766_20260101_120000.html');
+});
+
+test('buildExportFileName useFriendlyFileName 输出 `<名称>(<QQ号>).<ext>` (#134)', () => {
+    const fn = buildExportFileName({
+        chatTypePrefix: 'friend',
+        peerUid: '12345',
+        sessionName: 'Alice',
+        dateStr: '20260101',
+        timeStr: '120000',
+        extension: 'html',
+        useFriendlyFileName: true,
+    });
+    assert.equal(fn, 'Alice(12345).html');
+});
+
+test('buildExportFileName useFriendlyFileName 优先级高于 useNameInFileName', () => {
+    const fn = buildExportFileName({
+        chatTypePrefix: 'group',
+        peerUid: '99887766',
+        sessionName: '研发组',
+        dateStr: '20260101',
+        timeStr: '120000',
+        extension: 'html',
+        useNameInFileName: true,
+        useFriendlyFileName: true,
+    });
+    assert.equal(fn, '研发组(99887766).html');
+});
+
+test('buildExportFileName useFriendlyFileName 缺 sessionName 时退回默认', () => {
+    const fn = buildExportFileName({
+        chatTypePrefix: 'friend',
+        peerUid: '12345',
+        sessionName: '12345', // 等于 peerUid，视作没有可用名称
+        dateStr: '20260101',
+        timeStr: '120000',
+        extension: 'html',
+        useFriendlyFileName: true,
+    });
+    assert.equal(fn, 'friend_12345_20260101_120000.html');
+});
+
+test('buildExportDirName useFriendlyFileName 与文件名一致 (suffix 在末尾)', () => {
+    const dir = buildExportDirName({
+        chatTypePrefix: 'group',
+        peerUid: '99887766',
+        sessionName: '研发组',
+        dateStr: '20260101',
+        timeStr: '120000',
+        suffix: '_chunked_jsonl',
+        useFriendlyFileName: true,
+    });
+    assert.equal(dir, '研发组(99887766)_chunked_jsonl');
+});
+
+test('disambiguateExportFileName 不存在时原样返回', () => {
+    const out = disambiguateExportFileName(
+        '/tmp/out',
+        'Alice(12345).html',
+        '20260101',
+        '120000',
+        () => false
+    );
+    assert.equal(out, 'Alice(12345).html');
+});
+
+test('disambiguateExportFileName 存在时追加 _<日期>_<时间> 后缀，扩展名保留', () => {
+    const out = disambiguateExportFileName(
+        '/tmp/out',
+        'Alice(12345).html',
+        '20260101',
+        '120000',
+        (p) => p === path.join('/tmp/out', 'Alice(12345).html')
+    );
+    assert.equal(out, 'Alice(12345)_20260101_120000.html');
+});
+
+test('disambiguateExportFileName 没有扩展名时把后缀直接拼到末尾', () => {
+    const out = disambiguateExportFileName(
+        '/tmp/out',
+        'AliceWithoutExt',
+        '20260101',
+        '120000',
+        () => true
+    );
+    assert.equal(out, 'AliceWithoutExt_20260101_120000');
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -36,6 +36,12 @@ import { ZipExporter } from '../utils/ZipExporter.js';
 import { StreamingZipExporter } from '../utils/StreamingZipExporter.js';
 import { VERSION, APP_INFO } from '../version.js';
 import { PathManager } from '../utils/PathManager.js';
+import {
+    buildExportFileName,
+    buildExportDirName,
+    disambiguateExportFileName,
+    sanitizeChatNameForFileName,
+} from '../utils/exportFileName.js';
 import { resolvePeerUid } from './peerResolution.js';
 
 // 导入类型定义
@@ -2043,13 +2049,19 @@ export class QQChatExporterApiServer {
                     }
                 }
 
-                // Issue #216: 根据用户选项生成文件名（可选包含聊天名称）
+                // Issue #216 / #134: 根据用户选项生成文件名（可选包含聊天名称 / 友好命名）
                 const useNameInFileName = options?.useNameInFileName === true;
-                const fileName = this.generateExportFileName(
+                const useFriendlyFileName = options?.useFriendlyFileName === true;
+                const baseFileName = this.generateExportFileName(
                     chatTypePrefix, actualPeer.peerUid, sessionName,
-                    dateStr, timeStr, fileExt, useNameInFileName
+                    dateStr, timeStr, fileExt, useNameInFileName, useFriendlyFileName
                 );
-                
+                // Issue #134: 友好命名不带时间戳，多次导出会同名碰撞，这里加一层
+                // 唯一化处理（主流程里只做这一处，其它路径走原逻辑）。
+                const fileName = useFriendlyFileName
+                    ? this.disambiguateExportFileName(outputDir, baseFileName, dateStr, timeStr)
+                    : baseFileName;
+
                 const filePath = path.join(outputDir, fileName);
                 const downloadUrl = this.generateDownloadUrl(filePath, fileName, customOutputDir);
 
@@ -2159,11 +2171,12 @@ export class QQChatExporterApiServer {
                     }
                 }
 
-                // Issue #216: 根据用户选项生成文件名（可选包含聊天名称）
+                // Issue #216 / #134: 根据用户选项生成文件名（可选包含聊天名称 / 友好命名）
                 const useNameInFileName = options?.useNameInFileName === true;
+                const useFriendlyFileName = options?.useFriendlyFileName === true;
                 const fileName = this.generateExportFileName(
                     chatTypePrefix, actualPeer.peerUid, sessionName,
-                    dateStr, timeStr, 'zip', useNameInFileName
+                    dateStr, timeStr, 'zip', useNameInFileName, useFriendlyFileName
                 ).replace(/\.zip$/, '_streaming.zip');  // 添加 _streaming 后缀（只替换末尾）
                 
                 const filePath = path.join(outputDir, fileName);
@@ -2276,11 +2289,12 @@ export class QQChatExporterApiServer {
                     }
                 }
 
-                // Issue #216: 根据用户选项生成目录名（可选包含聊天名称）
+                // Issue #216 / #134: 根据用户选项生成目录名（可选包含聊天名称 / 友好命名）
                 const useNameInFileName = options?.useNameInFileName === true;
+                const useFriendlyFileName = options?.useFriendlyFileName === true;
                 const dirName = this.generateExportDirName(
                     chatTypePrefix, actualPeer.peerUid, sessionName,
-                    dateStr, timeStr, '_chunked_jsonl', useNameInFileName
+                    dateStr, timeStr, '_chunked_jsonl', useNameInFileName, useFriendlyFileName
                 );
                 
                 const dirPath = path.join(outputDir, dirName);
@@ -5045,30 +5059,11 @@ export class QQChatExporterApiServer {
     }
 
     /**
-     * Issue #216: 安全处理聊天名称，用于文件名
-     * 移除文件名非法字符，限制长度，确保文件系统兼容性
-     * @param name 原始聊天名称
-     * @param maxLength 最大长度，默认50字符
-     * @returns 安全的文件名部分
+     * Issue #216: 安全处理聊天名称，用于文件名。
+     * 实际逻辑放在 utils/exportFileName.ts 里以便单元测试覆盖。
      */
     private sanitizeChatNameForFileName(name: string, maxLength: number = 50): string {
-        if (!name) return '';
-        // 移除文件名非法字符: < > : " / \ | ? *
-        // 同时移除控制字符和其他可能导致问题的字符
-        let safeName = name
-            .replace(/[<>:"/\\|?*\x00-\x1f]/g, '_')  // 替换非法字符为下划线
-            .replace(/\s+/g, '_')                     // 替换空白字符为下划线
-            .replace(/_+/g, '_')                      // 合并连续下划线
-            .replace(/^_|_$/g, '');                   // 移除首尾下划线
-        
-        // 限制长度
-        if (safeName.length > maxLength) {
-            safeName = safeName.slice(0, maxLength);
-            // 确保不以下划线结尾
-            safeName = safeName.replace(/_+$/, '');
-        }
-        
-        return safeName;
+        return sanitizeChatNameForFileName(name, maxLength);
     }
 
     /**
@@ -5090,17 +5085,33 @@ export class QQChatExporterApiServer {
         dateStr: string,
         timeStr: string,
         extension: string,
-        useNameInFileName: boolean = false
+        useNameInFileName: boolean = false,
+        useFriendlyFileName: boolean = false
     ): string {
-        if (useNameInFileName && sessionName && sessionName !== peerUid) {
-            const safeName = this.sanitizeChatNameForFileName(sessionName);
-            if (safeName) {
-                // 格式: group_群名_QQ号_日期_时间.扩展名
-                return `${chatTypePrefix}_${safeName}_${peerUid}_${dateStr}_${timeStr}.${extension}`;
-            }
-        }
-        // 默认格式: group_QQ号_日期_时间.扩展名
-        return `${chatTypePrefix}_${peerUid}_${dateStr}_${timeStr}.${extension}`;
+        return buildExportFileName({
+            chatTypePrefix,
+            peerUid,
+            sessionName,
+            dateStr,
+            timeStr,
+            extension,
+            useNameInFileName,
+            useFriendlyFileName,
+        });
+    }
+
+    /**
+     * Issue #134: 友好命名（`<名称>(<QQ号>).<ext>`）不带时间戳，重复导出会撞名。
+     * 当目标目录里已经存在同名文件时，附加 `_<dateStr>_<timeStr>` 作为去重后缀。
+     * 不存在或友好命名未启用时直接返回原文件名。
+     */
+    private disambiguateExportFileName(
+        outputDir: string,
+        fileName: string,
+        dateStr: string,
+        timeStr: string
+    ): string {
+        return disambiguateExportFileName(outputDir, fileName, dateStr, timeStr);
     }
 
     /**
@@ -5112,6 +5123,7 @@ export class QQChatExporterApiServer {
      * @param timeStr 时间字符串 (HHMMSS)
      * @param suffix 目录后缀 (如 _chunked_jsonl)
      * @param useNameInFileName 是否在目录名中包含聊天名称
+     * @param useFriendlyFileName 是否使用 Issue #134 的友好命名
      * @returns 生成的目录名
      */
     private generateExportDirName(
@@ -5121,17 +5133,19 @@ export class QQChatExporterApiServer {
         dateStr: string,
         timeStr: string,
         suffix: string,
-        useNameInFileName: boolean = false
+        useNameInFileName: boolean = false,
+        useFriendlyFileName: boolean = false
     ): string {
-        if (useNameInFileName && sessionName && sessionName !== peerUid) {
-            const safeName = this.sanitizeChatNameForFileName(sessionName);
-            if (safeName) {
-                // 格式: group_群名_QQ号_日期_时间_后缀
-                return `${chatTypePrefix}_${safeName}_${peerUid}_${dateStr}_${timeStr}${suffix}`;
-            }
-        }
-        // 默认格式: group_QQ号_日期_时间_后缀
-        return `${chatTypePrefix}_${peerUid}_${dateStr}_${timeStr}${suffix}`;
+        return buildExportDirName({
+            chatTypePrefix,
+            peerUid,
+            sessionName,
+            dateStr,
+            timeStr,
+            suffix,
+            useNameInFileName,
+            useFriendlyFileName,
+        });
     }
     
     /**

--- a/plugins/qq-chat-exporter/lib/utils/exportFileName.ts
+++ b/plugins/qq-chat-exporter/lib/utils/exportFileName.ts
@@ -1,0 +1,131 @@
+/**
+ * Export filename utilities.
+ *
+ * 提供给 ApiServer 与定时任务复用的文件名生成 / 去重逻辑：
+ * - {@link sanitizeChatNameForFileName} 把会话名称裁剪成跨平台安全的文件名片段。
+ * - {@link buildExportFileName} 根据用户选项产出最终文件名（包含 Issue #134 的友好命名）。
+ * - {@link buildExportDirName} 用于 chunked_jsonl 等目录格式。
+ * - {@link disambiguateExportFileName} 在友好命名碰撞时追加 `_<日期>_<时间>` 后缀。
+ *
+ * 这些函数是纯函数（disambiguate 仅依赖一个 exists 探针），方便单元测试覆盖。
+ */
+
+import path from 'path';
+import fs from 'fs';
+
+const ILLEGAL_FILENAME_CHARS = /[<>:"/\\|?*\u0000-\u001f]/g;
+
+/**
+ * 把会话名称压成安全文件名片段：
+ * - 移除 Windows / POSIX 都禁用的字符与控制字符；
+ * - 把空白与连续下划线压平；
+ * - 限制长度，避免触发 OS 文件名上限。
+ */
+export function sanitizeChatNameForFileName(name: string, maxLength: number = 50): string {
+    if (!name) return '';
+    let safe = String(name)
+        .replace(ILLEGAL_FILENAME_CHARS, '_')
+        .replace(/\s+/g, '_')
+        .replace(/_+/g, '_')
+        .replace(/^_|_$/g, '');
+    if (safe.length > maxLength) {
+        safe = safe.slice(0, maxLength).replace(/_+$/, '');
+    }
+    return safe;
+}
+
+export interface BuildExportFileNameOptions {
+    /** 业务前缀，例如 friend / group。 */
+    chatTypePrefix: string;
+    /** 对方 UID（一般就是 QQ 号）。 */
+    peerUid: string;
+    /** 会话名称；为空 / 等于 peerUid 时退回默认格式。 */
+    sessionName: string;
+    /** YYYYMMDD。 */
+    dateStr: string;
+    /** HHMMSS。 */
+    timeStr: string;
+    /** 文件扩展名，不含点。 */
+    extension: string;
+    /** Issue #216 — 在文件名中带聊天名称。 */
+    useNameInFileName?: boolean;
+    /** Issue #134 — 友好命名 `<名称>(<QQ号>).<ext>`。优先级高于 useNameInFileName。 */
+    useFriendlyFileName?: boolean;
+}
+
+/**
+ * 根据选项产出最终文件名。
+ *
+ * 优先级：useFriendlyFileName > useNameInFileName > 默认。
+ *
+ * 友好命名缺少可用 sessionName 时退回默认格式而非崩溃。
+ */
+export function buildExportFileName(opts: BuildExportFileNameOptions): string {
+    const { chatTypePrefix, peerUid, sessionName, dateStr, timeStr, extension } = opts;
+    if (opts.useFriendlyFileName && sessionName && sessionName !== peerUid) {
+        const safeName = sanitizeChatNameForFileName(sessionName);
+        if (safeName) {
+            return `${safeName}(${peerUid}).${extension}`;
+        }
+    }
+    if (opts.useNameInFileName && sessionName && sessionName !== peerUid) {
+        const safeName = sanitizeChatNameForFileName(sessionName);
+        if (safeName) {
+            return `${chatTypePrefix}_${safeName}_${peerUid}_${dateStr}_${timeStr}.${extension}`;
+        }
+    }
+    return `${chatTypePrefix}_${peerUid}_${dateStr}_${timeStr}.${extension}`;
+}
+
+export interface BuildExportDirNameOptions extends Omit<BuildExportFileNameOptions, 'extension'> {
+    /** 例如 _chunked_jsonl，会原样附加在末尾。 */
+    suffix: string;
+}
+
+/** 与 {@link buildExportFileName} 同族，但用于目录名（不带扩展名）。 */
+export function buildExportDirName(opts: BuildExportDirNameOptions): string {
+    const { chatTypePrefix, peerUid, sessionName, dateStr, timeStr, suffix } = opts;
+    if (opts.useFriendlyFileName && sessionName && sessionName !== peerUid) {
+        const safeName = sanitizeChatNameForFileName(sessionName);
+        if (safeName) {
+            return `${safeName}(${peerUid})${suffix}`;
+        }
+    }
+    if (opts.useNameInFileName && sessionName && sessionName !== peerUid) {
+        const safeName = sanitizeChatNameForFileName(sessionName);
+        if (safeName) {
+            return `${chatTypePrefix}_${safeName}_${peerUid}_${dateStr}_${timeStr}${suffix}`;
+        }
+    }
+    return `${chatTypePrefix}_${peerUid}_${dateStr}_${timeStr}${suffix}`;
+}
+
+/**
+ * Issue #134：友好命名不带时间戳，重复导出会撞名。
+ *
+ * 当目标目录里已经存在同名文件时，附加 `_<dateStr>_<timeStr>` 作为去重后缀，
+ * 否则保持原文件名。`exists` 默认走 `fs.existsSync`，便于单元测试注入桩。
+ */
+export function disambiguateExportFileName(
+    outputDir: string,
+    fileName: string,
+    dateStr: string,
+    timeStr: string,
+    exists: (p: string) => boolean = fs.existsSync
+): string {
+    try {
+        const fullPath = path.join(outputDir, fileName);
+        if (!exists(fullPath)) {
+            return fileName;
+        }
+        const dotIdx = fileName.lastIndexOf('.');
+        if (dotIdx <= 0) {
+            return `${fileName}_${dateStr}_${timeStr}`;
+        }
+        const base = fileName.slice(0, dotIdx);
+        const ext = fileName.slice(dotIdx);
+        return `${base}_${dateStr}_${timeStr}${ext}`;
+    } catch {
+        return fileName;
+    }
+}

--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -828,6 +828,8 @@ export default function QCEDashboard() {
           keywords: config.keywords,
           excludeUserUins: config.excludeUserUins,
           useNameInFileName: config.useNameInFileName,
+          // Issue #134: 友好文件名格式
+          useFriendlyFileName: config.useFriendlyFileName,
           // Issue #341
           ...(Array.isArray(config.skipDownloadResourceTypes) && config.skipDownloadResourceTypes.length > 0 && {
             skipDownloadResourceTypes: config.skipDownloadResourceTypes,

--- a/qce-v4-tool/components/ui/batch-export-dialog.tsx
+++ b/qce-v4-tool/components/ui/batch-export-dialog.tsx
@@ -47,6 +47,8 @@ export interface BatchExportConfig {
   keywords: string
   excludeUserUins: string
   useNameInFileName: boolean
+  /** Issue #134: 友好文件名格式 `<名称>(<QQ号>).<扩展名>` */
+  useFriendlyFileName?: boolean
 }
 
 export interface BatchExportProgress {
@@ -84,6 +86,8 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
   const [keywords, setKeywords] = useState('')
   const [excludeUserUins, setExcludeUserUins] = useState('')
   const [useNameInFileName, setUseNameInFileName] = useState(true)
+  // Issue #134: 友好文件名格式
+  const [useFriendlyFileName, setUseFriendlyFileName] = useState(false)
   
   const [progress, setProgress] = useState<BatchExportProgress>({
     current: 0,
@@ -114,6 +118,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
       setKeywords('')
       setExcludeUserUins('')
       setUseNameInFileName(true)
+      setUseFriendlyFileName(false)
       setProgress({
         current: 0,
         total: items.length,
@@ -205,7 +210,8 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
       outputDir,
       keywords,
       excludeUserUins,
-      useNameInFileName
+      useNameInFileName,
+      useFriendlyFileName
     }
 
     try {
@@ -432,7 +438,26 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
                     { id: "skipFileDownloadOnly", checked: skipFileDownloadOnly, set: setSkipFileDownloadOnly, title: "仅保留文件元数据，不下载文件", desc: "图片 / 视频 / 音频仍正常下载；只有文件类资源（群文件、聊天发送的文档等）只保留文件名、大小、MD5 等元信息。", visible: !filterPureImageMessages, highlight: false },
                     { id: "preferGroupMemberName", checked: preferGroupMemberName, set: setPreferGroupMemberName, title: "优先使用群成员名称", desc: "群聊导出时优先使用群名片或群内名称。关闭后会改用 QQ 昵称或 QQ 号。这个选项仅对群聊生效。", visible: true, highlight: false },
                     { id: "exportAsZip", checked: exportAsZip, set: setExportAsZip, title: "导出为ZIP压缩包", desc: "将HTML文件和资源文件打包为ZIP格式（仅HTML格式可用）", visible: format === "HTML" && !streamingZipMode, highlight: false },
-                    { id: "useNameInFileName", checked: useNameInFileName, set: setUseNameInFileName, title: "文件名包含聊天名称", desc: "导出文件名中包含聊天对象的名称，方便识别", visible: true, highlight: false },
+                    {
+                      id: "useNameInFileName",
+                      checked: useNameInFileName,
+                      // Issue #134: 与友好命名互斥，避免输出双重前缀。
+                      set: (v: boolean) => { setUseNameInFileName(v); if (v) setUseFriendlyFileName(false); },
+                      title: "文件名包含聊天名称",
+                      desc: "导出文件名中包含聊天对象的名称，方便识别",
+                      visible: true,
+                      highlight: false,
+                    },
+                    {
+                      // Issue #134: 友好命名 `名称(QQ号).<ext>`
+                      id: "useFriendlyFileName",
+                      checked: useFriendlyFileName,
+                      set: (v: boolean) => { setUseFriendlyFileName(v); if (v) setUseNameInFileName(false); },
+                      title: "使用友好命名（名称(QQ号).html）",
+                      desc: "导出文件名使用 `名称(QQ号).<扩展名>` 格式，去掉前缀与时间戳；同名碰撞时自动追加 `_<日期>_<时间>` 后缀。与「文件名包含聊天名称」互斥。",
+                      visible: true,
+                      highlight: false,
+                    },
                     { id: "embedAvatarsAsBase64", checked: embedAvatarsAsBase64, set: setEmbedAvatarsAsBase64, title: "嵌入头像为Base64", desc: "将发送者头像以Base64格式嵌入JSON文件（仅JSON格式可用，会增加文件大小）", visible: format === "JSON", highlight: false },
                     // Issue #311: 自包含 HTML
                     { id: "embedResourcesAsDataUri", checked: embedResourcesAsDataUri, set: setEmbedResourcesAsDataUri, title: "生成自包含 HTML", desc: "将图片、语音、视频、小于 50 MB 的文件以 base64 内联到单个 HTML中，不再产出 resources 目录。适合需要单独发送的场景。", visible: format === "HTML" && !exportAsZip && !streamingZipMode, highlight: false }

--- a/qce-v4-tool/components/ui/task-wizard.tsx
+++ b/qce-v4-tool/components/ui/task-wizard.tsx
@@ -83,6 +83,7 @@ export function TaskWizard({
     streamingZipMode: false, // 流式ZIP导出模式
     outputDir: "", // Issue #192: 自定义导出路径
     useNameInFileName: false, // Issue #216: 文件名包含聊天名称
+    useFriendlyFileName: false, // Issue #134: 友好文件名格式 `<名称>(<QQ号>).<扩展名>`
     preferGroupMemberName: true, // Issue #358: 群聊优先使用群成员名称
   })
 
@@ -125,6 +126,7 @@ export function TaskWizard({
         streamingZipMode: prefilledData.streamingZipMode || false,
         outputDir: prefilledData.outputDir || "",  // Issue #192
         useNameInFileName: prefilledData.useNameInFileName || false,  // Issue #216
+        useFriendlyFileName: prefilledData.useFriendlyFileName || false,  // Issue #134
         preferGroupMemberName: prefilledData.preferGroupMemberName !== undefined ? prefilledData.preferGroupMemberName : true,
       })
     }
@@ -202,6 +204,7 @@ export function TaskWizard({
         streamingZipMode: false,
         outputDir: "", // Issue #192: 重置自定义导出路径
         useNameInFileName: false, // Issue #216: 重置文件名包含聊天名称
+        useFriendlyFileName: false, // Issue #134: 重置友好文件名格式
         preferGroupMemberName: true, // Issue #358: 重置群成员名称选项
       })
     }
@@ -1039,9 +1042,29 @@ export function TaskWizard({
               {
                 id: "useNameInFileName",
                 checked: form.useNameInFileName || false,
-                set: (v: boolean) => setForm((p) => ({ ...p, useNameInFileName: v })),
+                set: (v: boolean) =>
+                  setForm((p) => ({
+                    ...p,
+                    useNameInFileName: v,
+                    // 两种命名互斥：选上带名称后关掉友好命名，避免不一致。
+                    useFriendlyFileName: v ? false : p.useFriendlyFileName,
+                  })),
                 title: "文件名包含聊天名称",
                 desc: "在导出文件名中包含群名或好友昵称，方便批量导出后识别文件",
+                visible: true
+              },
+              {
+                // Issue #134: 友好文件名格式
+                id: "useFriendlyFileName",
+                checked: form.useFriendlyFileName || false,
+                set: (v: boolean) =>
+                  setForm((p) => ({
+                    ...p,
+                    useFriendlyFileName: v,
+                    useNameInFileName: v ? false : p.useNameInFileName,
+                  })),
+                title: "使用友好命名（名称(QQ号).html）",
+                desc: "导出文件名使用 `名称(QQ号).<扩展名>` 格式，去掉 friend_/group_ 前缀与时间戳。多次导出同一会话同名碰撞时，会自动追加 `_<日期>_<时间>` 后缀避免覆盖。启用后与「文件名包含聊天名称」互斥。",
                 visible: true
               },
               {

--- a/qce-v4-tool/hooks/use-export-tasks.ts
+++ b/qce-v4-tool/hooks/use-export-tasks.ts
@@ -449,6 +449,8 @@ export function useExportTasks(_props?: UseExportTasksProps) {
           preferGroupMemberName: form.preferGroupMemberName ?? true,
           ...(form.outputDir?.trim() && { outputDir: form.outputDir.trim() }),
           ...(form.useNameInFileName && { useNameInFileName: true }),
+          // Issue #134: 友好文件名格式 `<名称>(<QQ号>).<扩展名>`
+          ...(form.useFriendlyFileName && { useFriendlyFileName: true }),
           ...(Array.isArray(form.skipDownloadResourceTypes) && form.skipDownloadResourceTypes.length > 0 && {
             skipDownloadResourceTypes: form.skipDownloadResourceTypes,
           }),

--- a/qce-v4-tool/types/api.ts
+++ b/qce-v4-tool/types/api.ts
@@ -193,6 +193,12 @@ export interface CreateTaskForm {
   outputDir?: string
   /** 在文件名中包含聊天名称（Issue #216） */
   useNameInFileName?: boolean
+  /**
+   * 使用友好文件名格式 `<名称>(<QQ号>).<扩展名>`（Issue #134）。
+   * 启用后丢掉业务前缀与时间戳；同名碰撞时会自动追加 `_<日期>_<时间>` 后缀。
+   * 优先级高于 useNameInFileName；缺少可用 sessionName 时退回默认名称。
+   */
+  useFriendlyFileName?: boolean
   /** 群聊导出时优先使用群成员名称（Issue #358） */
   preferGroupMemberName?: boolean
   /**
@@ -231,6 +237,8 @@ export interface CreateTaskRequest {
     outputDir?: string
     /** 在文件名中包含聊天名称（Issue #216） */
     useNameInFileName?: boolean
+    /** 使用友好文件名格式 `<名称>(<QQ号>).<扩展名>`（Issue #134） */
+    useFriendlyFileName?: boolean
     /** 群聊导出时优先使用群成员名称（Issue #358） */
     preferGroupMemberName?: boolean
     /** 仅保留元数据、跳过下载的资源类型（Issue #341） */


### PR DESCRIPTION
## Summary

Issue #134 第 3 条意见：HTML 等导出文件名期望按 `好友名称(QQ号).html` 输出，而不是当前的 `friend_<uid>_<日期>_<时间>.html` 一长串字母数字。`useNameInFileName`（#216）只是再多塞一段名称，并没有覆盖这个诉求。

这个 PR 新增导出选项 `useFriendlyFileName`：

- 启用后文件名 / chunked 目录名采用 `<安全名称>(<QQ号>).<扩展名>` 格式，丢掉 `friend_` / `group_` 前缀和时间戳。
- 多次导出同一会话同名碰撞时，自动追加 `_<日期>_<时间>` 后缀避免覆盖（`Alice(12345).html` → `Alice(12345)_20260101_120000.html`）。
- 与 `useNameInFileName` 互斥（前端 UI 已经做单选），同时打开时友好命名优先。
- 缺少可用 `sessionName`（或 sessionName 等于 peerUid）时退回原默认名称，行为不变。

实现把命名 / 去重逻辑拆到独立的 `lib/utils/exportFileName.ts` 纯函数模块（`buildExportFileName` / `buildExportDirName` / `disambiguateExportFileName` / `sanitizeChatNameForFileName`），`ApiServer` 的同名 private 方法改为薄壳。这一来单元测试不需要起 ApiServer 也能覆盖，二来后续要在定时任务里复用同一套规则也方便。

## Frontend

- 单任务向导和批量导出对话框各新增「使用友好命名」勾选项，描述说明同名碰撞处理；与「文件名包含聊天名称」单选互斥。
- `CreateTaskForm` / `CreateTaskRequest` / `BatchExportConfig` 类型同步加 `useFriendlyFileName` 字段；提交参数里只在用户勾选时才透传，避免影响默认行为。

## Tests

- 新增 `__tests__/unit/exportFileName.test.ts` 11 项，覆盖 sanitize、友好命名优先级、缺名退回、同名去重、目录名后缀。
- `npm test` 在 `plugins/qq-chat-exporter` 下 71/71 通过。
- 前端 `npx tsc --noEmit` 无 error。

### Notes

- 当前 PR 只覆盖手动 / 批量导出主流程；定时任务（`ScheduledExportManager`）使用了独立的命名逻辑，没在这里同步改，避免影响范围放大。
- Issue #134 第 1 条（会话筛选 / 排序）会在 #344 一并处理，第 2 条（HTML 跳过文件下载）已由 #341 覆盖，第 4 条（本地直接打开 HTML 显示资源）已在 v4.9.9 修复。