### PR TITLE
feat(standalone): friendly sessions tab when running without NapCat (#340)

### DIFF
--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -987,6 +987,9 @@ export class QQChatExporterApiServer {
                 name: APP_INFO.name,
                 copyright: APP_INFO.copyright,
                 version: VERSION,
+                // issue #340：前端用这个字段区分插件 / 独立两种后端，独立模式下
+                // 跳过 /api/friends、/api/groups 之类需要 QQ 登录的请求。
+                mode: 'plugin' as const,
                 napcat: {
                     version: 'unknown',
                     online: selfInfo?.online || false,

--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -981,17 +981,30 @@ export default function QCEDashboard() {
     }
   }
 
+  // Issue #340：独立模式（start-standalone.bat 启动、没有 NapCat / QQ 登录态）
+  // 下，/api/friends 和 /api/groups 只会回 503 STANDALONE_MODE，没必要发请求；
+  // 「会话」一类需要登录态的页面也直接换成引导卡片。
+  const isStandalone = systemInfo?.mode === "standalone"
+
   useEffect(() => {
+    if (isStandalone) return
     if (activeTab === "sessions" && groups.length === 0 && friends.length === 0) {
       loadChatData()
     }
-  }, [activeTab, groups.length, friends.length, loadChatData])
+  }, [activeTab, groups.length, friends.length, loadChatData, isStandalone])
 
   useEffect(() => {
     if (!error) return
+    // Issue #340：独立模式下 friends/groups 必然失败，错误文案里通常带
+    // 「独立模式」或后端的 `STANDALONE_MODE` code，统一吞掉，避免连续弹两次
+    // 红色 toast 把用户吓走。Sessions tab 上已经有专门的引导卡片说明。
+    if (isStandalone && /独立模式|STANDALONE_MODE/i.test(error)) {
+      setError(null)
+      return
+    }
     toast.error("发生错误", { description: error })
     setError(null)
-  }, [error, setError])
+  }, [error, setError, isStandalone])
 
   useEffect(() => {
     if (!scheduledError) return
@@ -1280,7 +1293,7 @@ export default function QCEDashboard() {
           <div className="flex items-center gap-2">
             {/* Page-specific actions */}
 
-            {activeTab === "sessions" && (
+            {activeTab === "sessions" && !isStandalone && (
               <>
                 <Button size="sm" variant="ghost" className="h-8 text-[13px] rounded-full px-2" onClick={loadChatData} disabled={isLoading}>
                   <RefreshCw className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
@@ -1591,31 +1604,91 @@ export default function QCEDashboard() {
             {/* ==================== SESSIONS ==================== */}
             {activeTab === "sessions" && (
               <div className="p-5 space-y-4">
-                {batchMode && (
-                  <div className="text-[13px] text-muted-foreground px-1">
-                    已选择 {selectedItems.size} 个会话
+                {/* Issue #340：独立模式下没有 NapCat / QQ 登录态，无法拉群组和好友列表。
+                    用一张引导卡片替换原来的 SessionList，避免红色错误 toast 把用户吓退。 */}
+                {isStandalone ? (
+                  <div
+                    data-testid="sessions-standalone-banner"
+                    className="rounded-xl border border-black/[0.06] dark:border-white/[0.06] bg-card p-6 space-y-4"
+                  >
+                    <div className="flex items-start gap-3">
+                      <div className="w-9 h-9 rounded-lg bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300 flex items-center justify-center flex-shrink-0">
+                        <Database className="w-[18px] h-[18px]" />
+                      </div>
+                      <div className="space-y-1.5 min-w-0">
+                        <h3 className="text-[15px] font-semibold text-foreground">
+                          当前是独立模式
+                        </h3>
+                        <p className="text-[13px] text-muted-foreground/80 leading-relaxed">
+                          独立模式下没有运行 NapCat / 登录 QQ，无法获取群组和好友列表，也无法发起新的导出。
+                          已经导出的聊天记录、资源画廊、表情包都可以照常浏览。
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap gap-2 pt-1">
+                      <Button
+                        size="sm"
+                        variant="default"
+                        className="h-8 text-[13px] rounded-full px-3"
+                        onClick={() => setActiveTab("history")}
+                      >
+                        <History className="w-3.5 h-3.5 mr-1.5" />
+                        浏览聊天记录
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-8 text-[13px] rounded-full px-3"
+                        onClick={() => setActiveTab("stickers")}
+                      >
+                        <Sticker className="w-3.5 h-3.5 mr-1.5" />
+                        表情包
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-8 text-[13px] rounded-full px-3"
+                        onClick={() =>
+                          window.open(
+                            "https://github.com/shuakami/qq-chat-exporter#standalone",
+                            "_blank",
+                          )
+                        }
+                      >
+                        <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
+                        切换到完整模式
+                      </Button>
+                    </div>
                   </div>
+                ) : (
+                  <>
+                    {batchMode && (
+                      <div className="text-[13px] text-muted-foreground px-1">
+                        已选择 {selectedItems.size} 个会话
+                      </div>
+                    )}
+                    <SessionList
+                      groups={groups}
+                      friends={friends}
+                      isLoading={isLoading}
+                      batchMode={batchMode}
+                      selectedItems={selectedItems}
+                      avatarExportLoading={avatarExportLoading}
+                      onRefresh={loadChatData}
+                      onToggleBatchMode={handleToggleBatchMode}
+                      onSelectAll={handleSelectAll}
+                      onClearSelection={handleClearSelection}
+                      onToggleItem={handleToggleItem}
+                      onSelectMany={handleSelectMany}
+                      onOpenBatchExportDialog={handleOpenBatchExportDialog}
+                      onPreviewChat={handlePreviewChat}
+                      onOpenTaskWizard={handleOpenTaskWizard}
+                      onExportGroupAvatars={handleExportGroupAvatars}
+                      onOpenEssenceModal={handleOpenEssenceModal}
+                      onOpenGroupFilesModal={handleOpenGroupFilesModal}
+                    />
+                  </>
                 )}
-                <SessionList
-                  groups={groups}
-                  friends={friends}
-                  isLoading={isLoading}
-                  batchMode={batchMode}
-                  selectedItems={selectedItems}
-                  avatarExportLoading={avatarExportLoading}
-                  onRefresh={loadChatData}
-                  onToggleBatchMode={handleToggleBatchMode}
-                  onSelectAll={handleSelectAll}
-                  onClearSelection={handleClearSelection}
-                  onToggleItem={handleToggleItem}
-                  onSelectMany={handleSelectMany}
-                  onOpenBatchExportDialog={handleOpenBatchExportDialog}
-                  onPreviewChat={handlePreviewChat}
-                  onOpenTaskWizard={handleOpenTaskWizard}
-                  onExportGroupAvatars={handleExportGroupAvatars}
-                  onOpenEssenceModal={handleOpenEssenceModal}
-                  onOpenGroupFilesModal={handleOpenGroupFilesModal}
-                />
               </div>
             )}
 

--- a/qce-v4-tool/e2e/ui-smoke.spec.ts
+++ b/qce-v4-tool/e2e/ui-smoke.spec.ts
@@ -301,3 +301,85 @@ test.describe('Session list — QQ lookup (issue #204)', () => {
         await expect(page.getByText(/未在本机 NTQQ 数据中找到/)).toBeVisible({ timeout: 10_000 });
     });
 });
+
+/**
+ * Issue #340: 独立模式（start-standalone.bat）下没有 NapCat / QQ 登录态。
+ * 老版本进入 sessions 标签页会立刻发起 /api/friends + /api/groups，两个端点
+ * 都回 503 STANDALONE_MODE，前端在右上角连弹两次红色 toast，且 SessionList
+ * 卡在「加载中」。这里通过路由拦截把 /api/system/info 的 mode 改成 'standalone'，
+ * 验证前端会换成专门的引导卡片，并不再发出 friends / groups 请求。
+ */
+test.describe('Standalone mode (issue #340)', () => {
+    test('sessions tab shows a standalone banner instead of loading friends/groups', async ({ page }) => {
+        await clearLocalStorage(page);
+        await page.evaluate((value) => {
+            localStorage.setItem('qce_access_token', value);
+        }, TOKEN);
+
+        // 拦 /api/system/info：把 mode 改成 standalone，napcat.online 改成 false。
+        await page.route('**/api/system/info', async (route, request) => {
+            if (request.method() !== 'GET') {
+                await route.continue();
+                return;
+            }
+            const original = await route.fetch();
+            const json = await original.json();
+            if (json?.success && json.data) {
+                json.data.mode = 'standalone';
+                if (json.data.napcat) {
+                    json.data.napcat.online = false;
+                }
+            }
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify(json),
+            });
+        });
+
+        // 监控 friends / groups，应当一次都不被请求。
+        const friendsRequests: string[] = [];
+        const groupsRequests: string[] = [];
+        page.on('request', (req) => {
+            const url = req.url();
+            if (url.includes('/api/friends')) friendsRequests.push(url);
+            if (url.includes('/api/groups')) groupsRequests.push(url);
+        });
+
+        const response = await page
+            .goto(`${FRONTEND_BASE}${SHELL_PATH}`)
+            .catch(() => null);
+        test.skip(
+            !response || response.status() >= 500,
+            `frontend not reachable at ${FRONTEND_BASE}`
+        );
+
+        // 跳过欢迎弹窗（如有）。
+        const skipBtn = page.getByRole('button', { name: '跳过' }).first();
+        if (await skipBtn.isVisible({ timeout: 1500 }).catch(() => false)) {
+            await skipBtn.click().catch(() => null);
+        }
+
+        const sessionsTab = page.getByRole('button', { name: '会话', exact: true });
+        await expect(sessionsTab).toBeVisible({ timeout: 15_000 });
+        await sessionsTab.click();
+
+        // 引导卡片可见。
+        const banner = page.getByTestId('sessions-standalone-banner');
+        await expect(banner).toBeVisible({ timeout: 10_000 });
+        await expect(banner.getByText('当前是独立模式')).toBeVisible();
+        await expect(banner.getByRole('button', { name: /浏览聊天记录/ })).toBeVisible();
+
+        // 给一点时间确保前端没有偷偷发请求。
+        await page.waitForTimeout(800);
+        expect(friendsRequests, 'standalone mode must skip /api/friends').toEqual([]);
+        expect(groupsRequests, 'standalone mode must skip /api/groups').toEqual([]);
+
+        // 点击「浏览聊天记录」直接跳到 history 标签页。history 标签页的内容区
+        // 一定带「记录列表」这个 segment 切换按钮，用它来确认跳转成功。
+        await banner.getByRole('button', { name: /浏览聊天记录/ }).click();
+        await expect(
+            page.getByRole('button', { name: '记录列表', exact: true })
+        ).toBeVisible({ timeout: 10_000 });
+    });
+});

--- a/qce-v4-tool/types/api.ts
+++ b/qce-v4-tool/types/api.ts
@@ -18,6 +18,13 @@ export interface APIResponse<T> {
 export interface SystemInfo {
   name: string
   version: string
+  /**
+   * 后端运行形态。Issue #340：独立模式下没有 NapCat、没有 QQ 登录态，前端
+   * 看到这个值就应该跳过 /api/friends 和 /api/groups（这两个端点固定返回 503
+   * STANDALONE_MODE 错误），并在「会话」一类需要登录态的页面上提示用户走
+   * 「聊天记录」浏览历史导出。
+   */
+  mode?: 'plugin' | 'standalone'
   napcat: {
     version: string
     online: boolean


### PR DESCRIPTION
Issue #340 反馈的：跑 standalone（`start-standalone.bat`，没 NapCat 没 QQ 登录态）一进去就被红色 toast「加载好友失败：独立模式不支持获取好友列表...」糊一脸，会话面板空空的，用户也不知道接下来该干嘛。

standalone 本来就是用来翻已有导出的，但前端根本不知道自己接的是 `StandaloneServer`，照样在每次进会话页时去戳 `/api/friends` + `/api/groups`，俩都一定回 503 STANDALONE_MODE。

这次让前端真的认识独立模式：

- `GET /api/system/info` 现在带 `mode: "plugin" | "standalone"`。`StandaloneServer` 自己那边其实早就在返回 `"standalone"`，`ApiServer` 这边对齐返回 `"plugin"`。
- `qce-v4-tool/types/api.ts` 的 `SystemInfo` 加了同名字段，注释里写清楚为什么前端要管它。
- `qce-v4-tool/app/page.tsx` 看到 `mode === "standalone"` 时：
  - 进会话页不再去 fetch friends / groups
  - 渲染一张引导卡片（`data-testid="sessions-standalone-banner"`），写明白当前是独立模式，给「浏览聊天记录」「表情包」「切换到完整模式」三个按钮
  - 把右上角的「刷新」「批量导出」也藏起来，避免点了等于没点
  - 命中 `STANDALONE_MODE` / `独立模式` 的错误消息直接吞掉，不让全局 toast 把人吓走
- `qce-v4-tool/e2e/ui-smoke.spec.ts` 加了一组 `Standalone mode (issue #340)` 的 Playwright，用 `page.route` 把 `/api/system/info` 改写成 `mode: "standalone"`，断言：1) 卡片真出现了 2) friends/groups 一次都没被发出去 3) 点「浏览聊天记录」能切到 history 页。

本地验过：`qce-v4-tool` 跑 `npm run build` 过，`plugins/qq-chat-exporter` 跑 `npm run test:unit` 108/108 过，对真 mock 服务器跑 `npx playwright test e2e/ui-smoke.spec.ts` 8/8 过（含新加的 standalone case）。

顺便：`mode: "plugin"` 是新加字段，老前端忽略它没事，没破坏向后兼容。错误吞 toast 的逻辑也只在 `isStandalone` 时生效，plugin 模式下行为完全没变。