### PR TITLE
fix(fetcher): shrink batch size on API timeout instead of repeating same window (#305, #316)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/BatchMessageFetcher.adaptiveBatch.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/BatchMessageFetcher.adaptiveBatch.test.ts
@@ -1,0 +1,132 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { BatchMessageFetcher } from '../../lib/core/fetcher/BatchMessageFetcher.js';
+import { ErrorType, SystemError } from '../../lib/types/index.js';
+import { createMockCore } from '../helpers/MockNapCatCore.js';
+
+/**
+ * Issue #305 / #316：QQ NT 端在大批量条数下偶发慢，BatchMessageFetcher 的
+ * Promise.race 会在 timeout 触发 TIMEOUT_ERROR。原本下次重试还用同样的 batchSize
+ * 大概率再次超时。这里验证：
+ *   - 每碰到一次超时，下一次重试前 batchSize 会折半；
+ *   - 折半下限为 MIN_BATCH_SIZE_ON_TIMEOUT = 200；
+ *   - 非超时类错误不会触发缩小；
+ *   - 缩小到 200 之后再超时也不会继续往下减。
+ *
+ * 这里通过 `as any` 直接访问 `callWithRetry`，避免在测试里铺一整套 NapCat
+ * MsgApi 的 happy/sad path mock。
+ */
+
+interface PrivateFetcher {
+    config: { batchSize: number; timeout: number; retryCount: number; retryInterval: number };
+    callWithRetry<T>(apiCall: () => Promise<T>): Promise<T>;
+}
+
+function makeFetcher(): PrivateFetcher {
+    const core = createMockCore();
+    const fetcher = new BatchMessageFetcher(core as any, {
+        batchSize: 5000,
+        // timeout 实际不参与逻辑，因为 apiCall 自己抛 SystemError；保留一个不会触发的 5s。
+        timeout: 5000,
+        retryCount: 3,
+        retryInterval: 1,
+    });
+    return fetcher as unknown as PrivateFetcher;
+}
+
+function timeoutError(): SystemError {
+    return new SystemError({
+        type: ErrorType.TIMEOUT_ERROR,
+        message: 'API调用超时 (mock)',
+        timestamp: new Date(),
+    });
+}
+
+function apiError(): SystemError {
+    return new SystemError({
+        type: ErrorType.API_ERROR,
+        message: 'mock api error',
+        timestamp: new Date(),
+    });
+}
+
+test('TIMEOUT_ERROR 每次都会把下次重试的 batchSize 折半（不低于 200）', async () => {
+    const fetcher = makeFetcher();
+    assert.equal(fetcher.config.batchSize, 5000);
+
+    const observedBatchSizes: number[] = [];
+    await assert.rejects(
+        fetcher.callWithRetry(async () => {
+            observedBatchSizes.push(fetcher.config.batchSize);
+            throw timeoutError();
+        }),
+        (err: unknown) => err instanceof SystemError && err.type === ErrorType.TIMEOUT_ERROR,
+    );
+
+    // retryCount=3 表示总共 4 次尝试。前 3 次失败后会缩小，第 4 次失败后直接 break。
+    // 5000 -> 2500 -> 1250 -> 625，最终一次尝试用 625。
+    assert.deepEqual(observedBatchSizes, [5000, 2500, 1250, 625]);
+    assert.equal(fetcher.config.batchSize, 625);
+});
+
+test('非超时类错误不会触发自适应缩小', async () => {
+    const fetcher = makeFetcher();
+    const observedBatchSizes: number[] = [];
+
+    await assert.rejects(
+        fetcher.callWithRetry(async () => {
+            observedBatchSizes.push(fetcher.config.batchSize);
+            throw apiError();
+        }),
+        (err: unknown) => err instanceof SystemError && err.type === ErrorType.API_ERROR,
+    );
+
+    assert.deepEqual(observedBatchSizes, [5000, 5000, 5000, 5000]);
+    assert.equal(fetcher.config.batchSize, 5000);
+});
+
+test('batchSize 已经接近下限时不会跌破 200', async () => {
+    const fetcher = makeFetcher();
+    fetcher.config.batchSize = 250;
+
+    const observedBatchSizes: number[] = [];
+    await assert.rejects(
+        fetcher.callWithRetry(async () => {
+            observedBatchSizes.push(fetcher.config.batchSize);
+            throw timeoutError();
+        }),
+        (err: unknown) => err instanceof SystemError && err.type === ErrorType.TIMEOUT_ERROR,
+    );
+
+    // 250 -> 200（floor）-> 200（已到下限不再缩）-> 200。
+    assert.deepEqual(observedBatchSizes, [250, 200, 200, 200]);
+    assert.equal(fetcher.config.batchSize, 200);
+});
+
+test('文本里带 timeout / API调用超时 也会按超时识别', async () => {
+    const fetcher = makeFetcher();
+    fetcher.config.batchSize = 1000;
+
+    await assert.rejects(
+        fetcher.callWithRetry(async () => {
+            throw new Error('underlying socket timeout');
+        }),
+    );
+
+    // 1000 -> 500 -> 250 -> 200（不会跌破下限）。
+    assert.equal(fetcher.config.batchSize, 200);
+});
+
+test('成功调用不会再次改动 batchSize', async () => {
+    const fetcher = makeFetcher();
+    let attempts = 0;
+    const result = await fetcher.callWithRetry(async () => {
+        attempts++;
+        return 'ok';
+    });
+
+    assert.equal(result, 'ok');
+    assert.equal(attempts, 1);
+    assert.equal(fetcher.config.batchSize, 5000);
+});

--- a/plugins/qq-chat-exporter/lib/core/fetcher/BatchMessageFetcher.ts
+++ b/plugins/qq-chat-exporter/lib/core/fetcher/BatchMessageFetcher.ts
@@ -546,11 +546,18 @@ export class BatchMessageFetcher {
     }
 
     /**
-     * 带重试的API调用
+     * 带重试的 API 调用。
+     *
+     * issue #305 / #316：客户端选大批量、QQ 端 NT API 偶尔慢/卡时，
+     * 单次调用容易在 30s（默认）或 120s（导出场景）触发 TIMEOUT_ERROR。
+     * 原来的实现会用同样的 batchSize 重试，往往再次超时直至放弃。
+     * 现在每遇到一次超时，就把下一次重试的 batchSize 折半（不低于
+     * `MIN_BATCH_SIZE_ON_TIMEOUT`），让 QQ 客户端有机会用更小窗口完成查询。
+     * apiCall 闭包是惰性读取 `this.config.batchSize` 的，所以重试就会自动用新值。
      */
     private async callWithRetry<T>(apiCall: () => Promise<T>): Promise<T> {
         let lastError: Error | undefined;
-        
+
         for (let attempt = 0; attempt <= this.config.retryCount; attempt++) {
             try {
                 // 检查取消令牌
@@ -562,7 +569,7 @@ export class BatchMessageFetcher {
                     });
                 }
 
-                console.info(`[BatchMessageFetcher] 开始API调用 (尝试 ${attempt + 1}/${this.config.retryCount + 1})`);
+                console.info(`[BatchMessageFetcher] 开始API调用 (尝试 ${attempt + 1}/${this.config.retryCount + 1}) batchSize=${this.config.batchSize}`);
                 const result = await Promise.race([
                     apiCall(),
                     this.createTimeoutPromise<T>()
@@ -583,6 +590,17 @@ export class BatchMessageFetcher {
                     break;
                 }
 
+                // issue #305 / #316：超时类错误下次重试用更小的 batchSize。
+                if (this.isTimeoutError(error) && this.config.batchSize > BatchMessageFetcher.MIN_BATCH_SIZE_ON_TIMEOUT) {
+                    const previous = this.config.batchSize;
+                    const next = Math.max(
+                        BatchMessageFetcher.MIN_BATCH_SIZE_ON_TIMEOUT,
+                        Math.floor(previous / 2),
+                    );
+                    this.config.batchSize = next;
+                    console.warn(`[BatchMessageFetcher] 检测到超时，自适应缩小 batchSize: ${previous} -> ${next}`);
+                }
+
                 // 等待重试间隔
                 const retryDelay = this.config.retryInterval * (attempt + 1);
                 console.info(`[BatchMessageFetcher] 等待 ${retryDelay}ms 后重试`);
@@ -592,6 +610,24 @@ export class BatchMessageFetcher {
 
         throw lastError;
     }
+
+    /**
+     * 判断错误是否属于 API 超时。SystemError 直接看 type，其他场景容错地匹配
+     * 错误信息文本（防止上层包装后丢失类型）。
+     */
+    private isTimeoutError(error: unknown): boolean {
+        if (error instanceof SystemError) {
+            return error.type === ErrorType.TIMEOUT_ERROR;
+        }
+        if (error && typeof error === 'object' && 'message' in error) {
+            const message = String((error as { message: unknown }).message ?? '');
+            return /API调用超时|timeout/i.test(message);
+        }
+        return false;
+    }
+
+    /** issue #305 / #316：自适应缩小后的 batchSize 下限。 */
+    private static readonly MIN_BATCH_SIZE_ON_TIMEOUT = 200;
 
     /**
      * 创建超时Promise


### PR DESCRIPTION
## Summary

Closes #305, closes #316.

`BatchMessageFetcher` wraps every `MsgApi.getAioFirstViewLatestMsgs` /
`getMsgHistory` / `getMsgsBySeqRange` call with a `Promise.race` against
a configurable timeout (默认 30s，导出场景 120s). When the NapCat NT API
is slow — large groups, very long histories, contended IPC, slow磁盘 —
a 5000-message batch repeatedly trips that timer. 老逻辑里 `callWithRetry`
重试时仍使用同样的 `batchSize`，所以每次重试基本上还是会超时，最终
在 issue #305 / #316 里都表现为 `API调用超时 (120000ms)` 然后整段任务失败。

This PR makes the retry loop adaptive: each `TIMEOUT_ERROR` 把下次重试
要用的 `batchSize` 折半（不低于 `MIN_BATCH_SIZE_ON_TIMEOUT = 200`）。
`apiCall` 闭包是惰性读 `this.config.batchSize` 的，所以下一次重试自然
拿到更小的窗口。后续的 batch 也保留缩小后的值，因为这种慢通常是该会话
／机器的固有属性，没必要再放大回去触发同样的超时。非超时类错误（普通
API_ERROR、CONNECT_ERROR 等）走原路径，不缩 batchSize，避免临时网络抖
动直接惩罚整个任务的吞吐。

### Changes

- `plugins/qq-chat-exporter/lib/core/fetcher/BatchMessageFetcher.ts`
  - `callWithRetry`：捕获错误后，如命中 `isTimeoutError(error)` 且
    `batchSize > MIN_BATCH_SIZE_ON_TIMEOUT`，则把 `this.config.batchSize`
    折半（向下取整，floor 200），并打 warn 日志方便排查。
  - 新增 `isTimeoutError(error)`：`SystemError.type === TIMEOUT_ERROR`
    直接命中；非 SystemError 时容错地匹配 message 文本（`API调用超时`
    或 `timeout`），避免上层包装后丢失类型。
  - 新增 `MIN_BATCH_SIZE_ON_TIMEOUT = 200` 静态常量。
  - 调用日志附带 `batchSize=…`，便于在用户复现问题时判断是否已经在缩。

- `plugins/qq-chat-exporter/__tests__/unit/BatchMessageFetcher.adaptiveBatch.test.ts`
  覆盖：
  1. 持续 TIMEOUT_ERROR 时 batchSize 序列 5000 → 2500 → 1250 → 625；
  2. 非超时错误不会触发缩小；
  3. 缩到 200 之后不再继续往下减；
  4. message 文本里有 `timeout` 也按超时识别；
  5. 成功调用不影响 batchSize。

### Verification

- `cd plugins/qq-chat-exporter && npm run test:unit` — 108 tests pass
  (5 new in `BatchMessageFetcher.adaptiveBatch.test.ts`).
- 仅修改 fetcher 的内部重试策略，不改变 API 表面、配置接口或任何已落地数据。

### Notes

- 这里有意只在「失败 + 超时」之后缩，而不是在第一次进入 `callWithRetry`
  时就降；这样普通节奏下 batch 仍然是 5000，吞吐不变，只在确实卡住的
  会话上自适应。
- 没有自动「再放回去」是因为：QQ 端慢通常是该会话 / 该客户端的稳定特征
  （消息体里大量 ark / 多媒体 / 转发消息），重新放大概率立刻又超时；
  保持小窗口是更稳的策略。