### PR TITLE
fix(wizard): refresh group members each time the selector opens

### DIFF
--- a/qce-v4-tool/components/ui/task-wizard.tsx
+++ b/qce-v4-tool/components/ui/task-wizard.tsx
@@ -218,6 +218,10 @@ export function TaskWizard({
   const handleSelectTarget = (target: Group | Friend) => {
     setSelectedTarget(target)
     setShowTargetSelector(false)
+    // 切换会话目标时把上一群的成员缓存清掉，下一次打开成员选择器再拉新数据。
+    setGroupMembers([])
+    setSelectedMemberUins(new Set())
+    setMemberSelectorMode(null)
     if ("groupCode" in target) {
       setForm((p) => ({ ...p, chatType: 2, peerUid: target.groupCode, sessionName: target.groupName }))
     } else {
@@ -260,11 +264,10 @@ export function TaskWizard({
     const currentUins = currentRaw?.split(',').map(s => s.trim()).filter(Boolean) || []
     setSelectedMemberUins(new Set(currentUins))
     setMemberSearchTerm("")
-    if (groupMembers.length === 0) {
-      fetchGroupMembers(selectedTarget.groupCode)
-    }
+    // 每次打开都按当前选中的群拉一次成员，避免在向导里换群以后还在用上一群的列表（Codex 在 #412 复盘时指出）。
+    fetchGroupMembers(selectedTarget.groupCode)
     setMemberSelectorMode(mode)
-  }, [selectedTarget, form.includeUserUins, form.excludeUserUins, fetchGroupMembers, memberSelectorMode, groupMembers.length])
+  }, [selectedTarget, form.includeUserUins, form.excludeUserUins, fetchGroupMembers, memberSelectorMode])
 
   // 切换成员选中状态
   const toggleMemberSelection = useCallback((uin: string) => {


### PR DESCRIPTION
承接 #412 / #369。Codex 在那个 PR 的 review 里指出：群成员选择器只在 `groupMembers.length === 0` 时才拉新一次，结果是先在向导里给 A 群配过排除/包含，再换到 B 群、不关向导直接打开成员面板，会看到 A 群的旧成员列表，勾选后写入 B 群任务的过滤字段，导致筛错号。

这个 PR 做两件事：

- `handleSelectTarget` 切换会话目标时主动清掉 `groupMembers` / `selectedMemberUins`，并把成员面板收起来；下一次再打开时不会再看到上一会话的残留。
- `handleOpenMemberSelector` 去掉 `if (length === 0)` 的判断，每次打开都按当前选中的群再请求一次成员列表，避免这种跨群复用的状态。

后端没动，单测没改。本地 `pnpm build` 通过。