### PR TITLE
fix(preview): restore body pointer-events while previewing inside wizard (#300)

### DIFF
--- a/qce-v4-tool/components/ui/message-preview-modal.tsx
+++ b/qce-v4-tool/components/ui/message-preview-modal.tsx
@@ -230,6 +230,29 @@ export function MessagePreviewModal({ open, onClose, chat, onExport }: MessagePr
     }
   }, [open, chat])
 
+  /**
+   * Issue #300: 这个预览弹窗本身是 framer-motion 自定义模态，z-index 在更外层 Radix
+   * Dialog 之上，但 Radix 在它自己的 `<body>` 上挂了 `pointer-events: none` 来禁用底
+   * 层交互。结果就是任务向导里的 Dialog 还开着时打开预览，预览本身和它 fixed 子树
+   * 也被一起禁掉了点击。
+   *
+   * 这里在弹窗显示期间强制把 body 的 pointer-events 改回 auto，关闭后恢复成原样。
+   * 不动 Radix 自己的 modal=true 行为，只覆盖最末端的 body 状态，避免影响其它依赖
+   * Radix 屏蔽底层交互的弹层。
+   */
+  useEffect(() => {
+    if (!open) return
+    if (typeof document === 'undefined') return
+    const body = document.body
+    const previous = body.style.pointerEvents
+    body.style.pointerEvents = 'auto'
+    return () => {
+      // 关闭时优先恢复打开前的值；遇到 Radix 把 body 的 inline 样式整个清掉的情况
+      // （previous 为空字符串）就保持空字符串，让浏览器回到默认值。
+      body.style.pointerEvents = previous
+    }
+  }, [open])
+
   if (!chat) return null
 
   return (


### PR DESCRIPTION
## Summary

用户在 Framework UI 里从「创建导出任务」向导点「预览」之后，预览面板里的按钮 / 输入框 / 关闭都无响应，点击还会穿透到背景；DevTools 看到 `document.body.style.pointer-events` 是 `none`。

根因：

- 任务向导是 Radix `Dialog`（modal=true）。Radix 在 modal Dialog 打开时把 `body` 的 inline `pointer-events` 设为 `none`，目的是禁掉 Dialog 之外的底层交互。
- 预览弹窗（`MessagePreviewModal`）不是 Radix Dialog，是用 framer-motion 自己写的模态。它的容器 z-index 在向导之上，但 fixed 子树挂在 body 下，body 被 Radix 禁用 pointer-events 之后，整个预览也跟着挨枪 —— 表现就是任何输入 / 按钮都无响应。

修复就一个 useEffect：预览弹窗打开期间把 `document.body.style.pointerEvents` 显式设为 `auto`，关闭时恢复成打开前的值（一般就是 Radix 写入的 `none`，让向导继续屏蔽底层）。这样既保留 Radix 的 modal 屏蔽语义，又让覆盖在向导之上的预览自己能响应交互。不改 Radix 自己的行为，也不影响其它依赖 Radix 屏蔽逻辑的弹层。

## Tests

- 仓库 `npm test`（plugins/qq-chat-exporter）：80/80 通过 —— 这一改动只动前端，但跑一次保证没受其它分支牵连。
- 手动验证步骤：
  1. 打开任务向导，选好群 / 好友为目标，点「预览」；
  2. 预览弹窗内尝试输入搜索 / 切换分页 / 点关闭按钮 → 全部正常响应；
  3. 关闭预览，向导仍然处于打开状态，向导自身的交互正常；
  4. 用 DevTools 观察 `document.body.style.pointerEvents`：预览打开时 `auto`，关闭后恢复为 `none`，最后退出向导后 Radix 自己清掉。

### Notes

- 长期方案是把预览也改成 Radix Dialog（让两个弹层都进 Radix 的 modal 栈管理），但改动面更大。这里先做最小修复确认能解决用户反馈的现象。