### PR TITLE
fix(preview): only restore body pointer-events if we still own the override (#300)

### DIFF
--- a/qce-v4-tool/components/ui/message-preview-modal.tsx
+++ b/qce-v4-tool/components/ui/message-preview-modal.tsx
@@ -236,9 +236,10 @@ export function MessagePreviewModal({ open, onClose, chat, onExport }: MessagePr
    * 层交互。结果就是任务向导里的 Dialog 还开着时打开预览，预览本身和它 fixed 子树
    * 也被一起禁掉了点击。
    *
-   * 这里在弹窗显示期间强制把 body 的 pointer-events 改回 auto，关闭后恢复成原样。
-   * 不动 Radix 自己的 modal=true 行为，只覆盖最末端的 body 状态，避免影响其它依赖
-   * Radix 屏蔽底层交互的弹层。
+   * 这里在弹窗显示期间强制把 body 的 pointer-events 改回 auto。关闭时只在当前 body
+   * 仍是我们写入的 `auto` 时才回写之前的值；如果其它来源（比如 Radix 关闭 wizard 时
+   * 同步清掉了它自己的 lock）已经动过，我们就不再覆盖，避免把陈旧的 'none' 写回去
+   * 把整页锁死（Codex review on PR #400）。
    */
   useEffect(() => {
     if (!open) return
@@ -247,9 +248,9 @@ export function MessagePreviewModal({ open, onClose, chat, onExport }: MessagePr
     const previous = body.style.pointerEvents
     body.style.pointerEvents = 'auto'
     return () => {
-      // 关闭时优先恢复打开前的值；遇到 Radix 把 body 的 inline 样式整个清掉的情况
-      // （previous 为空字符串）就保持空字符串，让浏览器回到默认值。
-      body.style.pointerEvents = previous
+      if (body.style.pointerEvents === 'auto') {
+        body.style.pointerEvents = previous
+      }
     }
   }, [open])
 


### PR DESCRIPTION
## Summary

Follow-up to #400 to fix a race condition flagged by the Codex review. The previous cleanup snapshotted `body.style.pointerEvents` on open and unconditionally wrote it back on close. If the underlying Radix `TaskWizard` dialog closes while the preview modal is still open (for example via Escape), Radix synchronously clears its own `pointer-events: none` lock on the body. When the preview later closes, the cleanup restores the stale `none` snapshot and leaves the entire page non-interactive until refresh.

The fix narrows cleanup to the case where the body still carries the value we wrote (`auto`):

```ts
return () => {
  if (body.style.pointerEvents === "auto") {
    body.style.pointerEvents = previous
  }
}
```

If anything else has already cleared it (Radix unlocking, another modal taking over, third-party code), we no longer touch it.

### Notes

- No behaviour change when the preview modal is the only consumer of the body lock; `previous` (typically `""`) is restored as before.
- Reviewed against Codex bot P1 comment on #400.