### PR TITLE
fix(auth): only redirect on explicit 401/403, tolerate transient /auth failures (#346)

### DIFF
--- a/qce-v4-tool/components/auth-provider.tsx
+++ b/qce-v4-tool/components/auth-provider.tsx
@@ -38,35 +38,57 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     // 有本地 token，但需要向后端验证其有效性
     // 这解决了：用户先用独立模式（任意token通过）后用完整模式的问题
+    //
+    // Issue #346：在网络异常 / 中间代理抽风的场景下，POST /auth 可能：
+    //   - 长时间 hang 住（CDN / 透明代理在等远端）
+    //   - 直接 502 / 503 / 504（代理失败）
+    //   - 返回 HTML 错误页，`response.json()` 抛异常
+    //   - 返回 `{ success: false }` 但不是真的 token 失效
+    // 老逻辑只要 `data.success` 不为 truthy 就清掉本地 token + 跳回 /auth，
+    // 一次抽风用户就被踢出登录态。这里改成只有「后端明确告知 token 无效」
+    // （HTTP 401 / 403）时才清 token，其它情况一律放行；如果 token 真的失效，
+    // 紧接着的 `/api/*` 请求会被 fetch 拦截器以 401/403 兜住、再次跳回 /auth。
     const validateToken = async () => {
+      const controller = new AbortController()
+      const timeout = setTimeout(() => controller.abort(), 8000)
       try {
         const response = await fetch('/auth', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ token: authManager.getToken() })
+          body: JSON.stringify({ token: authManager.getToken() }),
+          signal: controller.signal,
         })
-        
-        const data = await response.json()
-        
-        if (data.success) {
-          // token 有效，初始化 fetch 拦截器
-          authManager.initialize()
-          setAuthState('authenticated')
-        } else {
-          // token 无效（可能是独立模式遗留的假token），清除并重定向
+        clearTimeout(timeout)
+
+        if (response.status === 401 || response.status === 403) {
+          // 后端明确说 token 无效（典型来源：独立模式遗留的假 token、
+          // security.json 被重写、或者用户的 IP 不在白名单里）。
           authManager.clearToken()
           setAuthState('redirecting')
           setTimeout(() => {
             window.location.href = '/qce-v4-tool/auth'
           }, 300)
+          return
         }
-      } catch {
-        // 网络错误时，假设后端未启动，允许继续（fetch拦截器会处理后续401）
+
+        // 5xx / 非 JSON 响应 / `success !== true`：当作中间代理或后端临时故障，
+        // 放过这次校验，让前端继续渲染。后续 API 真要 401/403 再走 fetch 拦截器。
+        if (!response.ok) {
+          console.warn('[QCE] /auth verify returned non-ok status', response.status)
+        }
+
+        authManager.initialize()
+        setAuthState('authenticated')
+      } catch (err) {
+        clearTimeout(timeout)
+        // 网络错误 / 超时 / abort：假设后端未启动或代理在抽风，允许继续。
+        // fetch 拦截器会在后续 API 请求遇到 401/403 时正确清 token + 跳转。
+        console.warn('[QCE] /auth verify failed, allowing continue:', err)
         authManager.initialize()
         setAuthState('authenticated')
       }
     }
-    
+
     validateToken()
   }, [pathname, isMounted])
 

--- a/qce-v4-tool/e2e/ui-smoke.spec.ts
+++ b/qce-v4-tool/e2e/ui-smoke.spec.ts
@@ -303,6 +303,131 @@ test.describe('Session list — QQ lookup (issue #204)', () => {
 });
 
 /**
+ * Issue #346: 网络抽风 / 中间代理篡改时，POST /auth 可能短暂返回 5xx 或被
+ * 改写成 success=false。老 AuthProvider 只要 success 不为 truthy 就清掉本地
+ * token + 跳回 /auth，把已经登录的用户踢出。新版只有 401 / 403 才会清 token，
+ * 其它一律放行。这里通过 page.route 模拟两种场景：
+ *   1. POST /auth 返回 502 → 用户保留 token，停留在主界面
+ *   2. POST /auth 返回 200 + `{ success: false }` 但状态码不是 401/403 → 同上
+ */
+test.describe('Auth validation resilience (issue #346)', () => {
+    test('transient 502 on /auth keeps the user inside the app', async ({ page }) => {
+        await clearLocalStorage(page);
+        await page.evaluate((value) => {
+            localStorage.setItem('qce_access_token', value);
+        }, TOKEN);
+
+        // 用 page.route 拦 POST /auth，在第一次校验请求上返回 502；后续别的
+        // /auth 流程都走真接口。
+        let blocked = false;
+        await page.route('**/auth', async (route, request) => {
+            if (!blocked && request.method() === 'POST') {
+                blocked = true;
+                await route.fulfill({
+                    status: 502,
+                    contentType: 'text/html',
+                    body: '<html><body>Bad Gateway</body></html>',
+                });
+                return;
+            }
+            await route.continue();
+        });
+
+        const response = await page
+            .goto(`${FRONTEND_BASE}${SHELL_PATH}`)
+            .catch(() => null);
+        test.skip(
+            !response || response.status() >= 500,
+            `frontend not reachable at ${FRONTEND_BASE}`
+        );
+
+        // 等到 AuthProvider 走完 / 渲染主界面：侧栏一定有「会话」入口。
+        await expect(page.getByRole('button', { name: '会话', exact: true }))
+            .toBeVisible({ timeout: 15_000 });
+
+        // 用户没有被踢回 /auth。
+        expect(new URL(page.url()).pathname).not.toMatch(/\/auth\/?$/);
+
+        // localStorage 里的 token 也没被清掉。
+        const stored = await page.evaluate(() => localStorage.getItem('qce_access_token'));
+        expect(stored).toBe(TOKEN);
+    });
+
+    test('non-401/403 with success:false body still keeps the user inside the app', async ({ page }) => {
+        await clearLocalStorage(page);
+        await page.evaluate((value) => {
+            localStorage.setItem('qce_access_token', value);
+        }, TOKEN);
+
+        let blocked = false;
+        await page.route('**/auth', async (route, request) => {
+            if (!blocked && request.method() === 'POST') {
+                blocked = true;
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        success: false,
+                        error: { type: 'PROXY_TAMPERING', message: 'reverse proxy ate the body' },
+                    }),
+                });
+                return;
+            }
+            await route.continue();
+        });
+
+        const response = await page
+            .goto(`${FRONTEND_BASE}${SHELL_PATH}`)
+            .catch(() => null);
+        test.skip(
+            !response || response.status() >= 500,
+            `frontend not reachable at ${FRONTEND_BASE}`
+        );
+
+        await expect(page.getByRole('button', { name: '会话', exact: true }))
+            .toBeVisible({ timeout: 15_000 });
+        expect(new URL(page.url()).pathname).not.toMatch(/\/auth\/?$/);
+        const stored = await page.evaluate(() => localStorage.getItem('qce_access_token'));
+        expect(stored).toBe(TOKEN);
+    });
+
+    test('explicit 403 still clears token and redirects to /auth', async ({ page }) => {
+        await clearLocalStorage(page);
+        await page.evaluate((value) => {
+            localStorage.setItem('qce_access_token', value);
+        }, TOKEN);
+
+        await page.route('**/auth', async (route, request) => {
+            if (request.method() === 'POST') {
+                await route.fulfill({
+                    status: 403,
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        success: false,
+                        error: { type: 'AUTH_ERROR', message: 'invalid token', context: { code: 'INVALID_TOKEN' } },
+                    }),
+                });
+                return;
+            }
+            await route.continue();
+        });
+
+        const response = await page
+            .goto(`${FRONTEND_BASE}${SHELL_PATH}`)
+            .catch(() => null);
+        test.skip(
+            !response || response.status() >= 500,
+            `frontend not reachable at ${FRONTEND_BASE}`
+        );
+
+        // 真 token 失效，前端应当踢回 /auth 并清掉 localStorage。
+        await page.waitForURL(/\/auth\/?$/, { timeout: 15_000 });
+        const stored = await page.evaluate(() => localStorage.getItem('qce_access_token'));
+        expect(stored).toBeNull();
+    });
+});
+
+/**
  * Issue #340: 独立模式（start-standalone.bat）下没有 NapCat / QQ 登录态。
  * 老版本进入 sessions 标签页会立刻发起 /api/friends + /api/groups，两个端点
  * 都回 503 STANDALONE_MODE，前端在右上角连弹两次红色 toast，且 SessionList


### PR DESCRIPTION
Issue #346 反馈的：网络一抽风，刚登录的用户立马被踢回 `/auth` 重新填 token。

查了下，根因在 `AuthProvider`。前端首页起来的时候会再发一次 `POST /auth { token }` 校验本地 token，老逻辑长这样：

```ts
const { success } = await response.json()
if (!success) {
  authManager.clearToken()
  window.location.href = '/qce-v4-tool/auth'
}
```

问题是「响应里 success 不是 truthy」这条件太宽：
- 上游代理 502 / 504：`response.json()` 直接抛，落进 catch 也跳走
- 透明代理把 body 改成 HTML 错误页：parse 抛，同上
- 后端临时不可用、`success: false` 但状态码不是 401 / 403：被当成「token 已失效」清掉
- 校验请求自己被卡住、超时：完全没兜底

这一次把判断收严：

- **只有** HTTP 401 / 403 才被当成「后端明确告诉我 token 无效」，清 token + 跳 `/auth`
- 5xx、非 JSON 响应、`success: false` 但状态码非 401 / 403、网络错误、超时：一律放行，让前端继续渲染
- 加了 8s `AbortController` 兜底，避免代理 hang 住把 splash 卡死
- 真假 token 不会漏：紧接着任何 `/api/*` 请求要是真拿到 401 / 403，会被 `lib/auth.ts` 里全局 fetch 拦截器接住、再正常清 token + 跳 `/auth`

在 `qce-v4-tool/e2e/ui-smoke.spec.ts` 里加了 `Auth validation resilience (issue #346)` 三个 case：

1. POST `/auth` 第一次回 502，断言侧栏按钮可见、不在 `/auth` 路径、`localStorage.qce_auth_token` 还在
2. POST `/auth` 200 + `{ success: false }`（非 401/403），同上断言
3. POST `/auth` 403 INVALID_TOKEN，断言被踢回 `/auth` 且 token 已清（保证旧的「真失效」路径没回归）

本地验过：`qce-v4-tool` 跑 `npm run build` 过，`plugins/qq-chat-exporter` 跑 `npm run test:unit` 108/108 过，对真 mock 服务器跑 `npx playwright test e2e/ui-smoke.spec.ts` 11/11 过。