### PR TITLE
feat(filter): only-include sender filter for export (#369)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/senderFilter.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/senderFilter.test.ts
@@ -1,0 +1,58 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildSenderFilter } from '../../lib/api/senderFilter.js';
+
+describe('buildSenderFilter', () => {
+    it('returns null when both lists are empty', () => {
+        assert.equal(buildSenderFilter(undefined, undefined), null);
+        assert.equal(buildSenderFilter([], []), null);
+        assert.equal(buildSenderFilter(null, null), null);
+    });
+
+    it('keeps only senders in includeUserUins when set', () => {
+        const filter = buildSenderFilter(['111', '222'], undefined);
+        assert.ok(filter, 'filter should be returned');
+        assert.equal(filter!('111'), true);
+        assert.equal(filter!('222'), true);
+        assert.equal(filter!('333'), false);
+        assert.equal(filter!(''), false);
+        assert.equal(filter!(null), false);
+        assert.equal(filter!(undefined), false);
+    });
+
+    it('drops senders in excludeUserUins when set', () => {
+        const filter = buildSenderFilter(undefined, ['999']);
+        assert.ok(filter);
+        assert.equal(filter!('999'), false);
+        assert.equal(filter!('111'), true);
+        assert.equal(filter!(''), true);
+    });
+
+    it('exclude wins when a uin is in both lists', () => {
+        const filter = buildSenderFilter(['111', '222'], ['111']);
+        assert.ok(filter);
+        assert.equal(filter!('111'), false);
+        assert.equal(filter!('222'), true);
+        assert.equal(filter!('333'), false);
+    });
+
+    it('handles numeric senderUin and trims whitespace in lists', () => {
+        const filter = buildSenderFilter([' 111 ', '222'], ['  333\t']);
+        assert.ok(filter);
+        assert.equal(filter!(111), true);
+        assert.equal(filter!(222), true);
+        assert.equal(filter!(333), false);
+        assert.equal(filter!('444'), false);
+    });
+
+    it('ignores empty strings inside lists', () => {
+        const filter = buildSenderFilter(['', '   ', '111'], []);
+        assert.ok(filter);
+        assert.equal(filter!('111'), true);
+        assert.equal(filter!('222'), false);
+    });
+
+    it('returns null if every entry in both lists is blank', () => {
+        assert.equal(buildSenderFilter(['', '   '], ['\t']), null);
+    });
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -49,6 +49,7 @@ import {
 import { resolvePeerUid } from './peerResolution.js';
 import { lookupUserByUin } from './userLookup.js';
 import { createSafeLogger, type SafeLogger } from './safeLogger.js';
+import { buildSenderFilter } from './senderFilter.js';
 import { buildResourceSummaryMessage } from '../utils/resourceSummary.js';
 
 // 导入类型定义
@@ -3790,14 +3791,10 @@ export class QQChatExporterApiServer {
             // 所有消息都保留，只是不下载图片等资源文件
             let filteredMessages = allMessages;
 
-            // 过滤指定用户的消息
-            if (filter?.excludeUserUins && filter.excludeUserUins.length > 0) {
-                const excludeSet = new Set(filter.excludeUserUins.map((uin: string) => String(uin)));
-                const beforeCount = filteredMessages.length;
-                filteredMessages = filteredMessages.filter(msg => {
-                    const senderUin = String(msg.senderUin || '');
-                    return !excludeSet.has(senderUin);
-                });
+            // 按 includeUserUins / excludeUserUins 过滤指定用户的消息
+            const senderFilter = buildSenderFilter(filter?.includeUserUins, filter?.excludeUserUins);
+            if (senderFilter) {
+                filteredMessages = filteredMessages.filter(msg => senderFilter(msg.senderUin));
             }
 
             // 所有格式都需要通过OneBot解析器处理
@@ -4301,6 +4298,7 @@ export class QQChatExporterApiServer {
         spoolRootDir: string,
         options: {
             excludeUserUins?: string[];
+            includeUserUins?: string[];
             resourceHandler?: ResourceHandler;
             processResources?: boolean;
             onBatchStart?: (info: { batchIndex: number; totalMessages: number }) => void;
@@ -4314,7 +4312,7 @@ export class QQChatExporterApiServer {
         fs.mkdirSync(spoolRootDir, { recursive: true });
 
         const batchFiles: string[] = [];
-        const excludeSet = new Set((options.excludeUserUins || []).map(uin => String(uin)));
+        const senderFilter = buildSenderFilter(options.includeUserUins, options.excludeUserUins);
         let batchCount = 0;
         let totalMessages = 0;
 
@@ -4323,8 +4321,8 @@ export class QQChatExporterApiServer {
             options.onBatchStart?.({ batchIndex: batchCount, totalMessages });
 
             let filteredBatch = batch;
-            if (excludeSet.size > 0) {
-                filteredBatch = filteredBatch.filter((msg: any) => !excludeSet.has(String(msg.senderUin || '')));
+            if (senderFilter) {
+                filteredBatch = filteredBatch.filter((msg: any) => senderFilter(msg.senderUin));
             }
 
             if (options.processResources && filteredBatch.length > 0 && options.resourceHandler) {
@@ -4543,6 +4541,7 @@ export class QQChatExporterApiServer {
                 path.join(tempDir!, 'message_batches'),
                 {
                     excludeUserUins: filter?.excludeUserUins,
+                    includeUserUins: filter?.includeUserUins,
                     resourceHandler: taskResourceHandler,
                     processResources: !options?.filterPureImageMessages,
                     onBatchStart: ({ batchIndex, totalMessages }) => {
@@ -4846,16 +4845,17 @@ export class QQChatExporterApiServer {
             // 开始第一个 chunk
             startNewChunk();
 
+            // include / exclude 同时生效的发件人过滤器
+            const jsonlSenderFilter = buildSenderFilter(filter?.includeUserUins, filter?.excludeUserUins);
+
             // 流式获取 -> 解析 -> 写入
             for await (const batch of messageGenerator) {
                 batchCount++;
                 const currentProgress = Math.min(batchCount * 3, 80);
-                
-                // 过滤指定用户
+
                 let filteredBatch = batch;
-                if (filter?.excludeUserUins && filter.excludeUserUins.length > 0) {
-                    const excludeSet = new Set(filter.excludeUserUins.map((uin: string) => String(uin)));
-                    filteredBatch = filteredBatch.filter((msg: any) => !excludeSet.has(String(msg.senderUin || '')));
+                if (jsonlSenderFilter) {
+                    filteredBatch = filteredBatch.filter((msg: any) => jsonlSenderFilter(msg.senderUin));
                 }
 
                 // 逐条解析并写入（不累积）

--- a/plugins/qq-chat-exporter/lib/api/senderFilter.ts
+++ b/plugins/qq-chat-exporter/lib/api/senderFilter.ts
@@ -1,0 +1,53 @@
+/**
+ * 发件人过滤器：根据 includeUserUins / excludeUserUins 决定一条消息的发送者
+ * UIN 是否应该被保留。
+ *
+ * 规则：
+ *   1. include 集合非空时，只保留 senderUin 在 include 集合里的消息；
+ *   2. exclude 集合非空时，丢弃 senderUin 在 exclude 集合里的消息（exclude 优先）；
+ *   3. include 与 exclude 同时为空（或都未提供）时返回 null，让调用方走零成本快路径。
+ *
+ * 抽出来后 #369 的「只导出指定 QQ」需求和原有「排除某些 QQ」可以共用同一份判断
+ * 逻辑，不会再出现一个入口能 include、另一个入口只能 exclude 的不一致情况。
+ */
+export type SenderFilter = (senderUin: string | number | null | undefined) => boolean;
+
+/**
+ * 把字符串数组规范成一个去掉首尾空白、去掉空串的字符串集合。
+ * 入参允许 undefined / null，返回的集合可能为空。
+ */
+function normalizeUinList(list: string[] | undefined | null): Set<string> {
+    if (!list || list.length === 0) return new Set();
+    const out = new Set<string>();
+    for (const item of list) {
+        if (item === undefined || item === null) continue;
+        const trimmed = String(item).trim();
+        if (!trimmed) continue;
+        out.add(trimmed);
+    }
+    return out;
+}
+
+/**
+ * 构造一个发件人过滤器。
+ *
+ * - 当 include 与 exclude 都为空时返回 `null`，调用方应跳过过滤步骤；
+ * - 否则返回一个 `(senderUin) => boolean` 函数，true 表示保留。
+ *
+ * senderUin 在不同代码路径里可能是 string / number / null / undefined，统一在这里转字符串比较。
+ */
+export function buildSenderFilter(
+    includeUserUins?: string[] | null,
+    excludeUserUins?: string[] | null
+): SenderFilter | null {
+    const include = normalizeUinList(includeUserUins);
+    const exclude = normalizeUinList(excludeUserUins);
+    if (include.size === 0 && exclude.size === 0) return null;
+
+    return (senderUin) => {
+        const uin = senderUin === undefined || senderUin === null ? '' : String(senderUin);
+        if (exclude.size > 0 && exclude.has(uin)) return false;
+        if (include.size > 0 && !include.has(uin)) return false;
+        return true;
+    };
+}

--- a/plugins/qq-chat-exporter/lib/types/index.ts
+++ b/plugins/qq-chat-exporter/lib/types/index.ts
@@ -68,6 +68,8 @@ export interface MessageFilter {
     senderUids?: string[];
     /** 排除的用户UIN列表（过滤掉这些用户的消息） */
     excludeUserUins?: string[];
+    /** 仅保留这些用户UIN的消息；为空表示不限制 */
+    includeUserUins?: string[];
     /** 消息类型筛选 */
     messageTypes?: Array<{
         type: NTMsgType;

--- a/qce-v4-tool/components/ui/task-wizard.tsx
+++ b/qce-v4-tool/components/ui/task-wizard.tsx
@@ -10,7 +10,7 @@ import { Badge } from "./badge"
 import { Separator } from "./separator"
 import { Avatar, AvatarImage, AvatarFallback } from "./avatar"
 import {
-  Users, User, Search, Loader2, ChevronDown, RefreshCw, Settings, Eye, FileText, CheckCircle, X, UserMinus, Check
+  Users, User, Search, Loader2, ChevronDown, RefreshCw, Settings, Eye, FileText, CheckCircle, X, UserMinus, UserPlus, Check
 } from "lucide-react"
 import { useSearch } from "@/hooks/use-search"
 import type { CreateTaskForm, Group, Friend, GroupMember } from "@/types/api"
@@ -59,8 +59,9 @@ export function TaskWizard({
   const [manualQQNumber, setManualQQNumber] = useState("")
   const [manualSessionName, setManualSessionName] = useState("")
   
-  // 群成员选择器状态
-  const [showMemberSelector, setShowMemberSelector] = useState(false)
+  // 群成员选择器状态：mode 表示当前选择器是给「排除」还是「仅导出」面板用的，
+  // null 表示未展开。Issue #369 把同一份选择器复用给两个目标字段。
+  const [memberSelectorMode, setMemberSelectorMode] = useState<'exclude' | 'include' | null>(null)
   const [groupMembers, setGroupMembers] = useState<GroupMember[]>([])
   const [membersLoading, setMembersLoading] = useState(false)
   const [selectedMemberUins, setSelectedMemberUins] = useState<Set<string>>(new Set())
@@ -75,6 +76,7 @@ export function TaskWizard({
     endTime: "",
     keywords: "",
     excludeUserUins: "",
+    includeUserUins: "",
     includeRecalled: false,
     includeSystemMessages: true,
     filterPureImageMessages: true, // JSON/TXT默认启用
@@ -115,6 +117,7 @@ export function TaskWizard({
         endTime: prefilledData.endTime || "",
         keywords: prefilledData.keywords || "",
         excludeUserUins: prefilledData.excludeUserUins || "",
+        includeUserUins: prefilledData.includeUserUins || "",
         includeRecalled: prefilledData.includeRecalled || false,
         includeSystemMessages:
           prefilledData.includeSystemMessages !== undefined ? prefilledData.includeSystemMessages : true,
@@ -196,6 +199,7 @@ export function TaskWizard({
         endTime: "",
         keywords: "",
         excludeUserUins: "",
+        includeUserUins: "",
         includeRecalled: false,
         includeSystemMessages: true,
         filterPureImageMessages: true, // JSON默认启用
@@ -244,19 +248,23 @@ export function TaskWizard({
     }
   }, [])
 
-  // 切换群成员选择器展开/收起
-  const handleOpenMemberSelector = useCallback(() => {
-    if (selectedTarget && "groupCode" in selectedTarget) {
-      if (!showMemberSelector) {
-        // 展开时：从当前 excludeUserUins 恢复已选中的成员
-        const currentUins = form.excludeUserUins?.split(',').map(s => s.trim()).filter(Boolean) || []
-        setSelectedMemberUins(new Set(currentUins))
-        setMemberSearchTerm("")
-        fetchGroupMembers(selectedTarget.groupCode)
-      }
-      setShowMemberSelector(!showMemberSelector)
+  // 切换群成员选择器展开/收起。mode 决定面板服务于哪一个字段。
+  // 同一时间只展开一个面板：再点同一按钮收起，点另一按钮则切换面板内容。
+  const handleOpenMemberSelector = useCallback((mode: 'exclude' | 'include') => {
+    if (!(selectedTarget && "groupCode" in selectedTarget)) return
+    if (memberSelectorMode === mode) {
+      setMemberSelectorMode(null)
+      return
     }
-  }, [selectedTarget, form.excludeUserUins, fetchGroupMembers, showMemberSelector])
+    const currentRaw = mode === 'include' ? form.includeUserUins : form.excludeUserUins
+    const currentUins = currentRaw?.split(',').map(s => s.trim()).filter(Boolean) || []
+    setSelectedMemberUins(new Set(currentUins))
+    setMemberSearchTerm("")
+    if (groupMembers.length === 0) {
+      fetchGroupMembers(selectedTarget.groupCode)
+    }
+    setMemberSelectorMode(mode)
+  }, [selectedTarget, form.includeUserUins, form.excludeUserUins, fetchGroupMembers, memberSelectorMode, groupMembers.length])
 
   // 切换成员选中状态
   const toggleMemberSelection = useCallback((uin: string) => {
@@ -271,12 +279,14 @@ export function TaskWizard({
     })
   }, [])
 
-  // 确认选择的成员
+  // 确认选择的成员，根据当前面板写入 include 或 exclude 字段
   const confirmMemberSelection = useCallback(() => {
     const uins = Array.from(selectedMemberUins).join(',')
-    setForm(p => ({ ...p, excludeUserUins: uins }))
-    setShowMemberSelector(false)
-  }, [selectedMemberUins])
+    setForm(p => memberSelectorMode === 'include'
+      ? { ...p, includeUserUins: uins }
+      : { ...p, excludeUserUins: uins })
+    setMemberSelectorMode(null)
+  }, [selectedMemberUins, memberSelectorMode])
 
   // 过滤群成员
   const filteredMembers = groupMembers.filter(member => {
@@ -288,6 +298,97 @@ export function TaskWizard({
       (member.uin && member.uin.includes(term))
     )
   })
+
+  // 渲染折叠式群成员选择器面板。include 与 exclude 共用同一份 UI，由 mode 控制可见性，
+  // 只有 mode 与外层匹配时才展开，确认按钮的写入逻辑见 confirmMemberSelection。
+  const renderMemberSelectorPanel = (mode: 'exclude' | 'include') => (
+    <div className={`overflow-hidden transition-all duration-300 ease-in-out ${memberSelectorMode === mode ? "max-h-[350px] opacity-100" : "max-h-0 opacity-0"}`}>
+      <div className="border border-black/[0.06] dark:border-white/[0.06] rounded-xl p-3 space-y-2 bg-muted/50">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground/60" />
+          <Input
+            placeholder="搜索昵称、群名片或QQ号..."
+            value={memberSearchTerm}
+            onChange={(e) => setMemberSearchTerm(e.target.value)}
+            className="pl-9 h-8 text-sm rounded-full bg-card"
+          />
+        </div>
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span>已选择 {selectedMemberUins.size} 个成员</span>
+          {selectedMemberUins.size > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setSelectedMemberUins(new Set())}
+              className="h-5 px-2 text-xs text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300"
+            >
+              清空
+            </Button>
+          )}
+        </div>
+        <div className="max-h-[180px] overflow-y-auto border border-black/[0.06] dark:border-white/[0.06] rounded-lg bg-card">
+          {membersLoading ? (
+            <div className="flex items-center justify-center h-20">
+              <Loader2 className="w-5 h-5 animate-spin text-muted-foreground/60" />
+            </div>
+          ) : filteredMembers.length === 0 ? (
+            <div className="flex items-center justify-center h-20 text-muted-foreground text-xs">
+              {memberSearchTerm ? "没有找到匹配的成员" : "暂无群成员数据"}
+            </div>
+          ) : (
+            <div className="divide-y divide-black/[0.06] dark:divide-white/[0.06]">
+              {filteredMembers.slice(0, 50).map((member) => {
+                const uin = member.uin || member.uid
+                const isSelected = selectedMemberUins.has(uin)
+                const displayName = member.cardName || member.nick
+                const roleNum = typeof member.role === 'number' ? member.role : 0
+                const isOwner = roleNum === 4 || member.role === 'owner'
+                const isAdmin = roleNum === 3 || member.role === 'admin'
+                return (
+                  <div
+                    key={uin}
+                    onClick={() => toggleMemberSelection(uin)}
+                    className={`flex items-center gap-2 p-2 cursor-pointer hover:bg-muted transition-colors ${
+                      isSelected ? "bg-blue-50 dark:bg-blue-950/50" : ""
+                    }`}
+                  >
+                    <Checkbox checked={isSelected} className="w-4 h-4" />
+                    <Avatar className="w-6 h-6 rounded-full">
+                      <AvatarImage src={member.avatarUrl || `https://q1.qlogo.cn/g?b=qq&nk=${uin}&s=100`} />
+                      <AvatarFallback className="text-xs">{displayName[0]}</AvatarFallback>
+                    </Avatar>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-xs font-medium truncate flex items-center gap-1">
+                        {displayName}
+                        {isOwner && <Badge variant="secondary" className="text-[10px] px-1 py-0">群主</Badge>}
+                        {isAdmin && <Badge variant="secondary" className="text-[10px] px-1 py-0">管理</Badge>}
+                      </p>
+                      <p className="text-[10px] text-muted-foreground/60 truncate">
+                        {uin}
+                      </p>
+                    </div>
+                    {isSelected && <Check className="w-3 h-3 text-blue-600 flex-shrink-0" />}
+                  </div>
+                )
+              })}
+              {filteredMembers.length > 50 && (
+                <div className="p-2 text-center text-xs text-muted-foreground/60">
+                  仅显示前50个结果，请使用搜索缩小范围
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+        <Button
+          onClick={confirmMemberSelection}
+          size="sm"
+          className={`w-full h-7 text-xs rounded-full ${mode === 'include' ? 'bg-emerald-600 hover:bg-emerald-700' : 'bg-blue-600 hover:bg-blue-700'}`}
+        >
+          确认选择 ({selectedMemberUins.size})
+        </Button>
+      </div>
+    </div>
+  )
 
   const handleSearchInput = useCallback((value: string) => {
     setSearchTerm(value)
@@ -836,112 +937,18 @@ export function TaskWizard({
                 type="button"
                 variant="ghost"
                 size="sm"
-                onClick={handleOpenMemberSelector}
+                onClick={() => handleOpenMemberSelector('exclude')}
                 className="text-xs h-7 text-blue-600 hover:text-blue-700"
               >
                 <UserMinus className="w-3 h-3 mr-1" />
-                {showMemberSelector ? "收起" : "从群成员选择"}
-                <ChevronDown className={`w-3 h-3 ml-1 transition-transform duration-200 ${showMemberSelector ? "rotate-180" : ""}`} />
+                {memberSelectorMode === 'exclude' ? "收起" : "从群成员选择"}
+                <ChevronDown className={`w-3 h-3 ml-1 transition-transform duration-200 ${memberSelectorMode === 'exclude' ? "rotate-180" : ""}`} />
               </Button>
             )}
           </div>
           
-          {/* 折叠式群成员选择器 */}
-          <div className={`overflow-hidden transition-all duration-300 ease-in-out ${showMemberSelector ? "max-h-[350px] opacity-100" : "max-h-0 opacity-0"}`}>
-            <div className="border border-black/[0.06] dark:border-white/[0.06] rounded-xl p-3 space-y-2 bg-muted/50">
-              {/* 搜索框 */}
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground/60" />
-                <Input
-                  placeholder="搜索昵称、群名片或QQ号..."
-                  value={memberSearchTerm}
-                  onChange={(e) => setMemberSearchTerm(e.target.value)}
-                  className="pl-9 h-8 text-sm rounded-full bg-card"
-                />
-              </div>
-              
-              {/* 已选数量 */}
-              <div className="flex items-center justify-between text-xs text-muted-foreground">
-                <span>已选择 {selectedMemberUins.size} 个成员</span>
-                {selectedMemberUins.size > 0 && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setSelectedMemberUins(new Set())}
-                    className="h-5 px-2 text-xs text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300"
-                  >
-                    清空
-                  </Button>
-                )}
-              </div>
-              
-              {/* 成员列表 */}
-              <div className="max-h-[180px] overflow-y-auto border border-black/[0.06] dark:border-white/[0.06] rounded-lg bg-card">
-                {membersLoading ? (
-                  <div className="flex items-center justify-center h-20">
-                    <Loader2 className="w-5 h-5 animate-spin text-muted-foreground/60" />
-                  </div>
-                ) : filteredMembers.length === 0 ? (
-                  <div className="flex items-center justify-center h-20 text-muted-foreground text-xs">
-                    {memberSearchTerm ? "没有找到匹配的成员" : "暂无群成员数据"}
-                  </div>
-                ) : (
-                  <div className="divide-y divide-black/[0.06] dark:divide-white/[0.06]">
-                    {filteredMembers.slice(0, 50).map((member) => {
-                      const uin = member.uin || member.uid
-                      const isSelected = selectedMemberUins.has(uin)
-                      const displayName = member.cardName || member.nick
-                      // 处理 role: 4=owner, 3=admin, 其他=member
-                      const roleNum = typeof member.role === 'number' ? member.role : 0
-                      const isOwner = roleNum === 4 || member.role === 'owner'
-                      const isAdmin = roleNum === 3 || member.role === 'admin'
-                      return (
-                        <div
-                          key={uin}
-                          onClick={() => toggleMemberSelection(uin)}
-                          className={`flex items-center gap-2 p-2 cursor-pointer hover:bg-muted transition-colors ${
-                            isSelected ? "bg-blue-50 dark:bg-blue-950/50" : ""
-                          }`}
-                        >
-                          <Checkbox checked={isSelected} className="w-4 h-4" />
-                          <Avatar className="w-6 h-6 rounded-full">
-                            <AvatarImage src={member.avatarUrl || `https://q1.qlogo.cn/g?b=qq&nk=${uin}&s=100`} />
-                            <AvatarFallback className="text-xs">{displayName[0]}</AvatarFallback>
-                          </Avatar>
-                          <div className="flex-1 min-w-0">
-                            <p className="text-xs font-medium truncate flex items-center gap-1">
-                              {displayName}
-                              {isOwner && <Badge variant="secondary" className="text-[10px] px-1 py-0">群主</Badge>}
-                              {isAdmin && <Badge variant="secondary" className="text-[10px] px-1 py-0">管理</Badge>}
-                            </p>
-                            <p className="text-[10px] text-muted-foreground/60 truncate">
-                              {uin}
-                            </p>
-                          </div>
-                          {isSelected && <Check className="w-3 h-3 text-blue-600 flex-shrink-0" />}
-                        </div>
-                      )
-                    })}
-                    {filteredMembers.length > 50 && (
-                      <div className="p-2 text-center text-xs text-muted-foreground/60">
-                        仅显示前50个结果，请使用搜索缩小范围
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-              
-              {/* 确认按钮 */}
-              <Button 
-                onClick={confirmMemberSelection} 
-                size="sm"
-                className="w-full h-7 text-xs rounded-full bg-blue-600 hover:bg-blue-700"
-              >
-                确认选择 ({selectedMemberUins.size})
-              </Button>
-            </div>
-          </div>
-          
+          {renderMemberSelectorPanel('exclude')}
+
           <Textarea
             id="excludeUserUins"
             placeholder="用逗号分隔多个QQ号，如：123456789,987654321&#10;这些用户的消息将被过滤掉（适合过滤机器人）"
@@ -953,6 +960,42 @@ export function TaskWizard({
           {form.excludeUserUins && (
             <p className="text-xs text-muted-foreground">
               已选择 {form.excludeUserUins.split(',').filter(s => s.trim()).length} 个用户
+            </p>
+          )}
+        </div>
+
+        {/* Issue #369：仅导出指定 QQ 号的消息（与排除互不冲突；同一 QQ 同时出现时，排除优先生效） */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="includeUserUins">仅导出这些用户的消息（可选）</Label>
+            {selectedTarget && "groupCode" in selectedTarget && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => handleOpenMemberSelector('include')}
+                className="text-xs h-7 text-emerald-600 hover:text-emerald-700"
+              >
+                <UserPlus className="w-3 h-3 mr-1" />
+                {memberSelectorMode === 'include' ? "收起" : "从群成员选择"}
+                <ChevronDown className={`w-3 h-3 ml-1 transition-transform duration-200 ${memberSelectorMode === 'include' ? "rotate-180" : ""}`} />
+              </Button>
+            )}
+          </div>
+
+          {renderMemberSelectorPanel('include')}
+
+          <Textarea
+            id="includeUserUins"
+            placeholder="用逗号分隔多个QQ号，如：123456789,987654321&#10;留空表示不限制；填写后只会导出这些用户的消息"
+            value={form.includeUserUins || ""}
+            onChange={(e) => setForm((p) => ({ ...p, includeUserUins: e.target.value }))}
+            rows={2}
+            className="rounded-2xl"
+          />
+          {form.includeUserUins && (
+            <p className="text-xs text-muted-foreground">
+              已选择 {form.includeUserUins.split(',').filter(s => s.trim()).length} 个用户
             </p>
           )}
         </div>

--- a/qce-v4-tool/hooks/use-export-tasks.ts
+++ b/qce-v4-tool/hooks/use-export-tasks.ts
@@ -434,6 +434,10 @@ export function useExportTasks(_props?: UseExportTasksProps) {
           ...(form.excludeUserUins && {
             excludeUserUins: form.excludeUserUins.split(",").map((uin) => uin.trim()).filter(Boolean),
           }),
+          // Issue #369：仅导出指定 QQ 的消息。
+          ...(form.includeUserUins && {
+            includeUserUins: form.includeUserUins.split(",").map((uin) => uin.trim()).filter(Boolean),
+          }),
           includeRecalled: form.includeRecalled,
         },
         options: {

--- a/qce-v4-tool/types/api.ts
+++ b/qce-v4-tool/types/api.ts
@@ -213,6 +213,8 @@ export interface CreateTaskForm {
   filterPureImageMessages: boolean
   exportAsZip?: boolean
   excludeUserUins?: string
+  /** Issue #369：仅导出这些 QQ 的消息（逗号分隔），与 excludeUserUins 互不冲突。 */
+  includeUserUins?: string
   embedAvatarsAsBase64?: boolean
   /**
    * Issue #311: HTML 格式专用 — 资源以 base64 内联生成单个自包含 HTML。


### PR DESCRIPTION
下载导出时之前只能「排除某些 QQ 号」，没法反过来「只保留指定 QQ 号」。这个 PR 在原有 `excludeUserUins` 旁边补上 `includeUserUins`，两个字段同时生效，互不冲突，同一 QQ 同时出现在两边时排除优先。

后端：
- `MessageFilter` 新增 `includeUserUins?: string[]`
- 抽出 `lib/api/senderFilter.ts` 的 `buildSenderFilter`，把 include / exclude 的判定逻辑收到一处；`ApiServer` 三处过滤入口（导出主流程、JSONL 流式分块、按时间冷写盘）全部改用同一份 helper
- 新增 `senderFilter.test.ts` 覆盖 include 单生效 / exclude 单生效 / include + exclude 同时设置 / 数字 UIN / 空白 UIN 等场景，老的 122 条单测仍全部通过

前端：
- `CreateTaskForm` 新增 `includeUserUins`，提交时按逗号分隔解析后写入 filter
- 任务向导原本只有「排除用户」面板，现在拆成两块独立的输入区：上面是「排除用户」，下面新增「仅导出这些用户的消息」
- 群成员选择器抽成 `renderMemberSelectorPanel(mode)`，两边各一个折叠面板，`memberSelectorMode` 控制同一时间只展开一个
- 包含用户的配色用 emerald 与排除做视觉区分，文案说明「留空表示不限制」

Resolves #369

Notes:
没有动数据库 schema 与持久化字段；旧任务记录里如果没有 includeUserUins 字段，重跑时按未限制处理。