### PR TITLE
fix(api): tolerate missing core.context.logger via safe wrapper (#326)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/safeLogger.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/safeLogger.test.ts
@@ -1,0 +1,122 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSafeLogger } from '../../lib/api/safeLogger.js';
+
+interface RecordedConsole {
+    log: unknown[][];
+    warn: unknown[][];
+    error: unknown[][];
+    debug: unknown[][];
+}
+
+function makeFakeConsole(): { console: Console; recorded: RecordedConsole } {
+    const recorded: RecordedConsole = { log: [], warn: [], error: [], debug: [] };
+    const fake = {
+        log: (...args: unknown[]) => recorded.log.push(args),
+        warn: (...args: unknown[]) => recorded.warn.push(args),
+        error: (...args: unknown[]) => recorded.error.push(args),
+        debug: (...args: unknown[]) => recorded.debug.push(args),
+    } as unknown as Console;
+    return { console: fake, recorded };
+}
+
+describe('safeLogger', () => {
+    it('falls back to console when core is undefined', () => {
+        const { console: fake, recorded } = makeFakeConsole();
+        const logger = createSafeLogger(undefined, fake);
+        logger.log('hello');
+        logger.logWarn('warning');
+        logger.logError('boom');
+        logger.logDebug('detail');
+
+        assert.deepEqual(recorded.log, [['[QCE]', 'hello']]);
+        assert.deepEqual(recorded.warn, [['[QCE]', 'warning']]);
+        assert.deepEqual(recorded.error, [['[QCE]', 'boom']]);
+        assert.deepEqual(recorded.debug, [['[QCE]', 'detail']]);
+    });
+
+    it('falls back to console when core.context is missing', () => {
+        const { console: fake, recorded } = makeFakeConsole();
+        const logger = createSafeLogger({} as any, fake);
+        logger.log('hello');
+        assert.deepEqual(recorded.log, [['[QCE]', 'hello']]);
+    });
+
+    it('falls back to console when logger is missing', () => {
+        const { console: fake, recorded } = makeFakeConsole();
+        const logger = createSafeLogger({ context: {} } as any, fake);
+        logger.logError('boom');
+        assert.deepEqual(recorded.error, [['[QCE]', 'boom']]);
+    });
+
+    it('falls back when only some methods are present', () => {
+        const { console: fake, recorded } = makeFakeConsole();
+        const napcatLogger = {
+            log: (...args: unknown[]) => recorded.log.push(['napcat', ...args]),
+        };
+        const logger = createSafeLogger({ context: { logger: napcatLogger } } as any, fake);
+
+        logger.log('hello');
+        logger.logWarn('warning');
+        logger.logError('boom');
+
+        // log -> NapCat 真正的 logger
+        assert.deepEqual(recorded.log, [['napcat', 'hello']]);
+        // logWarn / logError 缺失 -> console
+        assert.deepEqual(recorded.warn, [['[QCE]', 'warning']]);
+        assert.deepEqual(recorded.error, [['[QCE]', 'boom']]);
+    });
+
+    it('routes calls to NapCat logger when fully present', () => {
+        const { console: fake } = makeFakeConsole();
+        const calls: Record<string, unknown[][]> = { log: [], logWarn: [], logError: [], logDebug: [] };
+        const napcatLogger = {
+            log: (...args: unknown[]) => { calls.log.push(args); },
+            logWarn: (...args: unknown[]) => { calls.logWarn.push(args); },
+            logError: (...args: unknown[]) => { calls.logError.push(args); },
+            logDebug: (...args: unknown[]) => { calls.logDebug.push(args); },
+        };
+        const logger = createSafeLogger({ context: { logger: napcatLogger } } as any, fake);
+
+        logger.log('a');
+        logger.logWarn('b');
+        logger.logError('c', 1, 2);
+        logger.logDebug('d');
+
+        assert.deepEqual(calls.log, [['a']]);
+        assert.deepEqual(calls.logWarn, [['b']]);
+        assert.deepEqual(calls.logError, [['c', 1, 2]]);
+        assert.deepEqual(calls.logDebug, [['d']]);
+    });
+
+    it('falls back to console if the underlying NapCat logger throws', () => {
+        const { console: fake, recorded } = makeFakeConsole();
+        const napcatLogger = {
+            log: () => { throw new Error('logger pipe broken'); },
+        };
+        const logger = createSafeLogger({ context: { logger: napcatLogger } } as any, fake);
+
+        // 不能让 log 抛出来污染调用方
+        logger.log('hello');
+
+        assert.deepEqual(recorded.log, [['[QCE]', 'hello']]);
+    });
+
+    it('preserves `this` binding when calling NapCat logger', () => {
+        const { console: fake } = makeFakeConsole();
+        const napcatLogger = {
+            tag: 'napcat',
+            received: [] as Array<{ tag: string; args: unknown[] }>,
+            log(this: { tag: string; received: Array<{ tag: string; args: unknown[] }> }, ...args: unknown[]) {
+                this.received.push({ tag: this.tag, args });
+            },
+        };
+        const logger = createSafeLogger({ context: { logger: napcatLogger } } as any, fake);
+
+        logger.log('hi');
+
+        assert.equal(napcatLogger.received.length, 1);
+        assert.equal(napcatLogger.received[0]!.tag, 'napcat');
+        assert.deepEqual(napcatLogger.received[0]!.args, ['hi']);
+    });
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -48,6 +48,7 @@ import {
 } from '../utils/manualExportFileName.js';
 import { resolvePeerUid } from './peerResolution.js';
 import { lookupUserByUin } from './userLookup.js';
+import { createSafeLogger, type SafeLogger } from './safeLogger.js';
 import { buildResourceSummaryMessage } from '../utils/resourceSummary.js';
 
 // 导入类型定义
@@ -150,6 +151,21 @@ export class QQChatExporterApiServer {
     
     // 缓存过期时间（10分钟）
     private readonly CACHE_EXPIRE_TIME = 10 * 60 * 1000;
+
+    /**
+     * Issue #326：用作插件嵌入到老 / 不兼容的 NapCat 版本时，
+     * `core.context.logger` 在某些路径上可能是 undefined（接口被改名、字段
+     * 在 setupMiddleware 完成前被读、或者 NapCatQQ overlay runtime 没匹配
+     * 上）。老代码直接读取 `core.context.logger.log` 会让 Express 中间件
+     * 链炸开，外层连一个 500 都返回不出去，前端表现就是「打开 Web 界面
+     * 什么都没有」。所有日志改走这个 getter，logger 缺失 / 抛异常时自动
+     * fallback 到 console，保证业务代码不会因为日志写不出来而崩。
+     *
+     * 真正的实现 + 单元测试在 `./safeLogger.ts`。
+     */
+    private get safeLogger(): SafeLogger {
+        return createSafeLogger(this.core);
+    }
 
     /**
      * 构造函数
@@ -324,7 +340,7 @@ export class QQChatExporterApiServer {
 
         // 日志中间件
         this.app.use((req: Request, _res: Response, next) => {
-            this.core.context.logger.log(`[API] ${req.method} ${req.path}`);
+            this.safeLogger.log(`[API] ${req.method} ${req.path}`);
             next();
         });
 
@@ -1256,7 +1272,7 @@ export class QQChatExporterApiServer {
                     groupCode
                 }, (req as any).requestId);
             } catch (error) {
-                this.core.context.logger.logError('[ApiServer] 获取群精华消息失败:', error);
+                this.safeLogger.logError('[ApiServer] 获取群精华消息失败:', error);
                 this.sendErrorResponse(res, error, (req as any).requestId);
             }
         });
@@ -1357,7 +1373,7 @@ export class QQChatExporterApiServer {
                     downloadUrl: `/downloads/essence/${fileName}`
                 }, (req as any).requestId);
             } catch (error) {
-                this.core.context.logger.logError('[ApiServer] 导出群精华消息失败:', error);
+                this.safeLogger.logError('[ApiServer] 导出群精华消息失败:', error);
                 this.sendErrorResponse(res, error, (req as any).requestId);
             }
         });
@@ -1589,7 +1605,7 @@ export class QQChatExporterApiServer {
                                 .filter((s: string) => s.length > 0)
                         );
                     } catch (e) {
-                        this.core.context.logger.logWarn(
+                        this.safeLogger.logWarn(
                             '[ApiServer] /api/recent-contacts: 获取好友列表失败，跳过去重',
                             e
                         );
@@ -1600,7 +1616,7 @@ export class QQChatExporterApiServer {
                             (groups || []).map((g: any) => String(g.groupCode || ''))
                         );
                     } catch (e) {
-                        this.core.context.logger.logWarn(
+                        this.safeLogger.logWarn(
                             '[ApiServer] /api/recent-contacts: 获取群组列表失败，跳过去重',
                             e
                         );
@@ -1686,9 +1702,9 @@ export class QQChatExporterApiServer {
                     this.core.apis.FriendApi as any,
                     {
                         logWarn: (msg, err) =>
-                            this.core.context.logger.logWarn(`[ApiServer] /api/users/lookup: ${msg}`, err),
+                            this.safeLogger.logWarn(`[ApiServer] /api/users/lookup: ${msg}`, err),
                         logDebug: (msg, err) =>
-                            this.core.context.logger.logDebug(`[ApiServer] /api/users/lookup: ${msg}`, err as any),
+                            this.safeLogger.logDebug(`[ApiServer] /api/users/lookup: ${msg}`, err as any),
                     },
                 );
                 this.sendSuccessResponse(res, result, (req as any).requestId);
@@ -2042,7 +2058,7 @@ export class QQChatExporterApiServer {
 
                 // Issue #226 / #353: 支持通过 QQ 号导出，自动转换为 uid。
                 // 旧版 NapCat 上 getUidByUinV2 不存在，resolvePeerUid 会安全降级到原始 peerUid。
-                const actualPeerUid = await resolvePeerUid(peer, this.core.apis?.UserApi, this.core.context.logger);
+                const actualPeerUid = await resolvePeerUid(peer, this.core.apis?.UserApi, this.safeLogger);
                 const actualPeer = { ...peer, peerUid: actualPeerUid };
 
                 // 生成任务ID
@@ -2178,7 +2194,7 @@ export class QQChatExporterApiServer {
                 }
 
                 // Issue #226 / #353: 支持通过 QQ 号导出，自动转换为 uid（兼容缺失 getUidByUinV2 的运行时）。
-                const actualPeerUid = await resolvePeerUid(peer, this.core.apis?.UserApi, this.core.context.logger);
+                const actualPeerUid = await resolvePeerUid(peer, this.core.apis?.UserApi, this.safeLogger);
                 const actualPeer = { ...peer, peerUid: actualPeerUid };
 
                 // 生成任务ID
@@ -2296,7 +2312,7 @@ export class QQChatExporterApiServer {
                 }
 
                 // Issue #226 / #353: 支持通过 QQ 号导出，自动转换为 uid（兼容缺失 getUidByUinV2 的运行时）。
-                const actualPeerUid = await resolvePeerUid(peer, this.core.apis?.UserApi, this.core.context.logger);
+                const actualPeerUid = await resolvePeerUid(peer, this.core.apis?.UserApi, this.safeLogger);
                 const actualPeer = { ...peer, peerUid: actualPeerUid };
 
                 // 生成任务ID
@@ -3496,7 +3512,7 @@ export class QQChatExporterApiServer {
     private setupWebSocket(): void {
         this.wss.on('connection', (ws: WebSocket) => {
             const requestId = this.generateRequestId();
-            this.core.context.logger.log(`[API] WebSocket连接建立: ${requestId}`);
+            this.safeLogger.log(`[API] WebSocket连接建立: ${requestId}`);
             
             this.wsConnections.add(ws);
 
@@ -3506,7 +3522,7 @@ export class QQChatExporterApiServer {
                     const message = JSON.parse(data.toString());
                     await this.handleWebSocketMessage(ws, message);
                 } catch (error) {
-                    this.core.context.logger.logError('[API] WebSocket消息处理失败', error);
+                    this.safeLogger.logError('[API] WebSocket消息处理失败', error);
                     this.sendWebSocketMessage(ws, {
                         type: 'error',
                         data: { message: '消息格式错误' },
@@ -3517,11 +3533,11 @@ export class QQChatExporterApiServer {
 
             ws.on('close', () => {
                 this.wsConnections.delete(ws);
-                this.core.context.logger.log(`[API] WebSocket连接关闭: ${requestId}`);
+                this.safeLogger.log(`[API] WebSocket连接关闭: ${requestId}`);
             });
 
             ws.on('error', (error) => {
-                this.core.context.logger.logError(`[API] WebSocket错误: ${requestId}`, error);
+                this.safeLogger.logError(`[API] WebSocket错误: ${requestId}`, error);
             });
 
             // 发送连接确认
@@ -3620,7 +3636,7 @@ export class QQChatExporterApiServer {
                 ws.send(JSON.stringify(message));
             }
         } catch (error) {
-            this.core.context.logger.logError('[API] 发送WebSocket消息失败:', error);
+            this.safeLogger.logError('[API] 发送WebSocket消息失败:', error);
         }
     }
 
@@ -5370,7 +5386,7 @@ export class QQChatExporterApiServer {
             requestId
         };
         
-        this.core.context.logger.logError('[API] 请求错误:', error);
+        this.safeLogger.logError('[API] 请求错误:', error);
         res.status(statusCode).json(response);
     }
 

--- a/plugins/qq-chat-exporter/lib/api/safeLogger.ts
+++ b/plugins/qq-chat-exporter/lib/api/safeLogger.ts
@@ -1,0 +1,66 @@
+/**
+ * 把 NapCat core 的 logger 包成「永远不会因为 logger 自己出问题而炸」的版本。
+ *
+ * Issue #326：QCE 被作为插件嵌入到老 / 不兼容版本的 NapCat 时，
+ * `core.context.logger` 在某些路径上可能整个就是 undefined（接口被改名、
+ * 字段在 setup 完成前被读、或者 NapCatQQ overlay runtime 没匹配上）。
+ * 老代码直接 `this.core.context.logger.log(...)` 让 Express 中间件链炸开，
+ * 外层连一个 500 都返回不出去，前端表现就是「打开 Web 界面什么都没有」。
+ *
+ * 这里提供一个统一的 `createSafeLogger`：
+ *  - logger 不可用 / 缺指定方法时，退回到 console
+ *  - logger 自己抛异常时，也退回到 console
+ *  - 永远返回完整的 4 个方法（log / logWarn / logError / logDebug）
+ */
+
+export interface NapCatLoggerLike {
+    log?: (...args: unknown[]) => void;
+    logWarn?: (...args: unknown[]) => void;
+    logError?: (...args: unknown[]) => void;
+    logDebug?: (...args: unknown[]) => void;
+}
+
+export interface NapCatCoreLike {
+    context?: {
+        logger?: NapCatLoggerLike;
+    };
+}
+
+export interface SafeLogger {
+    log: (...args: unknown[]) => void;
+    logWarn: (...args: unknown[]) => void;
+    logError: (...args: unknown[]) => void;
+    logDebug: (...args: unknown[]) => void;
+}
+
+type ConsoleSink = (...args: unknown[]) => void;
+
+function wrap(
+    fn: ((...args: unknown[]) => void) | undefined,
+    target: NapCatLoggerLike | undefined,
+    fallback: ConsoleSink,
+): (...args: unknown[]) => void {
+    if (typeof fn !== 'function') {
+        return fallback;
+    }
+    return (...args: unknown[]) => {
+        try {
+            fn.apply(target, args);
+        } catch {
+            fallback(...args);
+        }
+    };
+}
+
+export function createSafeLogger(
+    core: NapCatCoreLike | undefined | null,
+    consoleImpl: Console = console,
+): SafeLogger {
+    const logger = core?.context?.logger;
+    return {
+        log: wrap(logger?.log, logger, (...args) => consoleImpl.log('[QCE]', ...args)),
+        logWarn: wrap(logger?.logWarn, logger, (...args) => consoleImpl.warn('[QCE]', ...args)),
+        logError: wrap(logger?.logError, logger, (...args) => consoleImpl.error('[QCE]', ...args)),
+        logDebug: wrap(logger?.logDebug, logger, (...args) => consoleImpl.debug('[QCE]', ...args)),
+    };
+}


### PR DESCRIPTION
Closes #326。

报错来自 issue 里那个堆栈：

```
TypeError: Cannot read properties of undefined (reading 'logger')
    at QQChatExporterApiServer.sendErrorResponse
```

被当作插件塞进老/不太匹配的 NapCat 时，`core.context.logger` 在某些代码路径上会是 `undefined`（NapCat 接口改了、setup 还没跑完、overlay runtime 没装好都可能撞上）。原来代码直接 `this.core.context.logger.log(...)`，一个错误响应就把 Express 中间件链炸掉，连 500 都返回不出去，用户那边表现为 Web UI 一片空白，只在后端 console 里有这条 TypeError。

### 改动

新增 `plugins/qq-chat-exporter/lib/api/safeLogger.ts`，提供 `createSafeLogger(core)`：

- 永远返回完整的 `log / logWarn / logError / logDebug` 四个方法
- NapCat logger 不存在 / 缺方法 → 走 `console.*`（带 `[QCE]` 前缀方便排查）
- NapCat logger 自己抛了 → catch 后退到 `console.*`，不会把请求处理冒上去
- 保留 `this` 绑定，避免某些实现内部用了 `this.xxx`

`ApiServer.ts` 里 17 处 `this.core.context.logger.xxx` 全部改走 `this.safeLogger.xxx`。`peerResolution.resolvePeerUid` 接受的是 `LoggerLike { log }`，wrapper 的形状兼容，调用点不用改。

### 测试

`__tests__/unit/safeLogger.test.ts` 7 个 case：core/context/logger 缺失、单个方法缺失、underlying logger 抛异常、`this` 绑定。

```
✔ safeLogger
ℹ tests 7  pass 7  fail 0
```