### PR TITLE
feat(export): per-type skip download for image / video / audio / file (#344)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/skipResourceTypes.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/skipResourceTypes.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Issue #344：`toggleSkipResourceType` 是 task wizard / 批量导出 / 定时导出三个表单
+ * 共享的资源类型勾选器逻辑，单独跑一组单测确保它的语义不会随这些表单的样式
+ * 调整而漂移。
+ *
+ * 由于这个 helper 物理上住在 `qce-v4-tool/lib/skip-resource-types.ts`，前端目前没有
+ * 自己的 node 单测体系，这里复用插件已有的 tsx + node:test 体系跨目录 import。
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// `qce-v4-tool/package.json` 没有 `"type": "module"`，所以 tsx 把它下面的 .ts 文件
+// 当作 CJS 编译，命名导出会被收进 `default`。这里用命名空间 import 兼容两边
+// （ESM 真命名导出 / CJS interop default）。
+import * as skipResourceTypesMod from '../../../../qce-v4-tool/lib/skip-resource-types';
+
+type Mod = typeof import('../../../../qce-v4-tool/lib/skip-resource-types');
+const skipResourceTypes: Mod =
+    (skipResourceTypesMod as unknown as { default?: Mod }).default ??
+    (skipResourceTypesMod as unknown as Mod);
+const { toggleSkipResourceType } = skipResourceTypes;
+
+test('toggleSkipResourceType: 在 undefined 上加一项返回单元素数组', () => {
+    assert.deepEqual(toggleSkipResourceType(undefined, 'image', true), ['image']);
+});
+
+test('toggleSkipResourceType: 已存在的类型再开一次保持幂等', () => {
+    assert.deepEqual(toggleSkipResourceType(['image'], 'image', true), ['image']);
+});
+
+test('toggleSkipResourceType: 关闭最后一项时返回 undefined（避免给 API 传空数组）', () => {
+    assert.equal(toggleSkipResourceType(['image'], 'image', false), undefined);
+});
+
+test('toggleSkipResourceType: 关闭其中一项保留剩余项', () => {
+    assert.deepEqual(toggleSkipResourceType(['image', 'video', 'audio'], 'video', false), ['image', 'audio']);
+});
+
+test('toggleSkipResourceType: 输出按 image,video,audio,file 固定顺序排序', () => {
+    // 故意把输入打乱顺序，输出应该被规范成固定顺序。
+    assert.deepEqual(
+        toggleSkipResourceType(['file', 'audio', 'video', 'image'], 'image', true),
+        ['image', 'video', 'audio', 'file']
+    );
+});
+
+test('toggleSkipResourceType: 忽略不在白名单内的输入值', () => {
+    // 万一别的代码混入了一个未被识别的字符串（比如未来新增类型未同步），
+    // toggle 应当把它丢掉，避免后端拿到无效值。
+    assert.deepEqual(
+        toggleSkipResourceType(['image', 'sticker' as unknown as 'image'], 'video', true),
+        ['image', 'video']
+    );
+});
+
+test('toggleSkipResourceType: 空数组等价于 undefined 输入', () => {
+    assert.deepEqual(toggleSkipResourceType([], 'audio', true), ['audio']);
+    assert.equal(toggleSkipResourceType([], 'audio', false), undefined);
+});
+
+test('toggleSkipResourceType: 不修改输入数组', () => {
+    const input: ReadonlyArray<'image' | 'video' | 'audio' | 'file'> = ['image', 'video'];
+    toggleSkipResourceType(input, 'audio', true);
+    // input 仍然是原样
+    assert.deepEqual(input, ['image', 'video']);
+});

--- a/qce-v4-tool/components/ui/batch-export-dialog.tsx
+++ b/qce-v4-tool/components/ui/batch-export-dialog.tsx
@@ -11,6 +11,7 @@ import { Separator } from "@/components/ui/separator"
 import { Textarea } from "@/components/ui/textarea"
 import { FileText, Calendar, Download, CheckCircle2, XCircle, Loader2, Users, User, Package, FolderOpen } from "lucide-react"
 import { ScrollArea } from "@/components/ui/scroll-area"
+import { toggleSkipResourceType, type SkipDownloadResourceType } from "@/lib/skip-resource-types"
 
 export interface BatchExportItem {
   type: 'group' | 'friend'
@@ -81,7 +82,8 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
   const [includeSystemMessages, setIncludeSystemMessages] = useState(true)
   const [filterPureImageMessages, setFilterPureImageMessages] = useState(false) // HTML默认false
   const [preferGroupMemberName, setPreferGroupMemberName] = useState(true)
-  const [skipFileDownloadOnly, setSkipFileDownloadOnly] = useState(false)
+  // Issue #344：批量导出也支持按资源类型逐项跳过下载。
+  const [skipDownloadResourceTypes, setSkipDownloadResourceTypes] = useState<SkipDownloadResourceType[] | undefined>(undefined)
   const [outputDir, setOutputDir] = useState('')
   const [keywords, setKeywords] = useState('')
   const [excludeUserUins, setExcludeUserUins] = useState('')
@@ -113,7 +115,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
       setIncludeSystemMessages(true)
       setFilterPureImageMessages(false)
       setPreferGroupMemberName(true)
-      setSkipFileDownloadOnly(false)
+      setSkipDownloadResourceTypes(undefined)
       setOutputDir('')
       setKeywords('')
       setExcludeUserUins('')
@@ -204,8 +206,8 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
       includeSystemMessages,
       filterPureImageMessages,
       preferGroupMemberName,
-      ...(skipFileDownloadOnly && !filterPureImageMessages && {
-        skipDownloadResourceTypes: ['file' as const]
+      ...(!filterPureImageMessages && skipDownloadResourceTypes && skipDownloadResourceTypes.length > 0 && {
+        skipDownloadResourceTypes,
       }),
       outputDir,
       keywords,
@@ -435,7 +437,11 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
                     { id: "streamingZipMode", checked: streamingZipMode, set: setStreamingZipMode, title: "流式导出（超大消息量专用）", desc: format === "HTML" ? "专为50万+消息量设计，全程流式处理防止内存溢出。输出ZIP格式。" : "专为50万+消息量设计，全程流式处理防止内存溢出。输出分块JSONL格式。", visible: format === "HTML" || format === "JSON", highlight: true },
                     { id: "includeSystemMessages", checked: includeSystemMessages, set: setIncludeSystemMessages, title: "包含系统消息", desc: "包含入群通知、撤回提示等系统提示消息", visible: true, highlight: false },
                     { id: "filterPureImageMessages", checked: filterPureImageMessages, set: setFilterPureImageMessages, title: "快速导出（跳过资源下载）", desc: "保留所有消息记录，但不下载图片/视频/音频等资源文件，大幅加快导出速度", visible: true, highlight: false },
-                    { id: "skipFileDownloadOnly", checked: skipFileDownloadOnly, set: setSkipFileDownloadOnly, title: "仅保留文件元数据，不下载文件", desc: "图片 / 视频 / 音频仍正常下载；只有文件类资源（群文件、聊天发送的文档等）只保留文件名、大小、MD5 等元信息。", visible: !filterPureImageMessages, highlight: false },
+                    // Issue #344：分别控制图片 / 视频 / 音频 / 文件四种资源是否参与下载。
+                    { id: "skipFileDownloadOnly", checked: !!skipDownloadResourceTypes?.includes('file'), set: (v: boolean) => setSkipDownloadResourceTypes((curr) => toggleSkipResourceType(curr, 'file', v)), title: "仅保留文件元数据，不下载文件", desc: "图片 / 视频 / 音频仍正常下载；只有文件类资源（群文件、聊天发送的文档等）只保留文件名、大小、MD5 等元信息。", visible: !filterPureImageMessages, highlight: false },
+                    { id: "skipImageDownload", checked: !!skipDownloadResourceTypes?.includes('image'), set: (v: boolean) => setSkipDownloadResourceTypes((curr) => toggleSkipResourceType(curr, 'image', v)), title: "不下载图片", desc: "批量导出时跳过图片，HTML 中以占位形式显示。需要保留图片可关闭此项。", visible: !filterPureImageMessages, highlight: false },
+                    { id: "skipVideoDownload", checked: !!skipDownloadResourceTypes?.includes('video'), set: (v: boolean) => setSkipDownloadResourceTypes((curr) => toggleSkipResourceType(curr, 'video', v)), title: "不下载视频", desc: "批量导出时跳过视频，避免长时间或群聊导出时占用大量带宽和磁盘空间。", visible: !filterPureImageMessages, highlight: false },
+                    { id: "skipAudioDownload", checked: !!skipDownloadResourceTypes?.includes('audio'), set: (v: boolean) => setSkipDownloadResourceTypes((curr) => toggleSkipResourceType(curr, 'audio', v)), title: "不下载语音", desc: "批量导出时跳过 SILK / AMR 等语音消息。对只想保留文字记录的场景很有用。", visible: !filterPureImageMessages, highlight: false },
                     { id: "preferGroupMemberName", checked: preferGroupMemberName, set: setPreferGroupMemberName, title: "优先使用群成员名称", desc: "群聊导出时优先使用群名片或群内名称。关闭后会改用 QQ 昵称或 QQ 号。这个选项仅对群聊生效。", visible: true, highlight: false },
                     { id: "exportAsZip", checked: exportAsZip, set: setExportAsZip, title: "导出为ZIP压缩包", desc: "将HTML文件和资源文件打包为ZIP格式（仅HTML格式可用）", visible: format === "HTML" && !streamingZipMode, highlight: false },
                     {

--- a/qce-v4-tool/components/ui/scheduled-export-wizard.tsx
+++ b/qce-v4-tool/components/ui/scheduled-export-wizard.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react"
 import type { CreateScheduledExportForm, Group, Friend } from "@/types/api"
 import { useSearch } from "@/hooks/use-search"
+import { toggleSkipResourceType, type SkipDownloadResourceType } from "@/lib/skip-resource-types"
 
 interface ScheduledExportWizardProps {
   isOpen: boolean
@@ -63,7 +64,8 @@ export function ScheduledExportWizard({
     includeSystemMessages: true,
     filterPureImageMessages: false,
     preferGroupMemberName: true,
-    skipFileDownloadOnly: false,
+    // Issue #344：定时导出也支持按资源类型逐项跳过下载。
+    skipDownloadResourceTypes: undefined as SkipDownloadResourceType[] | undefined,
   })
 
   // 选中的目标
@@ -119,9 +121,9 @@ export function ScheduledExportWizard({
           ? prefilledData.filterPureImageMessages 
           : defaultFilter,
         preferGroupMemberName: prefilledData.preferGroupMemberName !== undefined ? prefilledData.preferGroupMemberName : true,
-        skipFileDownloadOnly: Array.isArray(prefilledData.skipDownloadResourceTypes)
-          ? prefilledData.skipDownloadResourceTypes.includes('file')
-          : false,
+        skipDownloadResourceTypes: Array.isArray(prefilledData.skipDownloadResourceTypes) && prefilledData.skipDownloadResourceTypes.length > 0
+          ? (prefilledData.skipDownloadResourceTypes as SkipDownloadResourceType[])
+          : undefined,
       })
 
       // 如果有预填充的目标，添加到选中列表
@@ -156,7 +158,7 @@ export function ScheduledExportWizard({
         includeSystemMessages: true,
         filterPureImageMessages: false,
         preferGroupMemberName: true,
-        skipFileDownloadOnly: false,
+        skipDownloadResourceTypes: undefined,
       })
       setSelectedTargets([])
       setSearchTerm("")
@@ -210,8 +212,8 @@ export function ScheduledExportWizard({
         includeSystemMessages: baseForm.includeSystemMessages,
         filterPureImageMessages: baseForm.filterPureImageMessages,
         preferGroupMemberName: baseForm.preferGroupMemberName,
-        ...(baseForm.skipFileDownloadOnly && !baseForm.filterPureImageMessages && {
-          skipDownloadResourceTypes: ['file' as const],
+        ...(!baseForm.filterPureImageMessages && baseForm.skipDownloadResourceTypes && baseForm.skipDownloadResourceTypes.length > 0 && {
+          skipDownloadResourceTypes: baseForm.skipDownloadResourceTypes,
         }),
       }
       
@@ -849,12 +851,37 @@ export function ScheduledExportWizard({
                       desc: "保留所有消息记录，但不下载图片/视频/音频等资源文件，大幅加快导出速度",
                       visible: true,
                     },
+                    // Issue #344：定时导出也支持分别控制图片 / 视频 / 音频 / 文件是否参与下载。
                     {
                       id: "skipFileDownloadOnly",
-                      checked: baseForm.skipFileDownloadOnly,
-                      set: (v: boolean) => setBaseForm(p => ({ ...p, skipFileDownloadOnly: v })),
+                      checked: !!baseForm.skipDownloadResourceTypes?.includes('file'),
+                      set: (v: boolean) => setBaseForm(p => ({ ...p, skipDownloadResourceTypes: toggleSkipResourceType(p.skipDownloadResourceTypes, 'file', v) })),
                       title: "仅保留文件元数据，不下载文件",
                       desc: "图片 / 视频 / 音频仍正常下载；只有文件类资源（群文件、聊天发送的文档等）只保留文件名、大小、MD5 等元信息。",
+                      visible: !baseForm.filterPureImageMessages,
+                    },
+                    {
+                      id: "skipImageDownload",
+                      checked: !!baseForm.skipDownloadResourceTypes?.includes('image'),
+                      set: (v: boolean) => setBaseForm(p => ({ ...p, skipDownloadResourceTypes: toggleSkipResourceType(p.skipDownloadResourceTypes, 'image', v) })),
+                      title: "不下载图片",
+                      desc: "定时导出时跳过图片资源的下载。适用于只需定期备份文本记录、不在意图片的场景。",
+                      visible: !baseForm.filterPureImageMessages,
+                    },
+                    {
+                      id: "skipVideoDownload",
+                      checked: !!baseForm.skipDownloadResourceTypes?.includes('video'),
+                      set: (v: boolean) => setBaseForm(p => ({ ...p, skipDownloadResourceTypes: toggleSkipResourceType(p.skipDownloadResourceTypes, 'video', v) })),
+                      title: "不下载视频",
+                      desc: "定时导出时跳过视频资源，避免定时任务下载大量视频占用带宽和磁盘。",
+                      visible: !baseForm.filterPureImageMessages,
+                    },
+                    {
+                      id: "skipAudioDownload",
+                      checked: !!baseForm.skipDownloadResourceTypes?.includes('audio'),
+                      set: (v: boolean) => setBaseForm(p => ({ ...p, skipDownloadResourceTypes: toggleSkipResourceType(p.skipDownloadResourceTypes, 'audio', v) })),
+                      title: "不下载语音",
+                      desc: "定时导出时跳过 SILK / AMR 语音消息。对只需要文字记录的备份场景很有用。",
                       visible: !baseForm.filterPureImageMessages,
                     },
                     {

--- a/qce-v4-tool/components/ui/task-wizard.tsx
+++ b/qce-v4-tool/components/ui/task-wizard.tsx
@@ -15,6 +15,7 @@ import {
 import { useSearch } from "@/hooks/use-search"
 import type { CreateTaskForm, Group, Friend, GroupMember } from "@/types/api"
 import { Checkbox } from "./checkbox"
+import { toggleSkipResourceType } from "@/lib/skip-resource-types"
 
 interface TaskWizardProps {
   isOpen: boolean
@@ -1007,20 +1008,50 @@ export function TaskWizard({
                 desc: "保留所有消息记录，但不下载图片/视频/音频等资源文件，大幅加快导出速度",
                 visible: true
               },
+              // Issue #344：仅保留文件元数据，不下载文件
               {
                 id: "skipFileDownloadOnly",
                 checked: !!form.skipDownloadResourceTypes?.includes('file'),
-                set: (v: boolean) => setForm((p) => {
-                  const current = new Set(p.skipDownloadResourceTypes || []);
-                  if (v) {
-                    current.add('file');
-                  } else {
-                    current.delete('file');
-                  }
-                  return { ...p, skipDownloadResourceTypes: Array.from(current) };
-                }),
+                set: (v: boolean) => setForm((p) => ({
+                  ...p,
+                  skipDownloadResourceTypes: toggleSkipResourceType(p.skipDownloadResourceTypes, 'file', v),
+                })),
                 title: "仅保留文件元数据，不下载文件",
                 desc: "图片 / 视频 / 音频仍正常下载；只有文件类资源（群文件、聊天发送的文档等）只保留文件名、大小、MD5 等元信息。适合不需要本地副本的备份场景。",
+                visible: !form.filterPureImageMessages
+              },
+              // Issue #344：按资源类型逐项跳过，让用户在不开启「快速导出」的前提下也能精确控制要不要下载图片 / 视频 / 音频。
+              {
+                id: "skipImageDownload",
+                checked: !!form.skipDownloadResourceTypes?.includes('image'),
+                set: (v: boolean) => setForm((p) => ({
+                  ...p,
+                  skipDownloadResourceTypes: toggleSkipResourceType(p.skipDownloadResourceTypes, 'image', v),
+                })),
+                title: "不下载图片",
+                desc: "导出时跳过图片资源的下载，HTML 中以占位形式显示，JSON / TXT 仅保留消息文本与元数据。需要保留图片可关闭此项。",
+                visible: !form.filterPureImageMessages
+              },
+              {
+                id: "skipVideoDownload",
+                checked: !!form.skipDownloadResourceTypes?.includes('video'),
+                set: (v: boolean) => setForm((p) => ({
+                  ...p,
+                  skipDownloadResourceTypes: toggleSkipResourceType(p.skipDownloadResourceTypes, 'video', v),
+                })),
+                title: "不下载视频",
+                desc: "导出时跳过视频资源的下载。视频文件通常体积较大，长时间或群聊导出时容易占用大量带宽和磁盘空间。",
+                visible: !form.filterPureImageMessages
+              },
+              {
+                id: "skipAudioDownload",
+                checked: !!form.skipDownloadResourceTypes?.includes('audio'),
+                set: (v: boolean) => setForm((p) => ({
+                  ...p,
+                  skipDownloadResourceTypes: toggleSkipResourceType(p.skipDownloadResourceTypes, 'audio', v),
+                })),
+                title: "不下载语音",
+                desc: "导出时跳过 SILK / AMR 等语音消息的下载。对只想保留文字记录的备份场景很有用。",
                 visible: !form.filterPureImageMessages
               },
               {

--- a/qce-v4-tool/lib/skip-resource-types.ts
+++ b/qce-v4-tool/lib/skip-resource-types.ts
@@ -1,0 +1,46 @@
+/**
+ * Issue #344：在创建任务、批量导出、定时导出三处都允许用户按资源类型独立控制
+ * 是否跳过下载（图片 / 视频 / 音频 / 文件）。这里集中实现切换逻辑，避免三个表单
+ * 各自维护一份 Set 操作出现行为漂移。
+ *
+ * 后端 (`ResourceHandler.setSkipDownloadTypes`) 接受这四种字符串，未识别的值会被忽略。
+ */
+
+export type SkipDownloadResourceType = 'image' | 'video' | 'audio' | 'file';
+
+const VALID_TYPES: ReadonlySet<SkipDownloadResourceType> = new Set([
+  'image',
+  'video',
+  'audio',
+  'file',
+]);
+
+/**
+ * 在现有 `skipDownloadResourceTypes` 列表上按需添加 / 移除 `type`，返回稳定排序、
+ * 去重之后的新数组。`undefined` 输入按空数组处理。空结果返回 `undefined`，避免
+ * 把空数组写进 API 请求体。
+ *
+ * 排序固定为 `image, video, audio, file`，方便快照测试和接口幂等。
+ */
+export function toggleSkipResourceType(
+  current: readonly string[] | undefined,
+  type: SkipDownloadResourceType,
+  enabled: boolean,
+): SkipDownloadResourceType[] | undefined {
+  const next = new Set<SkipDownloadResourceType>();
+  if (current) {
+    for (const t of current) {
+      if (VALID_TYPES.has(t as SkipDownloadResourceType)) {
+        next.add(t as SkipDownloadResourceType);
+      }
+    }
+  }
+  if (enabled) {
+    next.add(type);
+  } else {
+    next.delete(type);
+  }
+  if (next.size === 0) return undefined;
+  const order: SkipDownloadResourceType[] = ['image', 'video', 'audio', 'file'];
+  return order.filter((t) => next.has(t));
+}


### PR DESCRIPTION
## Summary

Issue #344 里反映「快速导出（跳过资源下载）」是一刀切——要么全跳，要么全下；
而「仅保留文件元数据，不下载文件」也只覆盖 `file` 一种类型。用户经常想要中间档，
比如「保留图片但跳过视频/语音」「全部跳过但保留文件」等组合。

这版给三处入口（创建任务、批量导出、定时导出）的高级选项里都补上了
**图片 / 视频 / 语音** 三个独立勾选项，配合原有的「不下载文件」一起写入
`skipDownloadResourceTypes`。后端 `ResourceHandler.setSkipDownloadTypes`
已经认得 `image | video | audio | file` 四种 type，所以没有改动后端逻辑。

具体改动：

- 抽出 `qce-v4-tool/lib/skip-resource-types.ts`，把切换逻辑收成一个共享的
  `toggleSkipResourceType(current, type, enabled)`。输出固定按
  `image, video, audio, file` 排序、去重，关掉最后一项时返回 `undefined`，
  避免给 API 传空数组、便于幂等比较。
- `task-wizard.tsx` / `batch-export-dialog.tsx` / `scheduled-export-wizard.tsx`
  三个表单从原来的单 boolean (`skipFileDownloadOnly`) 改成
  `skipDownloadResourceTypes: SkipDownloadResourceType[]`，prefill / 重置 /
  提交链路都跟着改了一遍。`scheduled-export-wizard` 的 prefill 也兼容旧任务
  的 `skipDownloadResourceTypes` 字段。
- 「快速导出（跳过资源下载）」勾上时，这一组按钮整体隐藏，避免用户在
  两条互斥路径上同时操作。

### 测试

- 新增 `__tests__/unit/skipResourceTypes.test.ts` 覆盖 helper 的 8 个边界
  情况：从 `undefined` 起步、幂等开同一项、关到空返回 `undefined`、保留剩
  余项、固定输出顺序、白名单过滤、空数组等价于 `undefined`、不可变性。
- `npm run test:unit` 全量 103 个用例通过（原 95 + 新增 8）。
- `pnpm build` 在前端 Next.js 项目下编译通过，没有新警告。

### Notes

- 没有改动 `ResourceHandler` / `ApiServer` / `ScheduledExportManager` 任何
  下载调度逻辑，新增的 UI 只是把已有 backend 字段进一步暴露给用户。
- `BatchExportConfig.skipDownloadResourceTypes` 类型保持原样
  (`Array<'image' | 'video' | 'audio' | 'file'>`), 兼容老 caller。
