### PR TITLE
feat(auth): one-click login URL and richer token-finding help (#287)

### DIFF
--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -89,6 +89,16 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm exec playwright install --with-deps chromium
 
+      - name: Build frontend (static export)
+        working-directory: qce-v4-tool
+        run: pnpm build
+
+      - name: Stage built frontend for the mock server
+        run: |
+          mkdir -p static
+          rm -rf static/qce-v4-tool
+          cp -r qce-v4-tool/out static/qce-v4-tool
+
       - name: Start mock API server
         working-directory: plugins/qq-chat-exporter
         run: |
@@ -102,14 +112,18 @@ jobs:
             sleep 1
           done
           curl -fsS http://localhost:40653/health
+          # Confirm the static frontend is being served too.
+          curl -fsS -o /dev/null -w '[ci] /qce-v4-tool/auth -> %{http_code}\n' \
+            http://localhost:40653/qce-v4-tool/auth
         env:
           QCE_MOCK_TOKEN: qce_mock_token_for_tests
 
-      - name: Run Playwright API smoke tests
+      - name: Run Playwright tests (API + UI)
         working-directory: qce-v4-tool
-        run: pnpm exec playwright test e2e/api-smoke.spec.ts
+        run: pnpm exec playwright test
         env:
           E2E_API_URL: http://localhost:40653
+          E2E_FRONTEND_URL: http://localhost:40653
           QCE_MOCK_TOKEN: qce_mock_token_for_tests
 
       - name: Mock server logs (always)

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -5494,15 +5494,26 @@ export class QQChatExporterApiServer {
                 if (accessToken) {
                     console.log(`${green}[QCE]${reset} Token: ${green}${accessToken}${reset}`);
                 }
-                
+
                 // 显示前端地址
                 if (frontendStatus.isRunning && frontendStatus.mode === 'production') {
-                    const toolUrl = serverAddresses.external 
-                        ? `${serverAddresses.external}/qce-v4-tool` 
-                        : `${serverAddresses.local}/qce-v4-tool`;
+                    const baseUrl = serverAddresses.external
+                        ? serverAddresses.external
+                        : serverAddresses.local;
+                    const toolUrl = `${baseUrl}/qce-v4-tool`;
                     console.log(`${green}[QCE]${reset} Web界面: ${green}${toolUrl}${reset}`);
+                    // Issue #287: Framework 用户没有内嵌登录入口，每次都得手动从 security.json
+                    // 抠 token。这里直接把 token 拼进 auth 页 URL，复制到浏览器一次到位。
+                    if (accessToken) {
+                        const oneClickUrl = `${baseUrl}/qce-v4-tool/auth?token=${encodeURIComponent(accessToken)}`;
+                        console.log(`${green}[QCE]${reset} 一键登录: ${green}${oneClickUrl}${reset}`);
+                    }
                 } else if (frontendStatus.mode === 'development') {
                     console.log(`${green}[QCE]${reset} Web界面: ${green}${frontendStatus.frontendUrl}${reset}`);
+                    if (accessToken && frontendStatus.frontendUrl) {
+                        const oneClickUrl = `${frontendStatus.frontendUrl.replace(/\/$/, '')}/auth?token=${encodeURIComponent(accessToken)}`;
+                        console.log(`${green}[QCE]${reset} 一键登录: ${green}${oneClickUrl}${reset}`);
+                    }
                 }
                 console.log('');
                 

--- a/qce-v4-tool/app/auth/page.tsx
+++ b/qce-v4-tool/app/auth/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { ArrowRight, X, Eye, EyeOff, Lock, ExternalLink } from 'lucide-react'
+import { ArrowRight, X, Eye, EyeOff, Lock, ExternalLink, CheckCircle2 } from 'lucide-react'
 import AuthManager from '@/lib/auth'
 
 export default function AuthPage() {
@@ -12,14 +12,76 @@ export default function AuthPage() {
   const [showToken, setShowToken] = useState(false)
   const [showHelp, setShowHelp] = useState(false)
   const [isReady, setIsReady] = useState(false)
+  // Issue #287: 支持从 URL `?token=` 参数自动填入并一键登录，
+  // 配合后端启动时打印的「一键登录」链接，省掉手动从 security.json 复制 token。
+  const [autoFromUrl, setAutoFromUrl] = useState(false)
+  const submittedFromUrlRef = useRef(false)
+
+  // Token 校验逻辑独立出来，URL 自动登录和表单提交都走同一条。
+  const verifyAndStoreToken = async (rawToken: string): Promise<boolean> => {
+    try {
+      const response = await fetch('/auth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: rawToken }),
+      })
+
+      const data = await response.json()
+      if (data.success) {
+        AuthManager.getInstance().setToken(rawToken)
+        return true
+      }
+      setError(data.error?.message || '令牌验证失败')
+      return false
+    } catch {
+      setError('无法连接到服务器，请确保 NapCat 正在运行')
+      return false
+    }
+  }
 
   useEffect(() => {
     const authManager = AuthManager.getInstance()
     if (authManager.isAuthenticated()) {
       window.location.href = '/qce-v4-tool'
-    } else {
-      setTimeout(() => setIsReady(true), 600)
+      return
     }
+
+    // 先看 URL 里有没有 token；有就清掉再走自动登录，避免历史栏暴露 token。
+    let urlToken: string | null = null
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search)
+      urlToken = params.get('token')
+      if (urlToken) {
+        params.delete('token')
+        const newUrl =
+          window.location.pathname +
+          (params.toString() ? '?' + params.toString() : '') +
+          window.location.hash
+        window.history.replaceState({}, '', newUrl)
+      }
+    }
+
+    if (urlToken && !submittedFromUrlRef.current) {
+      submittedFromUrlRef.current = true
+      setToken(urlToken)
+      setAutoFromUrl(true)
+      setIsReady(true)
+      setLoading(true)
+      // 给一帧时间渲染「检测到一键登录链接」提示，再发请求。
+      setTimeout(async () => {
+        const ok = await verifyAndStoreToken(urlToken!)
+        if (ok) {
+          window.location.href = '/qce-v4-tool'
+        } else {
+          // URL token 失效（比如换了 security.json）就退回手动表单。
+          setAutoFromUrl(false)
+          setLoading(false)
+        }
+      }, 100)
+      return
+    }
+
+    setTimeout(() => setIsReady(true), 600)
   }, [])
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -32,27 +94,12 @@ export default function AuthPage() {
     setLoading(true)
     setError('')
 
-    try {
-      const response = await fetch('/auth', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token: token.trim() }),
-      })
-
-      const data = await response.json()
-
-      if (data.success) {
-        const authManager = AuthManager.getInstance()
-        authManager.setToken(token.trim())
-        window.location.href = '/qce-v4-tool'
-      } else {
-        setError(data.error?.message || '令牌验证失败')
-      }
-    } catch {
-      setError('无法连接到服务器，请确保 NapCat 正在运行')
-    } finally {
-      setLoading(false)
+    const ok = await verifyAndStoreToken(token.trim())
+    if (ok) {
+      window.location.href = '/qce-v4-tool'
+      return
     }
+    setLoading(false)
   }
 
   return (
@@ -85,6 +132,18 @@ export default function AuthPage() {
               <h1 className="text-2xl font-semibold text-foreground">访问验证</h1>
               <p className="text-muted-foreground mt-2 text-[14px]">请输入访问令牌以继续使用</p>
             </div>
+
+            {/* Issue #287: 当 URL 带 ?token= 时显示自动登录条幅，让用户清楚状态 */}
+            {autoFromUrl && (
+              <motion.div
+                initial={{ opacity: 0, y: -4 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="mb-4 px-4 py-3 rounded-xl bg-emerald-50 dark:bg-emerald-950/40 border border-emerald-100 dark:border-emerald-900/40 text-emerald-700 dark:text-emerald-300 text-[13px] flex items-center gap-2"
+              >
+                <CheckCircle2 className="w-4 h-4 flex-shrink-0" />
+                <span>已从一键登录链接读取访问令牌，正在验证...</span>
+              </motion.div>
+            )}
 
             {/* Form Card */}
             <div className="bg-card rounded-2xl border border-black/[0.05] dark:border-white/[0.06] p-6 shadow-[0_2px_8px_rgba(0,0,0,0.015)]">
@@ -195,28 +254,51 @@ export default function AuthPage() {
               </div>
 
               {/* Modal Content */}
-              <div className="p-6 space-y-5">
+              <div className="p-6 space-y-5 max-h-[70vh] overflow-y-auto">
                 <p className="text-muted-foreground text-[14px] leading-relaxed">
-                  令牌是一串随机字符，用来验证你的身份。每次启动 NapCat 时会自动生成一个新的。
+                  令牌是一串随机字符，用来验证你的身份。每次启动 NapCat / QCE 时会自动生成一个新的。
                 </p>
 
+                {/* Issue #287: 一键登录是 Framework 用户最省心的入口，先讲它 */}
                 <div className="space-y-3">
-                  <p className="text-[13px] font-medium text-foreground">去哪找？</p>
+                  <p className="text-[13px] font-medium text-foreground">最快的方式：用一键登录链接（推荐）</p>
                   <p className="text-muted-foreground text-[13px] leading-relaxed">
-                    打开 NapCat 的黑色控制台窗口，往上翻一翻，找到带有 <span className="font-mono bg-black/[0.04] dark:bg-white/[0.06] px-1.5 py-0.5 rounded text-foreground">[QCE] Token:</span> 的那一行，后面那串字符就是了。
+                    QCE 启动后会在控制台打印一条「一键登录」链接，复制到浏览器打开即可，本页会自动读取并完成验证。
+                  </p>
+                  <div className="rounded-lg bg-neutral-900 dark:bg-neutral-950 p-4 font-mono text-xs overflow-x-auto leading-relaxed">
+                    <div className="text-neutral-400">[QCE] QQChatExporter v5.x.x</div>
+                    <div className="text-green-400">[QCE] Token: WgZt3v*UMTqT#i!qleEO!76n02Y^ns$X</div>
+                    <div className="text-neutral-500">[QCE] Web界面: http://127.0.0.1:40653/qce-v4-tool</div>
+                    <div className="text-green-400">[QCE] 一键登录: http://127.0.0.1:40653/qce-v4-tool/auth?token=...</div>
+                  </div>
+                </div>
+
+                <div className="space-y-3 pt-2 border-t border-black/[0.04] dark:border-white/[0.04]">
+                  <p className="text-[13px] font-medium text-foreground">从控制台手动复制</p>
+                  <p className="text-muted-foreground text-[13px] leading-relaxed">
+                    打开 QCE 控制台窗口，往上翻一翻，找到带有 <span className="font-mono bg-black/[0.04] dark:bg-white/[0.06] px-1.5 py-0.5 rounded text-foreground">[QCE] Token:</span> 的那一行，后面那串字符就是 Token。
                   </p>
                 </div>
 
-                {/* Console Example */}
-                <div className="rounded-lg bg-neutral-900 dark:bg-neutral-950 p-4 font-mono text-xs overflow-x-auto">
-                  <div className="text-neutral-400">[QCE] QQChatExporter v5.x.x</div>
-                  <div className="text-green-400">[QCE] Token: WgZt3v*UMTqT#i!qleEO!76n02Y^ns$X</div>
-                  <div className="text-neutral-500">[QCE] Web界面: http://127.0.0.1:40653/qce-v4-tool</div>
+                <div className="space-y-3 pt-2 border-t border-black/[0.04] dark:border-white/[0.04]">
+                  <p className="text-[13px] font-medium text-foreground">从 security.json 找（Framework 模式）</p>
+                  <p className="text-muted-foreground text-[13px] leading-relaxed">
+                    Framework 模式下控制台不一定常驻，可以按 <span className="font-mono bg-black/[0.04] dark:bg-white/[0.06] px-1.5 py-0.5 rounded text-foreground">Win + R</span> 输入：
+                  </p>
+                  <div className="rounded-lg bg-neutral-900 dark:bg-neutral-950 p-3 font-mono text-xs overflow-x-auto">
+                    <span className="text-green-400">%USERPROFILE%\.qq-chat-exporter</span>
+                  </div>
+                  <p className="text-muted-foreground text-[13px] leading-relaxed">
+                    打开里面的 <span className="font-mono bg-black/[0.04] dark:bg-white/[0.06] px-1.5 py-0.5 rounded text-foreground">security.json</span>，找到 <span className="font-mono bg-black/[0.04] dark:bg-white/[0.06] px-1.5 py-0.5 rounded text-foreground">accessToken</span> 字段，复制对应的字符串值即可。
+                  </p>
                 </div>
 
-                <p className="text-muted-foreground/70 text-xs">
-                  复制 Token 那行冒号后面的内容，粘贴到输入框即可。
-                </p>
+                <div className="space-y-2 pt-2 border-t border-black/[0.04] dark:border-white/[0.04]">
+                  <p className="text-[13px] font-medium text-foreground">Token 突然不能用了？</p>
+                  <p className="text-muted-foreground text-[13px] leading-relaxed">
+                    QQ 大版本更新或重新登录后，QCE 通常需要重启才能继续工作。重启后再用最新打印的 Token / 一键登录链接登录即可，老的 Token 会失效。
+                  </p>
+                </div>
               </div>
 
               {/* Modal Footer */}

--- a/qce-v4-tool/app/auth/page.tsx
+++ b/qce-v4-tool/app/auth/page.tsx
@@ -40,13 +40,8 @@ export default function AuthPage() {
   }
 
   useEffect(() => {
-    const authManager = AuthManager.getInstance()
-    if (authManager.isAuthenticated()) {
-      window.location.href = '/qce-v4-tool'
-      return
-    }
-
-    // 先看 URL 里有没有 token；有就清掉再走自动登录，避免历史栏暴露 token。
+    // 先把 URL 里的 ?token= 剥掉再做任何跳转，避免任何分支（包括已登录直接跳）
+    // 把带 token 的 URL 留在浏览器历史 / 地址栏里。
     let urlToken: string | null = null
     if (typeof window !== 'undefined') {
       const params = new URLSearchParams(window.location.search)
@@ -59,6 +54,12 @@ export default function AuthPage() {
           window.location.hash
         window.history.replaceState({}, '', newUrl)
       }
+    }
+
+    const authManager = AuthManager.getInstance()
+    if (authManager.isAuthenticated()) {
+      window.location.href = '/qce-v4-tool'
+      return
     }
 
     if (urlToken && !submittedFromUrlRef.current) {

--- a/qce-v4-tool/e2e/ui-smoke.spec.ts
+++ b/qce-v4-tool/e2e/ui-smoke.spec.ts
@@ -2,27 +2,139 @@
  * UI smoke test - boots the auth page, drops a token and makes sure we land
  * on the main app shell. Skipped automatically when the frontend isn't
  * reachable so this can run in environments where only the API is up.
+ *
+ * To run these locally:
+ *   1. `cd qce-v4-tool && pnpm build`
+ *   2. `mkdir -p ../static && rm -rf ../static/qce-v4-tool && cp -r out ../static/qce-v4-tool`
+ *   3. `cd ../plugins/qq-chat-exporter && pnpm mock:server`
+ *   4. `cd ../../qce-v4-tool && E2E_FRONTEND_URL=http://localhost:40653 pnpm exec playwright test e2e/ui-smoke.spec.ts`
+ *
+ * The mock server serves the built frontend under `/qce-v4-tool/...` plus the
+ * REST API on the same origin, which matches production routing far more
+ * closely than `next dev` does.
  */
 
 import { test, expect } from '@playwright/test';
 
 const TOKEN = process.env.QCE_MOCK_TOKEN ?? 'qce_mock_token_for_tests';
+const FRONTEND_BASE = process.env.E2E_FRONTEND_URL ?? 'http://localhost:40653';
+// Production URL has the frontend living under `/qce-v4-tool/`.
+const AUTH_PATH = `/qce-v4-tool/auth`;
+const SHELL_PATH = `/qce-v4-tool`;
+
+async function clearLocalStorage(page: import('@playwright/test').Page) {
+    // We can't use addInitScript here – that runs on EVERY navigation in the
+    // page, so it would also wipe a token the auth flow just persisted.
+    await page.goto(`${FRONTEND_BASE}${SHELL_PATH}`).catch(() => null);
+    await page.evaluate(() => localStorage.clear()).catch(() => null);
+}
 
 test.describe('Auth flow', () => {
+
     test('home page loads', async ({ page }) => {
-        const response = await page.goto('/').catch(() => null);
-        test.skip(!response || response.status() >= 500, 'frontend not reachable');
-        // We expect either the main app page or a redirect to /auth
+        const response = await page.goto(`${FRONTEND_BASE}${SHELL_PATH}`).catch(() => null);
+        test.skip(
+            !response || response.status() >= 500,
+            `frontend not reachable at ${FRONTEND_BASE}`
+        );
         const title = await page.title();
         expect(title.length).toBeGreaterThan(0);
     });
 
-    test('passing ?token=... in URL stores it for future requests', async ({ page }) => {
-        const response = await page.goto(`/auth?token=${TOKEN}`).catch(() => null);
-        test.skip(!response || response.status() >= 500, 'frontend not reachable');
-        // The auth manager pulls the token out of the URL and stashes it in
-        // localStorage. We just check that the storage entry shows up.
+    /**
+     * Issue #287: the server prints a one-click login URL like
+     * `…/qce-v4-tool/auth?token=<accessToken>`. The auth page should detect
+     * that token, strip it from the URL bar (so history doesn't keep a copy),
+     * verify it against the API, persist it to localStorage and forward the
+     * user out of `/auth`.
+     */
+    test('one-click ?token=... strips the query string and persists the token', async ({ page }) => {
+        await clearLocalStorage(page);
+        const response = await page
+            .goto(`${FRONTEND_BASE}${AUTH_PATH}?token=${TOKEN}`)
+            .catch(() => null);
+        test.skip(
+            !response || response.status() >= 500,
+            `frontend not reachable at ${FRONTEND_BASE}`
+        );
+
+        // `replaceState` should clear the `?token=` param before verification
+        // resolves, so it never hangs around in browser history.
+        await page.waitForFunction(() => !window.location.search.includes('token='), {
+            timeout: 15_000
+        });
+
+        // After verification succeeds the auth page persists the token and
+        // redirects out of /auth. Wait for the redirect to settle before
+        // checking storage – the in-flight navigation otherwise nukes our
+        // evaluate() context.
+        await page.waitForURL(
+            (url) => !url.pathname.endsWith('/auth') && !url.pathname.endsWith('/auth/'),
+            { timeout: 15_000 }
+        );
+
         const stored = await page.evaluate(() => localStorage.getItem('qce_access_token'));
         expect(stored).toBe(TOKEN);
+    });
+
+    /**
+     * Bad URL token: mock API rejects, we fall back to the manual form so the
+     * user can paste a fresh token from `security.json`. We must NOT redirect
+     * and must NOT keep the bogus token in localStorage.
+     */
+    test('one-click flow falls back to manual form when token is rejected', async ({ page }) => {
+        await clearLocalStorage(page);
+        const response = await page
+            .goto(`${FRONTEND_BASE}${AUTH_PATH}?token=definitely-wrong-token`)
+            .catch(() => null);
+        test.skip(
+            !response || response.status() >= 500,
+            `frontend not reachable at ${FRONTEND_BASE}`
+        );
+
+        // Query string still gets stripped immediately on mount.
+        await page.waitForFunction(() => !window.location.search.includes('token='), {
+            timeout: 15_000
+        });
+
+        // Wait for the verification round-trip to finish; the page should
+        // settle on the manual form without a redirect.
+        await page.waitForTimeout(1500);
+        const stored = await page.evaluate(() => localStorage.getItem('qce_access_token'));
+        expect(stored).toBeNull();
+        expect(new URL(page.url()).pathname).toMatch(/\/auth\/?$/);
+    });
+
+    /**
+     * Codex P2 on PR #401: even when the user is already authenticated, the
+     * auth page must scrub `?token=` from the URL before redirecting.
+     * Otherwise the token-bearing URL stays in history / address bar
+     * navigation when the user hits "back".
+     */
+    test('already-authenticated visit still strips ?token= from history', async ({ page }) => {
+        // Pre-seed a valid token so the auth page hits the
+        // `authManager.isAuthenticated()` branch.
+        await clearLocalStorage(page);
+        await page.evaluate((value) => {
+            localStorage.setItem('qce_access_token', value);
+        }, TOKEN);
+
+        const response = await page
+            .goto(`${FRONTEND_BASE}${AUTH_PATH}?token=${TOKEN}`)
+            .catch(() => null);
+        test.skip(
+            !response || response.status() >= 500,
+            `frontend not reachable at ${FRONTEND_BASE}`
+        );
+
+        // The auth page's effect should run `replaceState` to strip the
+        // ?token= query before kicking off the redirect.
+        await page.waitForFunction(() => !window.location.search.includes('token='), {
+            timeout: 15_000
+        });
+
+        // The URL the browser would record in history (after replaceState)
+        // must no longer contain the token.
+        expect(page.url()).not.toContain('token=');
     });
 });


### PR DESCRIPTION
## Summary

Framework 模式下用户没有内嵌登录入口，每次都得手动从 `~/.qq-chat-exporter/security.json` 抠 `accessToken` 粘贴；QQ 大版本更新或重新登录后 token 还会突然失效，文档里也没说清楚。这个 PR 把入口体感拉一档：

- `ApiServer` 启动日志多打一行「一键登录」URL，把 `accessToken` 直接拼进 `/qce-v4-tool/auth?token=...`。Production 模式从 `serverAddresses.external/local` 拼绝对地址；development 模式从 `frontendStatus.frontendUrl` 拼，避免 next dev 端口和 API 端口不一致。Token 用 `encodeURIComponent` 转义防特殊字符。
- `auth/page.tsx` 在 `useEffect` 里解析 `?token=` 查询参数：
  - 解析后立刻 `history.replaceState` 把它从地址栏剥掉，避免被记进浏览器历史；
  - 自动调 `verifyAndStoreToken`（与手动表单共用一条校验路径），成功就直接跳 `/qce-v4-tool`；
  - 失败时（比如 token 已轮换）平滑回退到原来的手动输入表单，把错误信息显示在原本的 error 区；
  - 顶部加一条绿色条幅「已从一键登录链接读取访问令牌，正在验证...」让用户清楚状态。
- 「找不到令牌？」帮助弹窗按使用频次重排：一键登录链接（推荐）→ 控制台手动复制 → `security.json` 备用路径（专门写给 Framework 用户）→ Token 失效兜底说明（QQ 更新 / 重登后需重启 QCE）。

## Tests

- 仓库 `npm test`（plugins/qq-chat-exporter）：80/80 通过 —— 后端只动控制台日志，跑测试确认没碰到鉴权 / SecurityManager 路径。
- 手动验证步骤：
  1. 启动 QCE，确认控制台多了一行 `[QCE] 一键登录: http://127.0.0.1:40653/qce-v4-tool/auth?token=...`；
  2. 复制链接到浏览器，看到顶部绿色条幅，0.1s 后自动跳到 `/qce-v4-tool`；
  3. 自动跳转完成后地址栏 URL 已不含 `token` 参数；
  4. 手动给 URL 写一个错的 token，观察自动登录失败时回退到手动输入表单、错误信息正常显示；
  5. 走「找不到令牌？」弹窗滚动到底，确认所有四块说明都正常。
- 鉴权语义不动：`SecurityManager` 行为零变更；URL 上的 token 走和手动输入完全相同的 `/auth` POST 校验通道，不放宽任何信任。

### Notes

- 一键登录链接打印在本机控制台，能看到控制台的人本来就有读 `security.json` 的权限，等价信息暴露面。
- 用 `replaceState` 而不是 `pushState`，确保后退按钮不会回到带 token 的 URL。