### PR TITLE
feat(merge): support merging manual export tasks (#163)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/manualExportFileName.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/manualExportFileName.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Issue #163: 手动导出文件名解析的单元测试。
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    parseManualExportFileName,
+    manualExportGroupKey,
+} from '../../lib/utils/manualExportFileName.js';
+
+test('parseManualExportFileName 解析默认格式 friend_<uid>_<date>_<time>.html', () => {
+    const r = parseManualExportFileName('friend_12345_20260101_120000.html');
+    assert.ok(r);
+    assert.equal(r!.chatType, 'friend');
+    assert.equal(r!.peerUid, '12345');
+    assert.equal(r!.sessionName, null);
+    assert.equal(r!.timestamp, '20260101-120000');
+    assert.equal(r!.extension, 'html');
+});
+
+test('parseManualExportFileName 解析 group_<uid>_<date>_<time>.json', () => {
+    const r = parseManualExportFileName('group_99887766_20260101_120000.json');
+    assert.ok(r);
+    assert.equal(r!.chatType, 'group');
+    assert.equal(r!.peerUid, '99887766');
+    assert.equal(r!.extension, 'json');
+});
+
+test('parseManualExportFileName 解析 #216 命名 group_<name>_<uid>_<date>_<time>.html', () => {
+    const r = parseManualExportFileName('group_研发组_99887766_20260101_120000.html');
+    assert.ok(r);
+    assert.equal(r!.chatType, 'group');
+    assert.equal(r!.sessionName, '研发组');
+    assert.equal(r!.peerUid, '99887766');
+});
+
+test('parseManualExportFileName 解析 #134 友好命名 <name>(<uid>).html', () => {
+    const r = parseManualExportFileName('Alice(12345).html');
+    assert.ok(r);
+    assert.equal(r!.peerUid, '12345');
+    assert.equal(r!.sessionName, 'Alice');
+    assert.equal(r!.timestamp, null);
+});
+
+test('parseManualExportFileName 解析 #134 碰撞命名 <name>(<uid>)_<date>_<time>.html', () => {
+    const r = parseManualExportFileName('Alice(12345)_20260101_120000.html');
+    assert.ok(r);
+    assert.equal(r!.peerUid, '12345');
+    assert.equal(r!.sessionName, 'Alice');
+    assert.equal(r!.timestamp, '20260101-120000');
+});
+
+test('parseManualExportFileName 不识别 jsonl / xlsx / txt 等不可合并的扩展名', () => {
+    assert.equal(parseManualExportFileName('friend_12345_20260101_120000.jsonl'), null);
+    assert.equal(parseManualExportFileName('Alice(12345).xlsx'), null);
+    assert.equal(parseManualExportFileName('group_99887766_20260101_120000.txt'), null);
+});
+
+test('parseManualExportFileName 不识别完全无规则的文件名', () => {
+    assert.equal(parseManualExportFileName('random_file.html'), null);
+    assert.equal(parseManualExportFileName('export.html'), null);
+});
+
+test('manualExportGroupKey 把同一 uid 的默认 / #216 命名分到一起', () => {
+    const a = parseManualExportFileName('friend_12345_20260101_120000.html')!;
+    const b = parseManualExportFileName('friend_Alice_12345_20260102_130000.html')!;
+    assert.equal(manualExportGroupKey(a), manualExportGroupKey(b));
+});
+
+test('manualExportGroupKey 把不同 chatType 但相同 uid 分开', () => {
+    const a = parseManualExportFileName('friend_12345_20260101_120000.html')!;
+    const b = parseManualExportFileName('group_12345_20260101_120000.html')!;
+    assert.notEqual(manualExportGroupKey(a), manualExportGroupKey(b));
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -42,6 +42,10 @@ import {
     disambiguateExportFileName,
     sanitizeChatNameForFileName,
 } from '../utils/exportFileName.js';
+import {
+    parseManualExportFileName,
+    manualExportGroupKey,
+} from '../utils/manualExportFileName.js';
 import { resolvePeerUid } from './peerResolution.js';
 
 // 导入类型定义
@@ -2918,12 +2922,84 @@ export class QQChatExporterApiServer {
                     taskName,
                     backupCount: backups.length,
                     backups: backups.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
-                    latestBackup: backups.reduce((latest, current) => 
+                    latestBackup: backups.reduce((latest, current) =>
                         new Date(current.createdAt) > new Date(latest.createdAt) ? current : latest
                     )
                 })).sort((a, b) => new Date(b.latestBackup.createdAt).getTime() - new Date(a.latestBackup.createdAt).getTime());
 
-                this.sendSuccessResponse(res, { scheduledTasks }, (req as any).requestId);
+                // Issue #163: 同时扫描手动导出目录，把每个会话的多次导出聚到一起，
+                // 让用户能像合并定时备份一样合并手动导出。
+                const manualBackups: Array<{
+                    fileName: string;
+                    taskName: string;
+                    chatType: 'friend' | 'group';
+                    peerUid: string;
+                    sessionName: string | null;
+                    timestamp: string;
+                    createdAt: string;
+                    fileSize: number;
+                    groupKey: string;
+                }> = [];
+                const manualExportDir = this.pathManager.getExportsDir();
+                if (fs.existsSync(manualExportDir)) {
+                    try {
+                        const files = fs.readdirSync(manualExportDir)
+                            .filter(f => f.endsWith('.html') || f.endsWith('.json'));
+                        for (const file of files) {
+                            try {
+                                const parsed = parseManualExportFileName(file);
+                                if (!parsed) continue;
+                                const filePath = path.join(manualExportDir, file);
+                                const stats = fs.statSync(filePath);
+                                manualBackups.push({
+                                    fileName: file,
+                                    // 单文件层面优先用 sessionName 让 UI 直观，没有时退回 `<type>_<uid>`。
+                                    taskName: parsed.sessionName ?? `${parsed.chatType}_${parsed.peerUid}`,
+                                    chatType: parsed.chatType,
+                                    peerUid: parsed.peerUid,
+                                    sessionName: parsed.sessionName,
+                                    timestamp: parsed.timestamp ?? stats.mtime.toISOString().replace(/[-:T]/g, '').slice(0, 14),
+                                    createdAt: stats.mtime.toISOString(),
+                                    fileSize: stats.size,
+                                    groupKey: manualExportGroupKey(parsed),
+                                });
+                            } catch (fileError) {
+                                console.warn(`[ApiServer] 无法读取手动导出文件 ${file}:`, fileError);
+                            }
+                        }
+                    } catch (dirError) {
+                        console.warn('[ApiServer] 读取 exports 目录失败:', dirError);
+                    }
+                }
+
+                // 按 groupKey 聚合，组内只有一个文件的会话也展示出来 —— 单文件无法合并，
+                // 但 UI 可以提示用户继续往同一会话里追加导出再来合并。
+                const groupedManual = new Map<string, typeof manualBackups>();
+                for (const b of manualBackups) {
+                    if (!groupedManual.has(b.groupKey)) {
+                        groupedManual.set(b.groupKey, []);
+                    }
+                    groupedManual.get(b.groupKey)!.push(b);
+                }
+
+                const manualTasks = Array.from(groupedManual.entries()).map(([groupKey, backups]) => {
+                    const sorted = backups.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+                    const latest = sorted[0];
+                    // 任务名优先用任意一个带 sessionName 的备份，否则退回 `<chatType>_<uid>`。
+                    const named = sorted.find((it) => it.sessionName);
+                    const taskName = named?.sessionName ?? latest.taskName;
+                    return {
+                        groupKey,
+                        taskName,
+                        chatType: latest.chatType,
+                        peerUid: latest.peerUid,
+                        backupCount: sorted.length,
+                        backups: sorted,
+                        latestBackup: latest,
+                    };
+                }).sort((a, b) => new Date(b.latestBackup.createdAt).getTime() - new Date(a.latestBackup.createdAt).getTime());
+
+                this.sendSuccessResponse(res, { scheduledTasks, manualTasks }, (req as any).requestId);
             } catch (error) {
                 this.sendErrorResponse(res, error, (req as any).requestId);
             }

--- a/plugins/qq-chat-exporter/lib/utils/manualExportFileName.ts
+++ b/plugins/qq-chat-exporter/lib/utils/manualExportFileName.ts
@@ -1,0 +1,111 @@
+/**
+ * Issue #163: 解析手动导出生成的文件名，把它们按「同一会话」分组用于合并。
+ *
+ * 手动导出可能产生几种文件名：
+ *  - 默认：     `friend_<uid>_<YYYYMMDD>_<HHMMSS>.<ext>`
+ *  - #216：    `friend_<safeName>_<uid>_<YYYYMMDD>_<HHMMSS>.<ext>`
+ *  - #134：    `<safeName>(<uid>).<ext>`
+ *  - #134 碰撞：`<safeName>(<uid>)_<YYYYMMDD>_<HHMMSS>.<ext>`
+ *
+ * 这里只识别 `html` / `json` 两种扩展名 —— 这是合并器目前能消费的格式；
+ * 其它格式（jsonl / xlsx / txt 等）即使在导出目录里也跳过，避免误把不可合并的
+ * 文件加进任务列表。
+ */
+
+export type ChatType = 'friend' | 'group';
+
+export interface ParsedManualExportFile {
+    /** 文件基础名（不含扩展名）。 */
+    baseName: string;
+    /** 文件扩展名，不含点。 */
+    extension: 'html' | 'json';
+    /** 解析出的会话类型。 */
+    chatType: ChatType;
+    /** 对方 UID（一般就是 QQ 号）。 */
+    peerUid: string;
+    /**
+     * 解析出的会话名称。`null` 时表示文件名里没有名称信息（例如默认格式里只有 UID）。
+     * 用于在合并对话框上显示更易读的标签；分组本身不依赖这个字段。
+     */
+    sessionName: string | null;
+    /** 解析出的时间戳（YYYYMMDD-HHMMSS），无时间戳的友好命名为 null。 */
+    timestamp: string | null;
+}
+
+/**
+ * 把扩展名归一化成统一的小写。返回 null 表示不是支持合并的扩展名。
+ */
+function normalizeExtension(ext: string): 'html' | 'json' | null {
+    const lower = ext.toLowerCase();
+    if (lower === 'html' || lower === 'json') return lower;
+    return null;
+}
+
+const RE_DEFAULT = /^(friend|group)_(\d+)_(\d{8})_(\d{6})\.(html|json)$/;
+const RE_NAMED = /^(friend|group)_(.+?)_(\d+)_(\d{8})_(\d{6})\.(html|json)$/;
+const RE_FRIENDLY = /^(.+?)\((\d+)\)(?:_(\d{8})_(\d{6}))?\.(html|json)$/;
+
+/**
+ * 尝试把单个手动导出的文件名解析成结构化数据。返回 null 表示不识别 / 不可合并。
+ */
+export function parseManualExportFileName(fileName: string): ParsedManualExportFile | null {
+    // 1. `<safeName>(<uid>).<ext>` / `<safeName>(<uid>)_<date>_<time>.<ext>`
+    const friendlyMatch = fileName.match(RE_FRIENDLY);
+    if (friendlyMatch) {
+        const [, name, uid, date, time, extRaw] = friendlyMatch;
+        const ext = normalizeExtension(extRaw);
+        if (!ext) return null;
+        // 友好命名格式没法 100% 区分 friend / group；为了让同一会话能聚到一起，
+        // 用 `friend` 做默认值，再借助 sessionName + uid 共同作为 group key。
+        return {
+            baseName: fileName.slice(0, fileName.lastIndexOf('.')),
+            extension: ext,
+            chatType: 'friend',
+            peerUid: uid,
+            sessionName: name,
+            timestamp: date && time ? `${date}-${time}` : null,
+        };
+    }
+
+    // 2. `<chatType>_<safeName>_<uid>_<date>_<time>.<ext>` (#216)
+    const namedMatch = fileName.match(RE_NAMED);
+    if (namedMatch) {
+        const [, chatType, name, uid, date, time, extRaw] = namedMatch;
+        const ext = normalizeExtension(extRaw);
+        if (!ext) return null;
+        return {
+            baseName: fileName.slice(0, fileName.lastIndexOf('.')),
+            extension: ext,
+            chatType: chatType as ChatType,
+            peerUid: uid,
+            sessionName: name,
+            timestamp: `${date}-${time}`,
+        };
+    }
+
+    // 3. `<chatType>_<uid>_<date>_<time>.<ext>` (默认)
+    const defaultMatch = fileName.match(RE_DEFAULT);
+    if (defaultMatch) {
+        const [, chatType, uid, date, time, extRaw] = defaultMatch;
+        const ext = normalizeExtension(extRaw);
+        if (!ext) return null;
+        return {
+            baseName: fileName.slice(0, fileName.lastIndexOf('.')),
+            extension: ext,
+            chatType: chatType as ChatType,
+            peerUid: uid,
+            sessionName: null,
+            timestamp: `${date}-${time}`,
+        };
+    }
+
+    return null;
+}
+
+/**
+ * 同一会话的合并组 key。`<chatType>_<peerUid>` 即可保证唯一；友好命名虽然不带 chatType
+ * 也会回退到 `friend`，但只要 peerUid 一致就能和 #216 / 默认格式聚到一起。
+ */
+export function manualExportGroupKey(parsed: ParsedManualExportFile): string {
+    return `${parsed.chatType}_${parsed.peerUid}`;
+}

--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -110,6 +110,8 @@ export default function QCEDashboard() {
   // 定时备份合并状态
   const [isScheduledMergeDialogOpen, setIsScheduledMergeDialogOpen] = useState(false)
   const [scheduledTasks, setScheduledTasks] = useState<Array<any>>([])
+  // Issue #163: 同一对话框里也展示手动导出，按会话聚合后允许混合合并。
+  const [manualTasks, setManualTasks] = useState<Array<any>>([])
   const [loadingScheduledTasks, setLoadingScheduledTasks] = useState(false)
   
   // 聊天记录筛选状态
@@ -906,10 +908,11 @@ export default function QCEDashboard() {
       const data = await response.json()
       if (data.success) {
         setScheduledTasks(data.data.scheduledTasks || [])
+        setManualTasks(data.data.manualTasks || [])
       }
     } catch (error) {
-      console.error('加载定时备份失败:', error)
-      addNotification('error', '加载失败', '无法获取定时备份列表')
+      console.error('加载备份列表失败:', error)
+      addNotification('error', '加载失败', '无法获取备份列表')
     } finally {
       setLoadingScheduledTasks(false)
     }
@@ -1393,21 +1396,34 @@ export default function QCEDashboard() {
               </>
             )}
             {activeTab === "history" && (
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-8 text-[13px] rounded-full px-2"
-                onClick={async () => {
-                  chatHistoryLoadedRef.current = false
-                  resourceIndexLoadedRef.current = false
-                  await Promise.all([handleLoadChatHistory(), loadResourceIndex()])
-                  chatHistoryLoadedRef.current = true
-                  resourceIndexLoadedRef.current = true
-                }}
-                disabled={chatHistoryLoading || resourceIndexLoading}
-              >
-                <RefreshCw className={`w-4 h-4 ${(chatHistoryLoading || resourceIndexLoading) ? 'animate-spin' : ''}`} />
-              </Button>
+              <>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-8 text-[13px] rounded-full px-2"
+                  onClick={async () => {
+                    chatHistoryLoadedRef.current = false
+                    resourceIndexLoadedRef.current = false
+                    await Promise.all([handleLoadChatHistory(), loadResourceIndex()])
+                    chatHistoryLoadedRef.current = true
+                    resourceIndexLoadedRef.current = true
+                  }}
+                  disabled={chatHistoryLoading || resourceIndexLoading}
+                >
+                  <RefreshCw className={`w-4 h-4 ${(chatHistoryLoading || resourceIndexLoading) ? 'animate-spin' : ''}`} />
+                </Button>
+                {/* Issue #163: 在「聊天记录」页也可以打开合并对话框，覆盖手动导出场景。 */}
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-8 text-[13px] rounded-full px-2.5"
+                  onClick={handleOpenScheduledMergeDialog}
+                  disabled={loadingScheduledTasks}
+                >
+                  <Combine className="w-4 h-4 mr-1" />
+                  合并
+                </Button>
+              </>
             )}
             {activeTab === "stickers" && (
               <>
@@ -2537,6 +2553,7 @@ export default function QCEDashboard() {
         open={isScheduledMergeDialogOpen}
         onOpenChange={setIsScheduledMergeDialogOpen}
         scheduledTasks={scheduledTasks}
+        manualTasks={manualTasks}
         onMerge={handleScheduledMerge}
       />
 

--- a/qce-v4-tool/components/ui/scheduled-backup-merge-dialog.tsx
+++ b/qce-v4-tool/components/ui/scheduled-backup-merge-dialog.tsx
@@ -25,10 +25,27 @@ interface ScheduledTask {
   latestBackup: ScheduledBackup
 }
 
+/**
+ * Issue #163: 手动导出任务的备份组。形状和 ScheduledTask 几乎一致，多了
+ * groupKey / chatType / peerUid 用于在 UI 上区分会话；taskName 在 API 层
+ * 已经选好优先用 sessionName，UI 直接展示。
+ */
+interface ManualTask {
+  groupKey: string
+  taskName: string
+  chatType: 'friend' | 'group'
+  peerUid: string
+  backupCount: number
+  backups: ScheduledBackup[]
+  latestBackup: ScheduledBackup
+}
+
 interface ScheduledBackupMergeDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   scheduledTasks: ScheduledTask[]
+  /** Issue #163: 同一对话框里也展示手动导出任务，让两类备份共用一套合并入口。 */
+  manualTasks?: ManualTask[]
   onMerge: (config: {
     sourceTaskIds: string[]  // 实际是文件名列表
     deleteSourceFiles: boolean
@@ -40,6 +57,7 @@ export function ScheduledBackupMergeDialog({
   open,
   onOpenChange,
   scheduledTasks,
+  manualTasks = [],
   onMerge
 }: ScheduledBackupMergeDialogProps) {
   const [selectedBackups, setSelectedBackups] = useState<Set<string>>(new Set())
@@ -68,7 +86,7 @@ export function ScheduledBackupMergeDialog({
     setSelectedBackups(newSelection)
   }
 
-  const handleSelectAllInTask = (task: ScheduledTask, checked: boolean | string) => {
+  const handleSelectAllInTask = (task: ScheduledTask | ManualTask, checked: boolean | string) => {
     const newSelection = new Set(selectedBackups)
     if (checked) {
       task.backups.forEach(backup => newSelection.add(backup.fileName))
@@ -78,11 +96,11 @@ export function ScheduledBackupMergeDialog({
     setSelectedBackups(newSelection)
   }
 
-  const isTaskFullySelected = (task: ScheduledTask): boolean => {
+  const isTaskFullySelected = (task: ScheduledTask | ManualTask): boolean => {
     return task.backups.every(backup => selectedBackups.has(backup.fileName))
   }
 
-  const isTaskPartiallySelected = (task: ScheduledTask): boolean => {
+  const isTaskPartiallySelected = (task: ScheduledTask | ManualTask): boolean => {
     const selected = task.backups.filter(backup => selectedBackups.has(backup.fileName)).length
     return selected > 0 && selected < task.backups.length
   }
@@ -119,8 +137,18 @@ export function ScheduledBackupMergeDialog({
   }
 
   const formatTimestamp = (timestamp: string): string => {
-    // 格式: 2025-11-28T06-24-13 -> 2025-11-28 06:24:13
-    return timestamp.replace('T', ' ').replace(/-/g, ':').slice(0, -3)
+    // 定时备份格式: 2025-11-28T06-24-13 -> 2025-11-28 06:24:13
+    if (timestamp.includes('T')) {
+      return timestamp.replace('T', ' ').replace(/-/g, ':').slice(0, -3)
+    }
+    // 手动导出格式 (#163): 20251128-062413 -> 2025-11-28 06:24:13
+    const m = timestamp.match(/^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})$/)
+    if (m) return `${m[1]}-${m[2]}-${m[3]} ${m[4]}:${m[5]}:${m[6]}`
+    // ISO 字符串退路（mtime fallback）
+    if (/^\d{4}-\d{2}-\d{2}T/.test(timestamp)) {
+      return timestamp.replace('T', ' ').slice(0, 19)
+    }
+    return timestamp
   }
 
   return (
@@ -133,7 +161,7 @@ export function ScheduledBackupMergeDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Layers className="w-5 h-5" />
-            合并定时备份
+            合并备份
           </DialogTitle>
         </DialogHeader>
 
@@ -142,23 +170,28 @@ export function ScheduledBackupMergeDialog({
           <div className="w-2/5 flex flex-col">
             <div className="mb-4">
               <h3 className="text-base font-medium mb-1">选择要合并的备份</h3>
-              <p className="text-sm text-muted-foreground">至少选择 2 个备份文件进行合并</p>
+              <p className="text-sm text-muted-foreground">至少选择 2 个备份文件进行合并；定时备份和手动导出可以混合选择。</p>
             </div>
-            
+
             <div className="flex-1 overflow-hidden">
-              {scheduledTasks.length === 0 ? (
+              {scheduledTasks.length === 0 && manualTasks.length === 0 ? (
                 <div className="h-full flex items-center justify-center rounded-2xl border border-dashed border-black/[0.08] dark:border-white/[0.08] bg-muted/50">
                   <div className="text-center p-8">
                     <AlertCircle className="w-12 h-12 mx-auto mb-3 text-muted-foreground/60" />
-                    <p className="text-base font-medium text-foreground/80">暂无定时备份</p>
-                    <p className="text-sm text-muted-foreground mt-1">请先创建并运行定时导出任务</p>
+                    <p className="text-base font-medium text-foreground/80">暂无可合并的备份</p>
+                    <p className="text-sm text-muted-foreground mt-1">先创建定时导出任务，或者多次手动导出同一会话再来合并</p>
                   </div>
                 </div>
               ) : (
                 <ScrollArea className="h-full rounded-2xl border border-black/[0.06] dark:border-white/[0.06] p-2 bg-card/70">
-                  <div className="space-y-1">
+                  <div className="space-y-3">
+                    {scheduledTasks.length > 0 && (
+                      <div className="px-2 pt-1 pb-0.5 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                        定时备份
+                      </div>
+                    )}
                     {scheduledTasks.map(task => (
-                      <div key={task.taskName} className="rounded-xl bg-card overflow-hidden">
+                      <div key={`scheduled-${task.taskName}`} className="rounded-xl bg-card overflow-hidden">
                         {/* 任务头部 */}
                         <div className="flex items-center gap-3 p-3 hover:bg-muted/50 transition-colors">
                           <Checkbox
@@ -224,6 +257,85 @@ export function ScheduledBackupMergeDialog({
                         )}
                       </div>
                     ))}
+
+                    {manualTasks.length > 0 && (
+                      <div className="px-2 pt-3 pb-0.5 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                        手动导出
+                      </div>
+                    )}
+                    {manualTasks.map(task => {
+                      // 同一会话下的所有手动导出共用一行 expand/collapse；用 groupKey 当 key 避免和
+                      // 定时备份的 taskName 撞名（出现群名 = 定时任务名的边界情况）。
+                      const expandKey = `manual:${task.groupKey}`
+                      return (
+                        <div key={expandKey} className="rounded-xl bg-card overflow-hidden">
+                          <div className="flex items-center gap-3 p-3 hover:bg-muted/50 transition-colors">
+                            <Checkbox
+                              checked={isTaskFullySelected(task)}
+                              onCheckedChange={(checked) => handleSelectAllInTask(task, checked)}
+                            />
+                            <div className="flex-shrink-0">
+                              <FolderOpen className="w-5 h-5 text-emerald-600" />
+                            </div>
+                            <button
+                              onClick={() => toggleTask(expandKey)}
+                              className="flex-1 text-left min-w-0"
+                            >
+                              <div className="flex items-center justify-between gap-2">
+                                <div className="min-w-0">
+                                  <p className="font-medium text-sm text-foreground truncate">{task.taskName}</p>
+                                  <div className="flex items-center gap-2 mt-0.5">
+                                    <Badge variant="secondary" className="text-xs">
+                                      {task.backupCount} 个文件
+                                    </Badge>
+                                    <Badge variant="outline" className="text-xs">
+                                      {task.chatType === 'group' ? '群聊' : '好友'} · {task.peerUid}
+                                    </Badge>
+                                    <span className="text-xs text-muted-foreground truncate">
+                                      {formatTimestamp(task.latestBackup.timestamp)}
+                                    </span>
+                                  </div>
+                                </div>
+                                {expandedTasks.has(expandKey) ? (
+                                  <ChevronDown className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+                                ) : (
+                                  <ChevronRight className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+                                )}
+                              </div>
+                            </button>
+                          </div>
+
+                          {expandedTasks.has(expandKey) && (
+                            <div className="border-t border-black/[0.06] dark:border-white/[0.06] bg-muted/30">
+                              {task.backups.map(backup => (
+                                <div
+                                  key={backup.fileName}
+                                  className="flex items-center gap-3 p-3 pl-11 hover:bg-card transition-colors"
+                                >
+                                  <Checkbox
+                                    checked={selectedBackups.has(backup.fileName)}
+                                    onCheckedChange={(checked) => handleBackupSelection(backup.fileName, checked)}
+                                  />
+                                  <div className="flex-1 min-w-0">
+                                    <p className="text-sm font-medium text-foreground">
+                                      {formatTimestamp(backup.timestamp)}
+                                    </p>
+                                    <div className="flex items-center gap-2 mt-0.5">
+                                      <span className="text-xs text-muted-foreground">
+                                        {formatFileSize(backup.fileSize)}
+                                      </span>
+                                      <span className="text-xs text-muted-foreground/60 truncate">
+                                        {backup.fileName}
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      )
+                    })}
                   </div>
                 </ScrollArea>
               )}


### PR DESCRIPTION
## Summary

之前合并器（`/api/merge-resources`）的可用任务列表只扫描定时备份目录，issue #163 反映同样的合并能力对手动导出也有用 —— 比如多次手动导出同一会话的不同时间段，希望能合并成单一记录。底层 `ResourceMerger.validateSourceFiles` 其实早就同时搜 `exports` 和 `scheduled-exports` 两个目录，只是 UI 上没有把手动导出的文件喂给它的入口。

这个 PR 把入口补齐：

- 新增 `lib/utils/manualExportFileName.ts`，把手动导出的文件名解析为结构化数据。覆盖三种命名：默认 `friend_<uid>_<date>_<time>.html`、#216 `friend_<name>_<uid>_<date>_<time>.html`、#134 `<name>(<uid>).html`（含同名碰撞后缀变体）。返回 `{chatType, peerUid, sessionName, timestamp}` 以及会话级 group key `<chatType>_<peerUid>`。
- `/api/merge-resources/available-tasks` 在原有 `scheduledTasks` 字段基础上额外返回 `manualTasks`：扫描手动导出目录、按 group key 聚合，每个会话给出按时间倒序排列的 backup 列表，shape 与 `scheduledTasks` 对齐方便复用 UI。仅识别 `html` / `json` 两种扩展名 —— 这是合并器目前能消费的格式，其它格式（jsonl / xlsx / txt）跳过避免误列。
- `ScheduledBackupMergeDialog` 增加 `manualTasks?` 字段，对话框内拆出两个分区（「定时备份」/「手动导出」）共享一套选择 / 合并控件；用户可以混合勾选两类来源一起合并。空状态、标题文案同步调整。
- 「聊天记录」标签页新增「合并」按钮，让用户在看手动导出列表的页面也能直接打开合并对话框，避免必须切到「定时」标签才能找到入口。

## Tests

- 新增 `__tests__/unit/manualExportFileName.test.ts` 9 项，覆盖三种命名解析、不可合并扩展名、相同 / 不同 chatType 的分组逻辑。
- 仓库 `npm test`：80/80 通过（原 71 + 新增 9）。
- 复用现有 `ResourceMerger`，不改合并器本身，行为对老调用方（定时备份）零影响。

### Notes

- 合并器要求源文件有 `.json` 副本才能真正合并消息；HTML-only 的手动导出会被列出但点合并时只会拷资源、不参与消息合并。这是 `ResourceMerger.mergeMessages` 的既有约束（`if (!source.jsonPath) continue`），不在这个 PR 里改。
- 友好命名（`<name>(<uid>).html`）从文件名里没法 100% 区分 friend / group，会回退到 `friend` 作为 chatType。一般场景下 peerUid（QQ 号 / 群号）唯一，不会和实际 group 撞 key；如果用户同时有相同号码的好友和群，UI 上会显示两条独立的会话条目，需要用户自己挑对那一条 —— 当前实现里相比合到一起更安全。