### PR TITLE
feat(api): summarize per-batch resource downloads on task completion (#363)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/ResourceHandler.batchSummary.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/ResourceHandler.batchSummary.test.ts
@@ -1,0 +1,222 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { DatabaseManager } from '../../lib/core/storage/DatabaseManager.js';
+import { ResourceHandler } from '../../lib/core/resource/ResourceHandler.js';
+import { ResourceStatus } from '../../lib/types/index.js';
+import { createMockCore } from '../helpers/MockNapCatCore.js';
+import { msg } from '../fixtures/builders.js';
+
+/**
+ * Issue #363 — `processMessageResources` 之后能拿到一个干净的批次摘要：
+ *   - attempted 包含本次扫描到的所有资源；
+ *   - skipped 计 `setSkipDownloadTypes` 命中的；
+ *   - failed / downloaded 区分对，能让 ApiServer 给用户一句话总结，
+ *     避免他们把 NapCat 的 `[Rkey] 所有服务均已禁用` 日志当成导出失败。
+ *
+ * 测试只走「跳过文件 + 一张图片下载失败」这条最常见的、最贴近 #363 截图场景的路径。
+ */
+
+function tmpDir(prefix: string): { dir: string; cleanup: () => void } {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    return { dir, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
+}
+
+test('processMessageResources 后 getLastBatchSummary 返回正确的 attempted/skipped/failed', async () => {
+    const dbHome = tmpDir('qce-rh-db-');
+    const resHome = tmpDir('qce-rh-res-');
+    const prevUserProfile = process.env['USERPROFILE'];
+    process.env['USERPROFILE'] = resHome.dir;
+
+    try {
+        const dbPath = path.join(dbHome.dir, 'qce.sqlite');
+        const db = new DatabaseManager(dbPath);
+        await db.initialize();
+
+        const core = createMockCore();
+        const handler = new ResourceHandler(core as any, db, {
+            downloadTimeout: 200,
+            maxConcurrentDownloads: 1,
+            maxRetries: 0,
+            healthCheckInterval: 60_000,
+        });
+        handler.setSkipDownloadTypes(['file']);
+
+        // 一条消息带 1 个图片 + 1 个文件。文件被跳过下载，图片走默认健康检查（mock 环境拿不到合法链接）。
+        const m = msg({ peerUid: 'peer_a', chatType: 1, senderUid: 'u_other' })
+            .image({ md5: 'aabbccdd11', fileName: 'pic.jpg' })
+            .file({ filename: 'spec.pdf', size: 1024, md5: 'aabbccdd22' })
+            .build();
+
+        const resourceMap = await handler.processMessageResources([m]);
+        const summary = handler.getLastBatchSummary();
+
+        // 摘要总数应该等于实际解析出的资源数
+        const totalParsed = (resourceMap.get(m.msgId) || []).length;
+        assert.equal(summary.attempted, totalParsed);
+        assert.ok(summary.attempted >= 1, 'attempted 至少应当包含图片或文件中的一个');
+        assert.equal(summary.skipped, 1, '文件应被跳过');
+        // 摘要的四项加起来应等于 attempted（不重不漏）
+        assert.equal(
+            summary.alreadyAvailable + summary.downloaded + summary.failed + summary.skipped,
+            summary.attempted,
+        );
+        // 命中的所有资源里至少图片那条不会是 SKIPPED
+        const resources = resourceMap.get(m.msgId)!;
+        const nonSkipped = resources.filter(r => r.status !== ResourceStatus.SKIPPED);
+        assert.ok(nonSkipped.length >= 1);
+
+        await handler.cleanup();
+        await db.close();
+    } finally {
+        if (prevUserProfile === undefined) {
+            delete process.env['USERPROFILE'];
+        } else {
+            process.env['USERPROFILE'] = prevUserProfile;
+        }
+        dbHome.cleanup();
+        resHome.cleanup();
+    }
+});
+
+test('failedSamples 最多收集 5 条', async () => {
+    const dbHome = tmpDir('qce-rh-db-');
+    const resHome = tmpDir('qce-rh-res-');
+    const prevUserProfile = process.env['USERPROFILE'];
+    process.env['USERPROFILE'] = resHome.dir;
+
+    try {
+        const dbPath = path.join(dbHome.dir, 'qce.sqlite');
+        const db = new DatabaseManager(dbPath);
+        await db.initialize();
+
+        const core = createMockCore();
+        const handler = new ResourceHandler(core as any, db, {
+            downloadTimeout: 100,
+            maxConcurrentDownloads: 2,
+            maxRetries: 0,
+            healthCheckInterval: 60_000,
+        });
+
+        // 7 张图片，模拟所有图片都拿不到 url（mock 环境本就如此）。
+        const m = msg({ peerUid: 'peer_b', chatType: 1, senderUid: 'u_other' });
+        for (let i = 0; i < 7; i++) {
+            m.image({ md5: `face00${i}`, fileName: `img-${i}.jpg` });
+        }
+
+        await handler.processMessageResources([m.build()]);
+        const summary = handler.getLastBatchSummary();
+
+        assert.equal(summary.attempted, 7);
+        // 不强约束 failed 的具体数目（mock 网络环境结果有抖动），但 failedSamples 永远不超过 5。
+        assert.ok(summary.failedSamples.length <= 5, `failedSamples 不应超过 5 条，实际 ${summary.failedSamples.length}`);
+
+        await handler.cleanup();
+        await db.close();
+    } finally {
+        if (prevUserProfile === undefined) {
+            delete process.env['USERPROFILE'];
+        } else {
+            process.env['USERPROFILE'] = prevUserProfile;
+        }
+        dbHome.cleanup();
+        resHome.cleanup();
+    }
+});
+
+test('再次调用 processMessageResources 时摘要会被重置而不是累加', async () => {
+    const dbHome = tmpDir('qce-rh-db-');
+    const resHome = tmpDir('qce-rh-res-');
+    const prevUserProfile = process.env['USERPROFILE'];
+    process.env['USERPROFILE'] = resHome.dir;
+
+    try {
+        const dbPath = path.join(dbHome.dir, 'qce.sqlite');
+        const db = new DatabaseManager(dbPath);
+        await db.initialize();
+
+        const core = createMockCore();
+        const handler = new ResourceHandler(core as any, db, {
+            downloadTimeout: 100,
+            maxConcurrentDownloads: 1,
+            maxRetries: 0,
+            healthCheckInterval: 60_000,
+        });
+        handler.setSkipDownloadTypes(['file']);
+
+        const m1 = msg({ peerUid: 'p', chatType: 1, senderUid: 'u' })
+            .file({ filename: 'a.pdf', size: 1, md5: 'aaaa01' })
+            .build();
+        const m2 = msg({ peerUid: 'p', chatType: 1, senderUid: 'u' })
+            .file({ filename: 'b.pdf', size: 1, md5: 'aaaa02' })
+            .file({ filename: 'c.pdf', size: 1, md5: 'aaaa03' })
+            .build();
+
+        await handler.processMessageResources([m1]);
+        const first = handler.getLastBatchSummary();
+        assert.equal(first.attempted, 1);
+        assert.equal(first.skipped, 1);
+
+        await handler.processMessageResources([m2]);
+        const second = handler.getLastBatchSummary();
+        assert.equal(second.attempted, 2, '第二批应只看到 2 条，不应累加上一次的');
+        assert.equal(second.skipped, 2);
+
+        await handler.cleanup();
+        await db.close();
+    } finally {
+        if (prevUserProfile === undefined) {
+            delete process.env['USERPROFILE'];
+        } else {
+            process.env['USERPROFILE'] = prevUserProfile;
+        }
+        dbHome.cleanup();
+        resHome.cleanup();
+    }
+});
+
+test('空消息列表给出 attempted=0 的摘要', async () => {
+    const dbHome = tmpDir('qce-rh-db-');
+    const resHome = tmpDir('qce-rh-res-');
+    const prevUserProfile = process.env['USERPROFILE'];
+    process.env['USERPROFILE'] = resHome.dir;
+
+    try {
+        const dbPath = path.join(dbHome.dir, 'qce.sqlite');
+        const db = new DatabaseManager(dbPath);
+        await db.initialize();
+
+        const core = createMockCore();
+        const handler = new ResourceHandler(core as any, db, {
+            downloadTimeout: 100,
+            maxConcurrentDownloads: 1,
+            maxRetries: 0,
+            healthCheckInterval: 60_000,
+        });
+
+        await handler.processMessageResources([]);
+        const summary = handler.getLastBatchSummary();
+        assert.deepEqual(summary, {
+            attempted: 0,
+            alreadyAvailable: 0,
+            downloaded: 0,
+            failed: 0,
+            skipped: 0,
+            failedSamples: [],
+        });
+
+        await handler.cleanup();
+        await db.close();
+    } finally {
+        if (prevUserProfile === undefined) {
+            delete process.env['USERPROFILE'];
+        } else {
+            process.env['USERPROFILE'] = prevUserProfile;
+        }
+        dbHome.cleanup();
+        resHome.cleanup();
+    }
+});

--- a/plugins/qq-chat-exporter/__tests__/unit/resourceSummary.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/resourceSummary.test.ts
@@ -1,0 +1,113 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildResourceSummaryMessage } from '../../lib/utils/resourceSummary.js';
+
+/**
+ * Issue #363 — 资源摘要文案契约测试。
+ *
+ * 这条文案会直接出现在任务完成消息里，所以约束几个稳定属性：
+ *   1. 没资源时返回 null（不在 UI 上多嘴）；
+ *   2. 全部成功时只给数字，不带 Rkey / 重试这种容易吓到人的解释；
+ *   3. 有失败时一定带：本次数字、Rkey 解释、重试指引。
+ */
+
+test('attempted=0 时返回 null', () => {
+    assert.equal(buildResourceSummaryMessage(null), null);
+    assert.equal(buildResourceSummaryMessage(undefined), null);
+    assert.equal(
+        buildResourceSummaryMessage({
+            attempted: 0,
+            alreadyAvailable: 0,
+            downloaded: 0,
+            failed: 0,
+            skipped: 0,
+            failedSamples: [],
+        }),
+        null,
+    );
+});
+
+test('全部成功时只展示比例，不出现 Rkey / 重试', () => {
+    const msg = buildResourceSummaryMessage({
+        attempted: 10,
+        alreadyAvailable: 4,
+        downloaded: 6,
+        failed: 0,
+        skipped: 0,
+        failedSamples: [],
+    });
+    assert.ok(msg);
+    assert.match(msg!, /资源 10\/10/);
+    assert.doesNotMatch(msg!, /Rkey/);
+    assert.doesNotMatch(msg!, /重试/);
+});
+
+test('包含失败时同时给出数字、Rkey 解释和重试建议', () => {
+    const msg = buildResourceSummaryMessage({
+        attempted: 12,
+        alreadyAvailable: 3,
+        downloaded: 5,
+        failed: 4,
+        skipped: 0,
+        failedSamples: ['a.jpg', 'b.jpg', 'c.jpg', 'd.jpg'],
+    });
+    assert.ok(msg);
+    // 用户最先想看到的：本次到底有几个没下到
+    assert.match(msg!, /失败 4/);
+    // 含部分样本（前 3 条 + 等）
+    assert.match(msg!, /a\.jpg/);
+    assert.match(msg!, /b\.jpg/);
+    assert.match(msg!, /c\.jpg/);
+    assert.doesNotMatch(msg!, /d\.jpg/, '只展示前 3 个样本');
+    assert.match(msg!, / 等/);
+    // 必备的解释和指引
+    assert.match(msg!, /Rkey/);
+    assert.match(msg!, /重试|点开/);
+});
+
+test('skipped 计数与失败计数互不干扰', () => {
+    const onlySkipped = buildResourceSummaryMessage({
+        attempted: 5,
+        alreadyAvailable: 0,
+        downloaded: 0,
+        failed: 0,
+        skipped: 5,
+        failedSamples: [],
+    });
+    assert.ok(onlySkipped);
+    assert.match(onlySkipped!, /跳过 5/);
+    assert.doesNotMatch(onlySkipped!, /失败/);
+    assert.doesNotMatch(onlySkipped!, /Rkey/);
+
+    const skippedAndFailed = buildResourceSummaryMessage({
+        attempted: 8,
+        alreadyAvailable: 1,
+        downloaded: 1,
+        failed: 4,
+        skipped: 2,
+        failedSamples: ['x'],
+    });
+    assert.ok(skippedAndFailed);
+    assert.match(skippedAndFailed!, /跳过 2/);
+    assert.match(skippedAndFailed!, /失败 4/);
+    assert.match(skippedAndFailed!, /Rkey/);
+});
+
+test('失败 ≤ 3 条时不出现「等」字', () => {
+    const msg = buildResourceSummaryMessage({
+        attempted: 5,
+        alreadyAvailable: 1,
+        downloaded: 1,
+        failed: 3,
+        skipped: 0,
+        failedSamples: ['p1.png', 'p2.png', 'p3.png'],
+    });
+    assert.ok(msg);
+    assert.match(msg!, /p1\.png/);
+    assert.match(msg!, /p2\.png/);
+    assert.match(msg!, /p3\.png/);
+    // 只有 3 条样本，不应缀「等」
+    const segment = msg!.match(/含 [^）]+/)![0];
+    assert.doesNotMatch(segment, / 等/, segment);
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -48,6 +48,7 @@ import {
 } from '../utils/manualExportFileName.js';
 import { resolvePeerUid } from './peerResolution.js';
 import { lookupUserByUin } from './userLookup.js';
+import { buildResourceSummaryMessage } from '../utils/resourceSummary.js';
 
 // 导入类型定义
 import type { RawMessage } from 'NapCatQQ/src/core/types.js';
@@ -1903,7 +1904,10 @@ export class QQChatExporterApiServer {
                     startTime: task.filter?.startTime,
                     endTime: task.filter?.endTime,
                     isZipExport: task.isZipExport,
-                    originalFilePath: task.originalFilePath
+                    originalFilePath: task.originalFilePath,
+                    // issue #363：把资源摘要带回前端，让任务列表能直接告诉用户
+                    // 「本次有几个资源没拿到、是不是 Rkey 降级、要不要重试」。
+                    resourceSummary: task.resourceSummary
                 })).sort((a, b) => {
                     // 按创建时间倒序排列（最新的任务在前面）
                     const aTime = new Date(a.createdAt).getTime();
@@ -1941,7 +1945,9 @@ export class QQChatExporterApiServer {
                     completedAt: task.completedAt,
                     error: task.error,
                     startTime: task.filter?.startTime,
-                    endTime: task.filter?.endTime
+                    endTime: task.filter?.endTime,
+                    // issue #363：单任务详情也带上资源摘要。
+                    resourceSummary: task.resourceSummary
                 }, (req as any).requestId);
             } catch (error) {
                 this.sendErrorResponse(res, error, (req as any).requestId);
@@ -3798,6 +3804,9 @@ export class QQChatExporterApiServer {
 
             // 处理资源下载（如果启用了纯多媒体消息过滤，则跳过资源下载）
             let resourceMap: Map<string, any>;
+            // issue #363：把每次资源批处理的结果留到任务上，便于完成时给出一句
+            // 人类可读的总结，避免用户被 NapCat Rkey 日志误导。
+            let resourceSummary: ReturnType<typeof taskResourceHandler.getLastBatchSummary> | null = null;
             if (!options?.filterPureImageMessages) {
                 task = this.exportTasks.get(taskId);
                 if (task) {
@@ -3851,11 +3860,16 @@ export class QQChatExporterApiServer {
 
                 // 下载和处理资源（使用过滤后的消息列表）
                 resourceMap = await taskResourceHandler.processMessageResources(filteredMessages);
-                
+                resourceSummary = taskResourceHandler.getLastBatchSummary();
+
                 // 清除进度回调
                 taskResourceHandler.setProgressCallback(null);
-                
-                console.info(`[ApiServer] 处理了 ${resourceMap.size} 个消息的资源`);
+
+                console.info(
+                    `[ApiServer] 处理了 ${resourceMap.size} 个消息的资源（attempted=${resourceSummary.attempted}, ` +
+                    `downloaded=${resourceSummary.downloaded}, alreadyAvailable=${resourceSummary.alreadyAvailable}, ` +
+                    `failed=${resourceSummary.failed}, skipped=${resourceSummary.skipped}）`,
+                );
             } else {
                 console.info(`[ApiServer] 已启用纯多媒体消息过滤，跳过资源下载`);
                 resourceMap = new Map(); // 不下载资源，使用空Map
@@ -4042,20 +4056,28 @@ export class QQChatExporterApiServer {
 
             const stats = fs.statSync(finalFilePath);
 
+            // issue #363：用资源摘要拼一句给用户看的总结，让任务完成态本身就把
+            // 「有几个资源没拿到、是不是 Rkey 降级、要不要重试」讲清楚。
+            const resourceSummaryMessage = buildResourceSummaryMessage(resourceSummary);
+            const completionMessage = resourceSummaryMessage
+                ? `导出完成 · ${resourceSummaryMessage}`
+                : '导出完成';
+
             // 更新任务为完成状态
             task = this.exportTasks.get(taskId);
             if (task) {
                 await this.updateTaskStatus(taskId, {
                     status: 'completed',
                     progress: 100,
-                    message: '导出完成',
+                    message: completionMessage,
                     messageCount: sortedMessages.length,
                     filePath: finalFilePath,
                     fileSize: stats.size,
                     completedAt: new Date().toISOString(),
                     fileName: finalFileName,
                     isZipExport,
-                    originalFilePath: isZipExport ? filePath : undefined
+                    originalFilePath: isZipExport ? filePath : undefined,
+                    resourceSummary: resourceSummary ?? undefined,
                 });
             }
 
@@ -4074,14 +4096,15 @@ export class QQChatExporterApiServer {
                     taskId,
                     status: 'completed',
                     progress: 100,
-                    message: '导出完成',
+                    message: completionMessage,
                     messageCount: sortedMessages.length,
                     fileName: finalFileName,
                     filePath: finalFilePath,
                     fileSize: stats.size,
                     downloadUrl: finalDownloadUrl,
                     isZipExport,
-                    originalFilePath: isZipExport ? filePath : undefined
+                    originalFilePath: isZipExport ? filePath : undefined,
+                    resourceSummary: resourceSummary ?? undefined,
                 }
             });
 

--- a/plugins/qq-chat-exporter/lib/core/resource/ResourceHandler.ts
+++ b/plugins/qq-chat-exporter/lib/core/resource/ResourceHandler.ts
@@ -287,6 +287,34 @@ export type ResourceProgressCallback = (progress: {
 }) => void;
 
 /**
+ * 单次 `processMessageResources` 调用产出的资源摘要（issue #363）。
+ *
+ * 这套数字与 `progressCallback` 内部状态的区别：
+ *  - progressCallback 只在「需要下载」的资源上发回调，跳过 / 已经在本地的不算；
+ *  - 这份摘要描述本次实际尝试做了什么，让调用方（ApiServer / ScheduledExportManager）
+ *    可以在导出完成时给用户一段清晰的人类可读结论：本次到底动了多少资源、有几个
+ *    没拿到，免得用户单独看到 NapCat 的 `[Rkey] 所有服务均已禁用` 的日志后误判
+ *    为整个导出失败。
+ *
+ * `failedSamples` 仅给出最多前 5 个失败资源的精简标识（filename or md5），方便日志
+ * 与上层 UI 直接复用，不会把整个失败列表全塞回去。
+ */
+export interface ResourceBatchSummary {
+    /** 命中的总资源条数（包括跳过、已在本地、需要新下载的）。 */
+    attempted: number;
+    /** 命中后无需重新下载（命中本地缓存或已在 QQ 沙箱里）。 */
+    alreadyAvailable: number;
+    /** 实际新下载完成的条数。 */
+    downloaded: number;
+    /** 下载失败 / 触发熔断 / 健康检查不过的条数。 */
+    failed: number;
+    /** 因 `setSkipDownloadTypes` 主动跳过的条数（issue #341）。 */
+    skipped: number;
+    /** 失败资源的简短样本（最多 5 个），用于日志与 UI 提示。 */
+    failedSamples: string[];
+}
+
+/**
  * 资源处理器主类
  */
 export class ResourceHandler {
@@ -307,6 +335,19 @@ export class ResourceHandler {
     private totalResourcesForProgress: number = 0;
     private completedResourcesForProgress: number = 0;
     private failedResourcesForProgress: number = 0;
+
+    /**
+     * 上一次 processMessageResources 调用的摘要（issue #363）。
+     * 每次进入 processMessageResources 会被重置；导出流程在调用完成后立即读取。
+     */
+    private lastBatchSummary: ResourceBatchSummary = {
+        attempted: 0,
+        alreadyAvailable: 0,
+        downloaded: 0,
+        failed: 0,
+        skipped: 0,
+        failedSamples: [],
+    };
 
     /**
      * 跳过下载的资源类型集合（Issue #341）。
@@ -388,27 +429,45 @@ export class ResourceHandler {
      */
     async processMessageResources(messages: RawMessage[]): Promise<Map<string, ResourceInfo[]>> {
         const resourceMap = new Map<string, ResourceInfo[]>();
-        let totalResources = 0;
         let resourcesNeedingDownload = 0;
-        
+        const allResources: ResourceInfo[] = [];
+        // 第一遍扫描后即时记录初始状态（健康 / 跳过 / 待下载），下载完成后再
+        // 用最终状态对比，从而得到准确的 already / downloaded / failed 区分。
+        const initialState = new Map<ResourceInfo, 'available' | 'skipped' | 'pending'>();
+
         // 重置进度计数器
         this.totalResourcesForProgress = 0;
         this.completedResourcesForProgress = 0;
         this.failedResourcesForProgress = 0;
-        
+
+        // 重置摘要（issue #363）。每次调用结束后会被重新填充。
+        this.lastBatchSummary = {
+            attempted: 0,
+            alreadyAvailable: 0,
+            downloaded: 0,
+            failed: 0,
+            skipped: 0,
+            failedSamples: [],
+        };
+
         for (const message of messages) {
             const resources: ResourceInfo[] = [];
-            
+
             for (const element of message.elements) {
                 if (this.isMediaElement(element)) {
                     try {
                         const resourceInfo = await this.processElement(message, element);
                         if (resourceInfo) {
                             resources.push(resourceInfo);
-                            totalResources++;
+                            allResources.push(resourceInfo);
                             // Issue #341: 被跳过下载的资源不计入下载进度，避免进度永远卡住。
-                            if (!resourceInfo.accessible && resourceInfo.status !== ResourceStatus.SKIPPED) {
+                            if (resourceInfo.status === ResourceStatus.SKIPPED) {
+                                initialState.set(resourceInfo, 'skipped');
+                            } else if (!resourceInfo.accessible) {
+                                initialState.set(resourceInfo, 'pending');
                                 resourcesNeedingDownload++;
+                            } else {
+                                initialState.set(resourceInfo, 'available');
                             }
                         }
                     } catch (error) {
@@ -416,27 +475,83 @@ export class ResourceHandler {
                     }
                 }
             }
-            
+
             if (resources.length > 0) {
                 resourceMap.set(message.msgId, resources);
             }
         }
-        
+
         // 设置进度总数
         this.totalResourcesForProgress = resourcesNeedingDownload;
-        
+
         // 等待所有下载任务完成
         if (resourcesNeedingDownload > 0) {
             // 初始进度回调
             this.emitProgress();
-            
+
             // 给下载队列处理器足够时间启动和处理
             await new Promise(resolve => setTimeout(resolve, 1000));
-            
+
             await this.waitForAllDownloads();
         }
-        
+
+        // 计算本批次摘要（issue #363）。规则：
+        //  - 入口看到就 SKIPPED 的，记 skipped；
+        //  - 入口已经 accessible 的，记 alreadyAvailable；
+        //  - 入口需要下载、最终 DOWNLOADED + accessible 的，记 downloaded；
+        //  - 其它情况都算 failed（典型情况：NapCat Rkey 服务全降级 → 拿不到 url）。
+        const failedSamples: string[] = [];
+        for (const r of allResources) {
+            this.lastBatchSummary.attempted++;
+            const initial = initialState.get(r);
+            if (initial === 'skipped') {
+                this.lastBatchSummary.skipped++;
+                continue;
+            }
+            const ok = r.status === ResourceStatus.DOWNLOADED && r.accessible === true;
+            if (initial === 'available') {
+                if (ok) {
+                    this.lastBatchSummary.alreadyAvailable++;
+                } else {
+                    // 入口看着可用但 health check 之后又被打回 FAILED：算失败，
+                    // 让用户知道本次确实漏了。
+                    this.lastBatchSummary.failed++;
+                    if (failedSamples.length < 5) {
+                        failedSamples.push(r.fileName || r.md5 || r.id || 'unknown');
+                    }
+                }
+                continue;
+            }
+            // initial === 'pending'：等待下载结果
+            if (ok) {
+                this.lastBatchSummary.downloaded++;
+            } else {
+                this.lastBatchSummary.failed++;
+                if (failedSamples.length < 5) {
+                    failedSamples.push(r.fileName || r.md5 || r.id || 'unknown');
+                }
+            }
+        }
+        this.lastBatchSummary.failedSamples = failedSamples;
+
         return resourceMap;
+    }
+
+    /**
+     * 读取上一次 `processMessageResources` 的资源摘要（issue #363）。
+     *
+     * 调用时机：紧跟 `processMessageResources` 之后；中间不要再触发其它批次，否则
+     * 会被覆盖。返回的是内部状态的浅拷贝，调用方安全地把它原样存到任务记录里。
+     */
+    getLastBatchSummary(): ResourceBatchSummary {
+        return {
+            attempted: this.lastBatchSummary.attempted,
+            alreadyAvailable: this.lastBatchSummary.alreadyAvailable,
+            downloaded: this.lastBatchSummary.downloaded,
+            failed: this.lastBatchSummary.failed,
+            skipped: this.lastBatchSummary.skipped,
+            failedSamples: [...this.lastBatchSummary.failedSamples],
+        };
     }
 
     /**

--- a/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
+++ b/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
@@ -203,6 +203,18 @@ export interface ExecutionHistory {
     error?: string;
     /** 执行耗时（毫秒） */
     duration: number;
+    /**
+     * 资源下载摘要（issue #363）。仅在本次执行触发了资源下载时存在。
+     * 用来在执行历史 UI 上明确告诉用户本次到底丢了几个资源、是不是 Rkey 降级。
+     */
+    resourceSummary?: {
+        attempted: number;
+        alreadyAvailable: number;
+        downloaded: number;
+        failed: number;
+        skipped: number;
+        failedSamples: string[];
+    };
 }
 
 /**
@@ -566,6 +578,13 @@ export class ScheduledExportManager {
             // 下载资源（受 skipDownloadResourceTypes 影响）
             const resourceMap = await this.resourceHandler.processMessageResources(allMessages);
 
+            // issue #363：留下本次资源下载摘要，让 UI 能直接告诉用户本次有几个资源没拿到。
+            try {
+                history.resourceSummary = this.resourceHandler.getLastBatchSummary();
+            } catch {
+                // 旧版 ResourceHandler 不带 getLastBatchSummary 时忽略，不影响导出本身。
+            }
+
             // 重置共享 ResourceHandler 的状态，避免影响后续任务
             try {
                 this.resourceHandler.setSkipDownloadTypes([]);
@@ -651,8 +670,12 @@ export class ScheduledExportManager {
             }
 
             const stats = fs.statSync(filePath);
-            
-            history.status = 'success';
+
+            // issue #363：如果本次有资源下载失败，把状态降级为 partial，让用户在执行历史
+            // 列表上一眼就能看出来「本次导出文件出来了但漏了点东西」。
+            history.status = (history.resourceSummary && history.resourceSummary.failed > 0)
+                ? 'partial'
+                : 'success';
             history.messageCount = allMessages.length;
             history.filePath = filePath;
             history.fileSize = stats.size;

--- a/plugins/qq-chat-exporter/lib/utils/resourceSummary.ts
+++ b/plugins/qq-chat-exporter/lib/utils/resourceSummary.ts
@@ -1,0 +1,53 @@
+/**
+ * issue #363：把一份资源批处理摘要翻译成给用户看的中文一句话。
+ *
+ * 背景：用户在 NapCat 终端里看到 `[Rkey] 所有服务均已禁用，片段使用 fallBack 机制`
+ * 之类的日志后，无法判断 QCE 这次导出是不是成功、有没有漏图、要不要重试。这个
+ * helper 直接基于本次批处理的统计给出明确结论：
+ *   - 资源 X/Y、跳过 N、失败 M（含 a、b、c 等）；
+ *   - 失败时附上一句对 Rkey 降级的说明 + 重试建议。
+ *
+ * 抽成纯函数是为了让 ApiServer / ScheduledExportManager 都能复用，并且方便单测覆盖
+ * 各种 (failed, skipped, attempted) 组合而不需要拉起整个数据库 / 资源管线。
+ */
+
+export interface ResourceBatchSummaryLike {
+    attempted: number;
+    alreadyAvailable: number;
+    downloaded: number;
+    failed: number;
+    skipped: number;
+    failedSamples: string[];
+}
+
+/**
+ * 构造一句给用户看的资源摘要消息。
+ *
+ * 返回值约定：
+ *   - `null` 表示这一批没动过任何资源（纯文字消息或显式跳过资源下载），
+ *     调用方不需要在 UI 上额外提示什么。
+ *   - 否则永远返回完整一句话，调用方按需附加在任务的 message / progressMessage 字段里。
+ */
+export function buildResourceSummaryMessage(
+    summary: ResourceBatchSummaryLike | null | undefined,
+): string | null {
+    if (!summary || summary.attempted <= 0) return null;
+
+    const reused = summary.alreadyAvailable + summary.downloaded;
+    const parts: string[] = [`资源 ${reused}/${summary.attempted}`];
+    if (summary.skipped > 0) parts.push(`跳过 ${summary.skipped}`);
+    if (summary.failed > 0) {
+        const sampleList = (summary.failedSamples || []).slice(0, 3).join('、');
+        const sample = sampleList ? `（含 ${sampleList}${summary.failed > 3 ? ' 等' : ''}）` : '';
+        parts.push(`失败 ${summary.failed}${sample}`);
+    }
+
+    const head = parts.join('，');
+    if (summary.failed === 0) return head;
+
+    return (
+        `${head}。这通常是 QQ Rkey 服务临时降级导致下载链接拿不到（NapCat 终端会打 ` +
+        '`[Rkey] 所有服务均已禁用，片段使用 fallBack 机制`），文字内容不受影响。' +
+        '可以在 QQ 客户端重新点开这些消息让 NapCat 拿到新 token，再到 QCE 任务列表点「重试」补齐。'
+    );
+}

--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -1690,6 +1690,21 @@ export default function QCEDashboard() {
                             {task.error}
                           </div>
                         )}
+
+                        {/* issue #363：资源下载摘要。只在完成态、且本次确实有资源失败时显示。 */}
+                        {task.status === "completed" && task.resourceSummary && task.resourceSummary.failed > 0 && (
+                          <div className="mt-1.5 text-xs text-amber-700 dark:text-amber-400 leading-relaxed">
+                            <span className="font-medium">
+                              资源 {(task.resourceSummary.alreadyAvailable + task.resourceSummary.downloaded)}/{task.resourceSummary.attempted}
+                              ，失败 {task.resourceSummary.failed}
+                              {task.resourceSummary.skipped > 0 && `，跳过 ${task.resourceSummary.skipped}`}
+                            </span>
+                            <span className="text-muted-foreground/70">
+                              {' · '}
+                              这通常是 QQ Rkey 服务临时降级，文字内容不受影响；可在 QQ 客户端重新点开这些消息后再点「重试」。
+                            </span>
+                          </div>
+                        )}
                       </div>
 
                       <div className="ml-3 flex items-center gap-1.5 flex-shrink-0">

--- a/qce-v4-tool/e2e/ui-smoke.spec.ts
+++ b/qce-v4-tool/e2e/ui-smoke.spec.ts
@@ -199,6 +199,84 @@ test.describe('Session list — QQ lookup (issue #204)', () => {
         await expect(page.getByText('非好友 / 已注销')).toBeVisible({ timeout: 10_000 });
     });
 
+    /**
+     * Issue #363: 当本次导出有资源下载失败时，任务列表里这条任务下面应当出现
+     * 一段说明 Rkey 降级和重试方法的提示文案。这里直接拦截 `/api/tasks` 把一条
+     * 带 `resourceSummary.failed > 0` 的完成态任务塞进去，验证 UI 真的会渲染。
+     */
+    test('completed task with failed resources shows Rkey explanation banner (issue #363)', async ({ page }) => {
+        await clearLocalStorage(page);
+        await page.evaluate((value) => {
+            localStorage.setItem('qce_access_token', value);
+        }, TOKEN);
+
+        // 拦截 /api/tasks，让前端看到一条 issue #363 场景的完成任务。
+        await page.route('**/api/tasks', async (route, request) => {
+            // 只拦 GET，POST 走真接口（不影响其它流程）。
+            if (request.method() !== 'GET') {
+                await route.continue();
+                return;
+            }
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    success: true,
+                    data: {
+                        tasks: [
+                            {
+                                id: 'rkey-fallback-task',
+                                peer: { peerUid: '12345', chatType: 1 },
+                                sessionName: 'Rkey 降级测试会话',
+                                status: 'completed',
+                                progress: 100,
+                                format: 'HTML',
+                                messageCount: 200,
+                                fileName: 'rkey_test.html',
+                                filePath: '/tmp/rkey_test.html',
+                                fileSize: 12345,
+                                createdAt: new Date(Date.now() - 3 * 60 * 1000).toISOString(),
+                                completedAt: new Date(Date.now() - 1 * 60 * 1000).toISOString(),
+                                resourceSummary: {
+                                    attempted: 12,
+                                    alreadyAvailable: 3,
+                                    downloaded: 5,
+                                    failed: 4,
+                                    skipped: 0,
+                                    failedSamples: ['photo-1.jpg', 'photo-2.jpg', 'photo-3.jpg', 'photo-4.jpg'],
+                                },
+                            },
+                        ],
+                    },
+                }),
+            });
+        });
+
+        const response = await page
+            .goto(`${FRONTEND_BASE}${SHELL_PATH}`)
+            .catch(() => null);
+        test.skip(
+            !response || response.status() >= 500,
+            `frontend not reachable at ${FRONTEND_BASE}`
+        );
+
+        // 关掉欢迎弹窗（如有），切到任务标签页。
+        const skipBtn = page.getByRole('button', { name: '跳过' }).first();
+        if (await skipBtn.isVisible({ timeout: 1500 }).catch(() => false)) {
+            await skipBtn.click().catch(() => null);
+        }
+        const tasksTab = page.getByRole('button', { name: '任务', exact: true });
+        await expect(tasksTab).toBeVisible({ timeout: 15_000 });
+        await tasksTab.click();
+
+        // 任务行出现
+        await expect(page.getByText('Rkey 降级测试会话')).toBeVisible({ timeout: 10_000 });
+        // 数字行
+        await expect(page.getByText(/资源 8\/12，失败 4/)).toBeVisible({ timeout: 10_000 });
+        // Rkey 解释文案
+        await expect(page.getByText(/Rkey 服务临时降级|重新点开这些消息/)).toBeVisible({ timeout: 10_000 });
+    });
+
     test('searching for a non-existent QQ shows a friendly not-found message', async ({ page }) => {
         await clearLocalStorage(page);
         await page.evaluate((value) => {

--- a/qce-v4-tool/types/api.ts
+++ b/qce-v4-tool/types/api.ts
@@ -166,6 +166,31 @@ export interface ExportTask {
   originalFilePath?: string
   /** 是否为流式导出模式 */
   streamingMode?: boolean
+  /**
+   * 本次导出的资源下载摘要（issue #363）。
+   * 后端在 `processMessageResources` 完成后填充；纯文字消息或显式跳过资源下载时为 undefined。
+   */
+  resourceSummary?: ExportResourceSummary
+}
+
+/**
+ * 单次导出资源处理结果（issue #363）。
+ * 用来在任务列表 / 详情中给出明确结论，避免用户被 NapCat 终端的 `[Rkey] 所有服务均已禁用`
+ * 日志误导以为整个导出失败。
+ */
+export interface ExportResourceSummary {
+  /** 命中的总资源条数（包含跳过、命中本地的）。 */
+  attempted: number
+  /** 入口扫描时已经在本地、不需要重新下载的。 */
+  alreadyAvailable: number
+  /** 本次新下载完成的。 */
+  downloaded: number
+  /** 拿不到链接 / 健康检查不过的。 */
+  failed: number
+  /** 因 skipDownloadResourceTypes 主动跳过的。 */
+  skipped: number
+  /** 失败资源的简短样本（最多 5 个），用于在 UI 中显示具体哪些资源没下到。 */
+  failedSamples: string[]
 }
 
 export interface CreateTaskForm {


### PR DESCRIPTION
## Summary

Issue #363：用户在 NapCat 终端看到 `[Rkey] 所有服务均已禁用，片段使用 fallBack 机制` 时无法判断本次导出是不是真的成功。这个 PR 在导出完成时直接给出一段明确的人类可读结论，告诉用户本次到底处理了多少资源、有几个真没拿到、是哪些、要怎么补。

主要改动：

- **`ResourceHandler`** 在 `processMessageResources()` 内部记录每条资源的初始状态（已在本地 / 跳过 / 待下载），下载完成后对照最终状态分类为 `alreadyAvailable / downloaded / failed / skipped` 四桶，外加最多 5 条失败样本。新增 `getLastBatchSummary()` 公开方法暴露给上层。
- **`lib/utils/resourceSummary.ts`** 新增 `buildResourceSummaryMessage()` 纯函数：把摘要翻译成一句中文。全部成功时只给比例数字；有失败时附带 Rkey 降级解释 + 在 QQ 客户端重新点开消息、再去 QCE 任务列表点「重试」的具体补救步骤。
- **`ApiServer`** 在 `processMessageResources` 返回后立刻 `getLastBatchSummary()`，把摘要塞进任务的 `message` 字段（`导出完成 · 资源 8/12，失败 4（含 …）。这通常是 QQ Rkey 服务临时降级…`），WebSocket `export_complete` 推送、`/api/tasks`、`/api/tasks/:id` 都把 `resourceSummary` 透出给前端。
- **`ScheduledExportManager`** 同样捕获摘要写到 `ExecutionHistory.resourceSummary`，并在有失败时把执行状态从 `success` 降级为 `partial`，让定时备份的执行历史能直接区分「文件出来了但漏了几张图」和「真没出文件」。
- **前端** 在任务列表已完成的任务行下，仅当 `resourceSummary.failed > 0` 时渲染一行琥珀色提示，简短列出比例数字、跳过和失败数量，并附 Rkey 解释 / 重试指引。原本完全没有报错时不会多嘴。

### Notes

资源摘要的四桶之和恒等于 `attempted`，单测覆盖了：
- `getLastBatchSummary` 在多次调用之间被重置而不是累加；
- 文件被 `setSkipDownloadTypes(['file'])` 命中时进 `skipped`；
- 一次性 7 张图全失败时 `failedSamples` 截到 5 条；
- 空消息列表给出 `attempted=0` 的零值摘要。

`buildResourceSummaryMessage` 的契约也单测覆盖：`attempted=0` → `null`、全部成功不出现 Rkey/重试字样、有失败时三要素齐备、`failed ≤ 3` 时不缀「等」字、`skipped` 与 `failed` 在文案里互不干扰。

UI 渲染由 Playwright e2e 覆盖：拦截 `/api/tasks` 注入一条 `resourceSummary.failed=4` 的完成任务，断言任务行同时出现「资源 8/12，失败 4」与 Rkey 解释文案两条文本。

`ScheduledExportManager` 上 `resourceSummary` 的 try/catch fallback 是为了兼容外部第三方对 `ResourceHandler` 的 monkey-patch（旧版本可能没有 `getLastBatchSummary`）。