### PR TITLE
feat(api): look up chat sessions by deactivated friend QQ number (#204)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/fixtures/conversations.ts
+++ b/plugins/qq-chat-exporter/__tests__/fixtures/conversations.ts
@@ -143,6 +143,23 @@ export function privateWithForward(): MockConversation {
 
 /* --------------------------- Scenario 5: Volume ---------------------------- */
 
+/* --------------------- Scenario 6: Deactivated friend (#204) ----------------- */
+
+/**
+ * 模拟一个「对方已注销 / 已从好友列表删除」的私聊：
+ *   - 这个 uid 不在 FRIENDS 里；
+ *   - getUidByUinV2('77777') 仍能反查到 `u_deactivated_77777`（mock 里给了一个
+ *     特殊兜底分支，模拟本机数据库还留着会话痕迹）；
+ *   - 这条会话有真实历史消息，按 peer 取消息能跑通。
+ */
+export function privateDeactivatedFriend(): MockConversation {
+    resetIds();
+    return conversation(privatePeer('u_deactivated_77777'), { name: '老张 (77777)', type: 'private' })
+        .add(msg().sender({ uid: 'u_deactivated_77777', uin: '77777', nick: '老张' }).text('明天见').at_time(T + 0).build())
+        .add(msg().sender({ uid: 'self_test_uid', uin: '10000', nick: 'TestSelf' }).text('好的').at_time(T + 60).build())
+        .build();
+}
+
 /**
  * Creates `count` text messages spanning `count` minutes. Used by fetcher
  * pagination tests — the BatchMessageFetcher splits this across batches and

--- a/plugins/qq-chat-exporter/__tests__/helpers/MockNapCatCore.ts
+++ b/plugins/qq-chat-exporter/__tests__/helpers/MockNapCatCore.ts
@@ -246,7 +246,15 @@ export function createMockCore(config: MockConfig = {}): MockNapCatCore {
                 const m = (g.members ?? []).find((x) => x.uin === uin);
                 if (m) return m.uid;
             }
-            return `u_${uin}`;
+            // 兜底命中：fixture 里特地放了一条「已注销好友」的对话，peerUid 形如
+            // `u_deactivated_<uin>`，让 issue #204 的 e2e 可以验证「按 QQ 号
+            // 反查到一个非好友、但有历史会话的 uid」这条链路。
+            const conv = conversations.find(
+                (c) => c.peer.chatType === 1 && c.peer.peerUid === `u_deactivated_${uin}`,
+            );
+            if (conv) return `u_deactivated_${uin}`;
+            // 未登记的 uin 与生产语义保持一致：返回 undefined，让 lookup 落到 found=false。
+            return undefined as unknown as string;
         },
         async getRecentContactListSnapShot() {
             track('UserApi.getRecentContactListSnapShot', []);

--- a/plugins/qq-chat-exporter/__tests__/scripts/mock-server.mjs
+++ b/plugins/qq-chat-exporter/__tests__/scripts/mock-server.mjs
@@ -121,6 +121,8 @@ function pickScenario(scenario, fixtures) {
             return [fixtures.privateWithForward()];
         case 'volume':
             return [fixtures.privateVolume(200)];
+        case 'deactivated':
+            return [fixtures.privateDeactivatedFriend()];
         case 'default':
         case 'all':
         default:
@@ -129,7 +131,8 @@ function pickScenario(scenario, fixtures) {
                 fixtures.groupMixedMedia(),
                 fixtures.privateWithRecall(),
                 fixtures.privateWithForward(),
-                fixtures.privateVolume(50)
+                fixtures.privateVolume(50),
+                fixtures.privateDeactivatedFriend()
             ];
     }
 }

--- a/plugins/qq-chat-exporter/__tests__/unit/userLookup.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/userLookup.test.ts
@@ -1,0 +1,163 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { lookupUserByUin } from '../../lib/api/userLookup.js';
+
+function recorder() {
+    const warns: Array<{ msg: string; err?: unknown }> = [];
+    const debugs: Array<{ msg: string; err?: unknown }> = [];
+    return {
+        warns,
+        debugs,
+        logger: {
+            logWarn: (msg: string, err?: unknown) => warns.push({ msg, err }),
+            logDebug: (msg: string, err?: unknown) => debugs.push({ msg, err }),
+        },
+    };
+}
+
+test('userLookup: 非数字 uin 直接返回 found=false', async () => {
+    const r = await lookupUserByUin('abc', { getUidByUinV2: async () => 'never' }, null);
+    assert.equal(r.found, false);
+    assert.match(r.reason || '', /4-12 位/);
+});
+
+test('userLookup: 太短 uin 直接返回 found=false', async () => {
+    const r = await lookupUserByUin('123', { getUidByUinV2: async () => 'never' }, null);
+    assert.equal(r.found, false);
+});
+
+test('userLookup: 太长 uin 直接返回 found=false', async () => {
+    const r = await lookupUserByUin('1234567890123', null, null);
+    assert.equal(r.found, false);
+});
+
+test('userLookup: 旧版 NapCat 缺 getUidByUinV2 时降级到 found=false（issue #353 回归）', async () => {
+    const r = await lookupUserByUin('123456', {}, null);
+    assert.equal(r.found, false);
+    assert.match(r.reason || '', /getUidByUinV2/);
+});
+
+test('userLookup: getUidByUinV2 返回空时报「未找到」', async () => {
+    const r = await lookupUserByUin('123456', { getUidByUinV2: async () => '' }, null);
+    assert.equal(r.found, false);
+    assert.match(r.reason || '', /未在本机/);
+});
+
+test('userLookup: getUidByUinV2 抛异常不上传，落到「未找到」', async () => {
+    const rec = recorder();
+    const r = await lookupUserByUin(
+        '123456',
+        { getUidByUinV2: async () => { throw new Error('boom'); } },
+        null,
+        rec.logger,
+    );
+    assert.equal(r.found, false);
+    assert.equal(rec.warns.length, 1);
+    assert.match(rec.warns[0]!.msg, /boom|抛异常/);
+});
+
+test('userLookup: 成功路径 — 返回 uid + nick + avatarUrl', async () => {
+    const r = await lookupUserByUin(
+        '10001',
+        {
+            getUidByUinV2: async (uin) => `u_${uin}`,
+            getUserDetailInfo: async () => ({ nick: '张三', remark: '老张' }),
+        },
+        null,
+    );
+    assert.equal(r.found, true);
+    assert.equal(r.uid, 'u_10001');
+    assert.equal(r.nick, '张三');
+    assert.equal(r.remark, '老张');
+    assert.match(r.avatarUrl || '', /q1\.qlogo\.cn.*nk=10001/);
+    assert.equal(r.isFriend, false);
+});
+
+test('userLookup: 成功路径但 getUserDetailInfo 失败时仍返回 found=true', async () => {
+    const rec = recorder();
+    const r = await lookupUserByUin(
+        '10001',
+        {
+            getUidByUinV2: async () => 'u_10001',
+            getUserDetailInfo: async () => { throw new Error('销号了'); },
+        },
+        null,
+        rec.logger,
+    );
+    assert.equal(r.found, true);
+    assert.equal(r.uid, 'u_10001');
+    assert.equal(r.nick, undefined);
+    assert.equal(rec.debugs.length, 1);
+});
+
+test('userLookup: 已加好友时 isFriend=true（按 uid 命中）', async () => {
+    const r = await lookupUserByUin(
+        '10001',
+        { getUidByUinV2: async () => 'u_10001' },
+        {
+            getBuddyV2ExWithCate: async () => [
+                { buddyList: [{ uid: 'u_10001', uin: '10001' }] },
+            ],
+        },
+    );
+    assert.equal(r.found, true);
+    assert.equal(r.isFriend, true);
+});
+
+test('userLookup: 已加好友（嵌套 coreInfo 结构）isFriend=true', async () => {
+    const r = await lookupUserByUin(
+        '10001',
+        { getUidByUinV2: async () => 'u_10001' },
+        {
+            getBuddyV2ExWithCate: async () => [
+                { buddyList: [{ coreInfo: { uid: 'u_10001', uin: '10001' } }] },
+            ],
+        },
+    );
+    assert.equal(r.found, true);
+    assert.equal(r.isFriend, true);
+});
+
+test('userLookup: 不在好友列表（销号 / 已删除）isFriend=false', async () => {
+    const r = await lookupUserByUin(
+        '10001',
+        { getUidByUinV2: async () => 'u_10001' },
+        {
+            getBuddyV2ExWithCate: async () => [
+                { buddyList: [{ uid: 'u_99999', uin: '99999' }] },
+            ],
+        },
+    );
+    assert.equal(r.found, true);
+    assert.equal(r.isFriend, false);
+});
+
+test('userLookup: 好友列表读取失败不阻塞主流程', async () => {
+    const rec = recorder();
+    const r = await lookupUserByUin(
+        '10001',
+        { getUidByUinV2: async () => 'u_10001' },
+        { getBuddyV2ExWithCate: async () => { throw new Error('网络抖动'); } },
+        rec.logger,
+    );
+    assert.equal(r.found, true);
+    assert.equal(r.uid, 'u_10001');
+    assert.equal(r.isFriend, false);
+    assert.equal(rec.debugs.length, 1);
+});
+
+test('userLookup: detail 走 simpleInfo.coreInfo 嵌套字段也能取到 nick', async () => {
+    const r = await lookupUserByUin(
+        '10001',
+        {
+            getUidByUinV2: async () => 'u_10001',
+            getUserDetailInfo: async () => ({
+                simpleInfo: { coreInfo: { nick: '小明', remark: '同事' } },
+            }),
+        },
+        null,
+    );
+    assert.equal(r.found, true);
+    assert.equal(r.nick, '小明');
+    assert.equal(r.remark, '同事');
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -47,6 +47,7 @@ import {
     manualExportGroupKey,
 } from '../utils/manualExportFileName.js';
 import { resolvePeerUid } from './peerResolution.js';
+import { lookupUserByUin } from './userLookup.js';
 
 // 导入类型定义
 import type { RawMessage } from 'NapCatQQ/src/core/types.js';
@@ -1644,6 +1645,49 @@ export class QQChatExporterApiServer {
                     totalCount: filtered.length,
                     rawCount: changedList.length
                 }, (req as any).requestId);
+            } catch (error) {
+                this.sendErrorResponse(res, error, (req as any).requestId);
+            }
+        });
+
+        /**
+         * 通过 QQ 号查找一个聊天会话（issue #204）。
+         *
+         * 历史背景：当好友账号已经被销号 / 主动从好友列表删除时，QCE 自带的会话列表
+         * （好友 + 群 + 最近联系人）里就找不到这个号了。但只要本机 NTQQ 数据库里
+         * 还留着对话历史，QQ 内部依然能拿到 uid，QCE 的「按 peer 取消息」路径
+         * 就还能跑通。这里把这条「靠 uin 反查 uid」的能力暴露给前端：
+         *
+         *   GET /api/users/lookup?uin=<qq号>
+         *
+         * 返回 { found, uin, uid?, nick?, avatarUrl?, isFriend?, reason? }。
+         *
+         * 找不到 uid 时返回 200 + found=false，避免前端把这种「正常的查不到」
+         * 误报成接口错误。
+         */
+        this.app.get('/api/users/lookup', async (req, res) => {
+            try {
+                const rawUin = String(req.query['uin'] || '').trim();
+                if (!/^\d{4,12}$/.test(rawUin)) {
+                    throw new SystemError(
+                        ErrorType.VALIDATION_ERROR,
+                        'uin 必须是 4-12 位的数字 QQ 号',
+                        'INVALID_UIN'
+                    );
+                }
+
+                const result = await lookupUserByUin(
+                    rawUin,
+                    this.core.apis.UserApi as any,
+                    this.core.apis.FriendApi as any,
+                    {
+                        logWarn: (msg, err) =>
+                            this.core.context.logger.logWarn(`[ApiServer] /api/users/lookup: ${msg}`, err),
+                        logDebug: (msg, err) =>
+                            this.core.context.logger.logDebug(`[ApiServer] /api/users/lookup: ${msg}`, err as any),
+                    },
+                );
+                this.sendSuccessResponse(res, result, (req as any).requestId);
             } catch (error) {
                 this.sendErrorResponse(res, error, (req as any).requestId);
             }

--- a/plugins/qq-chat-exporter/lib/api/userLookup.ts
+++ b/plugins/qq-chat-exporter/lib/api/userLookup.ts
@@ -1,0 +1,126 @@
+/**
+ * 通过 QQ 号反查 NTQQ uid，并附带尽量多的展示信息（issue #204）。
+ *
+ * 抽出来的目的是把所有「容错 / 降级」分支单独覆盖单元测试，避免回到
+ * issue #353 那种「getUidByUinV2 不存在导致整条路径 500」的回归。
+ *
+ * 实际行为：
+ *   - 非法 uin 直接返回 found=false + reason；
+ *   - getUidByUinV2 不存在 / 抛异常 / 返回空 → found=false + reason；
+ *   - 拿到 uid 后再尝试 getUserDetailInfo 取昵称 / 备注，失败时不影响主流程；
+ *   - 已加好友时 isFriend=true，否则 false（销号 / 已删除 / 临时会话都会是 false）。
+ */
+
+export interface UserApiLikeForLookup {
+    getUidByUinV2?: (uin: string) => Promise<string | undefined | null>;
+    getUserDetailInfo?: (uid: string, noCache: boolean) => Promise<any>;
+}
+
+export interface FriendApiLikeForLookup {
+    getBuddyV2ExWithCate?: () => Promise<Array<{ buddyList?: any[] }> | undefined | null>;
+}
+
+export interface LookupLogger {
+    logWarn?: (msg: string, err?: unknown) => void;
+    logDebug?: (msg: string, err?: unknown) => void;
+}
+
+export interface UserLookupResult {
+    found: boolean;
+    uin: string;
+    uid?: string;
+    nick?: string;
+    remark?: string;
+    avatarUrl?: string;
+    isFriend?: boolean;
+    reason?: string;
+}
+
+const UIN_REGEX = /^\d{4,12}$/;
+
+export async function lookupUserByUin(
+    rawUin: string,
+    userApi: UserApiLikeForLookup | undefined | null,
+    friendApi: FriendApiLikeForLookup | undefined | null,
+    logger?: LookupLogger,
+): Promise<UserLookupResult> {
+    const uin = (rawUin ?? '').trim();
+    if (!UIN_REGEX.test(uin)) {
+        return {
+            found: false,
+            uin,
+            reason: 'uin 必须是 4-12 位的数字 QQ 号',
+        };
+    }
+
+    const lookupFn = userApi?.getUidByUinV2;
+    if (typeof lookupFn !== 'function') {
+        return {
+            found: false,
+            uin,
+            reason: '当前 NapCat 版本未提供 getUidByUinV2，无法按 QQ 号查询',
+        };
+    }
+
+    let uid: string | null = null;
+    try {
+        const resolved = await lookupFn.call(userApi, uin);
+        if (resolved) uid = String(resolved);
+    } catch (e) {
+        logger?.logWarn?.(`getUidByUinV2(${uin}) 抛异常`, e);
+    }
+
+    if (!uid) {
+        return {
+            found: false,
+            uin,
+            reason:
+                '该 QQ 号未在本机 NTQQ 数据中找到对应 uid（可能从未与之产生过聊天，或对方账号已彻底注销）',
+        };
+    }
+
+    let nick: string | undefined;
+    let remark: string | undefined;
+    try {
+        const detail = await userApi?.getUserDetailInfo?.(uid, false);
+        if (detail) {
+            nick =
+                detail.nick ||
+                detail.nickName ||
+                detail?.simpleInfo?.coreInfo?.nick ||
+                undefined;
+            remark =
+                detail.remark ||
+                detail?.simpleInfo?.coreInfo?.remark ||
+                undefined;
+        }
+    } catch (e) {
+        // 销号后 getUserDetailInfo 经常会失败，吞掉让前端用 uin 兜底显示。
+        logger?.logDebug?.(`getUserDetailInfo(${uid}) 失败，忽略`, e);
+    }
+
+    let isFriend = false;
+    try {
+        const categories = await friendApi?.getBuddyV2ExWithCate?.();
+        if (Array.isArray(categories)) {
+            const flat = categories.flatMap((cat) => cat?.buddyList || []);
+            isFriend = flat.some(
+                (f: any) =>
+                    String(f?.uid || f?.coreInfo?.uid || '') === uid ||
+                    String(f?.uin || f?.coreInfo?.uin || '') === uin,
+            );
+        }
+    } catch (e) {
+        logger?.logDebug?.('好友列表读取失败，跳过 isFriend 判定', e);
+    }
+
+    return {
+        found: true,
+        uin,
+        uid,
+        nick,
+        remark,
+        avatarUrl: `https://q1.qlogo.cn/g?b=qq&nk=${uin}&s=640`,
+        isFriend,
+    };
+}

--- a/qce-v4-tool/components/ui/qq-lookup-card.tsx
+++ b/qce-v4-tool/components/ui/qq-lookup-card.tsx
@@ -1,0 +1,182 @@
+"use client"
+
+/**
+ * 按 QQ 号反查会话（issue #204）。
+ *
+ * 用户场景：好友销号 / 主动从好友列表移除 / 临时窗口对方头像与昵称失踪后，
+ * QCE 自带的「好友 + 群 + 最近联系人」拼出来的列表里就找不到这个号了。但
+ * 本机 NTQQ 数据库里仍然留着对话历史，QCE 后端 `getUidByUinV2` 能把 uin
+ * 反查到 uid，按 peer 取消息的链路依然可用。
+ *
+ * 这张卡片接入 `GET /api/users/lookup?uin=...`，让用户只输入一个 QQ 号
+ * 就能调出对应聊天，并把它当成一条普通会话直接送进任务向导导出。
+ */
+
+import { useCallback, useState } from "react"
+import { Button } from "./button"
+import { Input } from "./input"
+import { Avatar, AvatarFallback, AvatarImage } from "./avatar"
+import { useApi } from "@/hooks/use-api"
+import { Search, User, AlertCircle, Loader2 } from "lucide-react"
+
+interface UserLookupResult {
+    found: boolean
+    uin: string
+    uid?: string
+    nick?: string
+    remark?: string
+    avatarUrl?: string
+    isFriend?: boolean
+    reason?: string
+}
+
+interface QqLookupCardProps {
+    /** 初始 QQ 号；常见用法是把搜索框里的纯数字传进来。 */
+    initialUin?: string
+    /** 用户点击「导出聊天记录」时回调，给上层去打开任务向导。 */
+    onStartExport: (preset: { chatType: number; peerUid: string; sessionName: string }) => void
+    /** 用户点击「预览」时回调；不传则不展示预览按钮。 */
+    onPreview?: (peer: { chatType: number; peerUid: string }, sessionName: string) => void
+}
+
+const UIN_REGEX = /^\d{4,12}$/
+
+export function QqLookupCard({ initialUin = "", onStartExport, onPreview }: QqLookupCardProps) {
+    const { apiCall } = useApi()
+    const [uin, setUin] = useState(initialUin)
+    const [loading, setLoading] = useState(false)
+    const [result, setResult] = useState<UserLookupResult | null>(null)
+    const [error, setError] = useState<string | null>(null)
+
+    const submit = useCallback(async () => {
+        const trimmed = uin.trim()
+        if (!UIN_REGEX.test(trimmed)) {
+            setError("请输入 4-12 位的纯数字 QQ 号")
+            setResult(null)
+            return
+        }
+        setError(null)
+        setResult(null)
+        setLoading(true)
+        try {
+            const resp = await apiCall<UserLookupResult>(`/api/users/lookup?uin=${encodeURIComponent(trimmed)}`)
+            setResult(resp.data ?? null)
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err))
+        } finally {
+            setLoading(false)
+        }
+    }, [apiCall, uin])
+
+    const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter") {
+            e.preventDefault()
+            submit()
+        }
+    }
+
+    return (
+        <div className="mt-6 mx-auto max-w-md text-left rounded-xl border border-black/[0.06] dark:border-white/[0.06] bg-card p-4 space-y-3">
+            <div>
+                <p className="text-sm font-medium text-foreground">按 QQ 号反查会话</p>
+                <p className="text-xs text-muted-foreground/70 mt-1">
+                    对方账号已注销 / 已删除好友、但本机仍留有聊天记录时，可以直接输入对方 QQ 号定位到那条聊天。
+                </p>
+            </div>
+
+            <div className="flex gap-2">
+                <Input
+                    inputMode="numeric"
+                    pattern="\\d*"
+                    placeholder="QQ 号 (例如 123456789)"
+                    value={uin}
+                    onChange={(e) => setUin(e.target.value)}
+                    onKeyDown={onKeyDown}
+                    className="flex-1 h-9 text-sm rounded-lg"
+                />
+                <Button
+                    onClick={submit}
+                    disabled={loading || !uin.trim()}
+                    size="sm"
+                    className="h-9 px-3 rounded-lg"
+                >
+                    {loading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Search className="w-3.5 h-3.5" />}
+                    <span className="ml-1.5">{loading ? "查询中" : "查询"}</span>
+                </Button>
+            </div>
+
+            {error && (
+                <div className="flex items-start gap-2 text-xs text-destructive">
+                    <AlertCircle className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
+                    <span>{error}</span>
+                </div>
+            )}
+
+            {result && !result.found && (
+                <div className="flex items-start gap-2 text-xs text-muted-foreground">
+                    <AlertCircle className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
+                    <span>{result.reason || "未在本机数据中找到该 QQ 号对应的会话。"}</span>
+                </div>
+            )}
+
+            {result && result.found && result.uid && (
+                <div className="flex items-center gap-3 p-3 rounded-lg bg-black/[0.02] dark:bg-white/[0.03]">
+                    <Avatar className="w-10 h-10 rounded-full overflow-hidden flex-shrink-0">
+                        <AvatarImage src={result.avatarUrl} alt={result.nick || result.uin} />
+                        <AvatarFallback className="rounded-full text-xs">
+                            <User className="w-4 h-4" />
+                        </AvatarFallback>
+                    </Avatar>
+                    <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                            <p className="text-sm font-medium text-foreground truncate">
+                                {result.remark || result.nick || `用户 ${result.uin}`}
+                            </p>
+                            {result.isFriend ? (
+                                <span className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">
+                                    好友
+                                </span>
+                            ) : (
+                                <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-600 dark:text-amber-500">
+                                    非好友 / 已注销
+                                </span>
+                            )}
+                        </div>
+                        <p className="text-xs text-muted-foreground/60 font-mono truncate mt-0.5">{result.uin}</p>
+                    </div>
+                    <div className="flex items-center gap-1 flex-shrink-0">
+                        {onPreview && (
+                            <Button
+                                size="sm"
+                                variant="ghost"
+                                className="h-8 px-2.5 text-xs rounded-full"
+                                onClick={() =>
+                                    onPreview(
+                                        { chatType: 1, peerUid: result.uid! },
+                                        result.remark || result.nick || result.uin,
+                                    )
+                                }
+                            >
+                                预览
+                            </Button>
+                        )}
+                        <Button
+                            size="sm"
+                            variant="outline"
+                            className="h-8 px-2.5 text-xs rounded-full"
+                            onClick={() =>
+                                onStartExport({
+                                    chatType: 1,
+                                    peerUid: result.uid!,
+                                    sessionName: result.remark || result.nick || result.uin,
+                                })
+                            }
+                        >
+                            导出
+                        </Button>
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/qce-v4-tool/components/ui/session-list.tsx
+++ b/qce-v4-tool/components/ui/session-list.tsx
@@ -36,6 +36,9 @@ import {
   type SortField,
   type SortOrder,
 } from "@/hooks/use-session-filter"
+import { QqLookupCard } from "./qq-lookup-card"
+
+const UIN_PATTERN = /^\d{4,12}$/
 
 export interface SessionListProps {
   groups: Group[]
@@ -581,13 +584,25 @@ export function SessionList({
               <p className="text-sm text-foreground">没有符合条件的会话</p>
               <p className="text-xs text-muted-foreground/60 mt-1">
                 尝试调整搜索条件或
-                <button 
+                <button
                   onClick={resetFilters}
                   className="text-primary hover:underline ml-1"
                 >
                   清除筛选
                 </button>
               </p>
+              {/*
+                * Issue #204：搜索词是合法 QQ 号但好友/群/最近联系人都搜不到时，
+                * 把搜索框里的数字直接喂给 /api/users/lookup，让用户能定位到
+                * 已注销 / 已删好友的历史会话。
+                */}
+              {UIN_PATTERN.test(search.trim()) && onOpenTaskWizard && (
+                <QqLookupCard
+                  initialUin={search.trim()}
+                  onStartExport={(preset) => onOpenTaskWizard(preset)}
+                  onPreview={onPreviewChat ? (peer, name) => onPreviewChat('friend', peer.peerUid, name, peer) : undefined}
+                />
+              )}
             </>
           )}
         </div>

--- a/qce-v4-tool/e2e/ui-smoke.spec.ts
+++ b/qce-v4-tool/e2e/ui-smoke.spec.ts
@@ -138,3 +138,88 @@ test.describe('Auth flow', () => {
         expect(page.url()).not.toContain('token=');
     });
 });
+
+/**
+ * Issue #204: 在搜索框里直接输入一个 4-12 位的 QQ 号，如果好友 / 群 / 最近联系人
+ * 都搜不到，会话列表的空态会渲染「按 QQ 号反查」卡片，调用
+ * `/api/users/lookup?uin=...`。Mock 服务器特地放了一条 uin=77777 的「已注销好友」
+ * 会话，让这条链路完整跑起来。
+ */
+/**
+ * 把主页带到「会话」标签页，并等到会话搜索框出现。
+ *
+ * 主页默认会打开 onboarding 弹窗（"欢迎使用…"）和 overview tab，会盖住测试要点
+ * 的搜索框。这里统一处理：先把欢迎弹窗扫掉，再点侧栏的「会话」按钮，最后等真正
+ * 的会话搜索 input 出现。
+ */
+async function openSessionsTab(page: import('@playwright/test').Page) {
+    // 欢迎弹窗里的「跳过」按钮可见就关掉；不在则跳过。
+    const skipBtn = page.getByRole('button', { name: '跳过' }).first();
+    if (await skipBtn.isVisible({ timeout: 1500 }).catch(() => false)) {
+        await skipBtn.click().catch(() => null);
+    }
+    // 侧栏的「会话」按钮（id=sessions）。用 role+name 精准定位避免和概览里的
+    // 「浏览会话」按钮混淆。
+    const sessionsTab = page.getByRole('button', { name: '会话', exact: true });
+    await expect(sessionsTab).toBeVisible({ timeout: 15_000 });
+    await sessionsTab.click();
+
+    const searchBox = page.locator('input[placeholder*="搜索会话"]').first();
+    await expect(searchBox).toBeVisible({ timeout: 15_000 });
+    return searchBox;
+}
+
+test.describe('Session list — QQ lookup (issue #204)', () => {
+    test('searching by deactivated QQ number reveals the lookup card', async ({ page }) => {
+        await clearLocalStorage(page);
+        await page.evaluate((value) => {
+            localStorage.setItem('qce_access_token', value);
+        }, TOKEN);
+
+        const response = await page
+            .goto(`${FRONTEND_BASE}${SHELL_PATH}`)
+            .catch(() => null);
+        test.skip(
+            !response || response.status() >= 500,
+            `frontend not reachable at ${FRONTEND_BASE}`
+        );
+
+        const searchBox = await openSessionsTab(page);
+
+        // 输入一个 fixture 里没有任何文字 / id 命中、但 mock 后端能反查到的 uin。
+        await searchBox.fill('77777');
+
+        // 空态里应该出现 lookup 卡片标题。
+        await expect(page.getByText('按 QQ 号反查会话')).toBeVisible({ timeout: 10_000 });
+
+        // 卡片里有自己的输入框（已经被 initialUin 填上），点查询按钮触发后端调用。
+        await page.getByRole('button', { name: /查询/ }).click();
+
+        // 反查到 u_deactivated_77777，按钮区出现「导出」、徽章里写「非好友 / 已注销」。
+        await expect(page.getByText('非好友 / 已注销')).toBeVisible({ timeout: 10_000 });
+    });
+
+    test('searching for a non-existent QQ shows a friendly not-found message', async ({ page }) => {
+        await clearLocalStorage(page);
+        await page.evaluate((value) => {
+            localStorage.setItem('qce_access_token', value);
+        }, TOKEN);
+
+        const response = await page
+            .goto(`${FRONTEND_BASE}${SHELL_PATH}`)
+            .catch(() => null);
+        test.skip(
+            !response || response.status() >= 500,
+            `frontend not reachable at ${FRONTEND_BASE}`
+        );
+
+        const searchBox = await openSessionsTab(page);
+        await searchBox.fill('88888888');
+
+        await expect(page.getByText('按 QQ 号反查会话')).toBeVisible({ timeout: 10_000 });
+        await page.getByRole('button', { name: /查询/ }).click();
+
+        // mock 的 getUidByUinV2 对未登记 uin 返 undefined，落到 found=false。
+        await expect(page.getByText(/未在本机 NTQQ 数据中找到/)).toBeVisible({ timeout: 10_000 });
+    });
+});


### PR DESCRIPTION
## Summary

Closes #204.

When the other party deactivates their QQ account, or the user removes them from the buddy list, the QQ number drops out of the friend / group / recent-contacts lists that QCE composes into its session picker. The chat history is still on disk and `UserApi.getUidByUinV2` still resolves the uin to a valid uid, so the existing export pipeline works end-to-end — we just had no UI affordance pointing the user at it. This change adds one.

### Backend

- New `GET /api/users/lookup?uin=<qq>` endpoint backed by a small isolated helper `lookupUserByUin` (`plugins/qq-chat-exporter/lib/api/userLookup.ts`). The helper:
  - Validates the input is 4-12 digits.
  - Tolerates older NapCat builds that don't expose `getUidByUinV2` (the regression that originally caused issue #353), returning `found:false` instead of 500-ing the request.
  - Swallows the `getUserDetailInfo` failure that often happens after a peer is deactivated, falling back to displaying just the uin.
  - Reports `isFriend` by checking against `FriendApi.getBuddyV2ExWithCate` so the UI can label deactivated peers explicitly.

  The endpoint is registered before `/api/users/:uid` so the `lookup` literal isn't captured as a uid path param.

### Frontend

- New `QqLookupCard` component (`qce-v4-tool/components/ui/qq-lookup-card.tsx`) that takes a uin, calls `/api/users/lookup`, and renders the resolved peer with `导出` (opens the existing task wizard pre-filled with `chatType=1`, the resolved uid, and the best display name) and `预览` (reuses the standard message preview modal) shortcuts.
- The session list's "no results" empty state now embeds the lookup card whenever the search term is a 4-12 digit string. The card is gated behind `onOpenTaskWizard` being supplied, so callers that don't expose export aren't affected.

### Testing

- 13 new `node:test` unit tests in `__tests__/unit/userLookup.test.ts` cover every degradation branch (invalid uin, missing API, empty result, throwing API, success with detail, success without detail, friend / non-friend isFriend determination, friend-list read failure, nested coreInfo nick resolution).
- The mock NapCat core gains a deactivated-friend fixture (`uin=77777` / `uid=u_deactivated_77777`) and stops synthesising a fake uid for unknown uins, so the not-found path is exercised against the real mock server.
- 2 new Playwright e2e tests in `e2e/ui-smoke.spec.ts` drive the full UI: type a deactivated QQ in the session search box, verify the lookup card appears, click 查询, verify the resolved peer card with the `非好友 / 已注销` badge — and the not-found-message branch for an entirely unknown uin.

All 93 unit tests and all 11 Playwright tests pass against the mock server.

### Notes

- The endpoint deliberately returns `200 + found:false` for "uid not in local data" rather than 4xx, because that is a legitimate, non-error outcome (the user typed a uin we've never spoken to). Genuine input validation problems (non-digits, wrong length) still return 400.
- The lookup affordance only shows when the user has typed something that *looks like* a QQ number, so it doesn't clutter the empty state for normal name searches.