### PR TITLE
feat(parser): expose merged-forward inner messages in JSON / TXT / HTML exports (#161)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/SimpleMessageParser.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/SimpleMessageParser.test.ts
@@ -336,6 +336,99 @@ test('forward element preserves resId and surfaces records via map', async () =>
     assert.equal(fw.data.resId, 'fw_001');
 });
 
+test('forward element exposes inner messages from inline records (#161)', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const inner = [
+        msg().sender({ uid: 'u_alice', uin: '11111', nick: 'Alice' }).text('inner1').at_time(T + 0).build(),
+        msg().sender({ uid: 'u_bob', uin: '22222', nick: 'Bob' }).text('inner2').at_time(T + 60).build()
+    ];
+    const m = msg().forward({ resId: 'fw_001', records: inner }).at_time(T + 120).build();
+    const [parsed] = await parser.parseMessages([m]);
+    const fw = parsed.content.elements[0];
+    assert.equal(fw.type, 'forward');
+    assert.equal(fw.data.messageCount, 2);
+    assert.equal(fw.data.messages.length, 2);
+    assert.equal(fw.data.messages[0].sender.name, 'Alice');
+    assert.equal(fw.data.messages[0].content.text, 'inner1');
+    assert.equal(fw.data.messages[1].sender.name, 'Bob');
+    assert.equal(fw.data.messages[1].content.text, 'inner2');
+    // 普通文本应该被解析成扁平 elements，方便 JSON 导出。
+    assert.equal(fw.data.messages[0].content.elements[0].type, 'text');
+    assert.equal(fw.data.messages[0].content.elements[0].data.text, 'inner1');
+});
+
+test('forward inline-records fallback feeds bridge MsgApi.getMultiMsg (#161)', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+
+    // 注意：用 forward({ resId, records: ... }) 时 builder 会把 records 顺手挂到外层
+    // 消息上，走的是 inline 分支。这里要验证 bridge 兜底，必须自己造一条只有
+    // multiForwardMsgElement 但没有 records 的消息，再让 MockNapCatCore 持有真正的
+    // records，让 MsgApi.getMultiMsg 通过 resId 找回它们。
+    const inner = [
+        msg().sender({ uid: 'u_carol', uin: '33333', nick: 'Carol' }).text('远程inner').at_time(T + 5).build()
+    ];
+    // 先造一条带 forward 元素 + records 的消息让 mock core 把 records 挂到 fw_002 上
+    const seed = msg().forward({ resId: 'fw_002', records: inner }).at_time(T + 10).build();
+    // 把 seed 注入 mock core 的对话池，以便 getMultiMsg 能查到
+    uninstallBridge();
+    const { createMockCore } = await import('../helpers/MockNapCatCore.js');
+    const mockCore = createMockCore({
+        conversations: [
+            {
+                peer: { chatType: 2, peerUid: 'group://7' },
+                messages: [seed]
+            }
+        ]
+    });
+    installBridge({ core: mockCore });
+
+    // 这条消息只有外壳元素，没有 records，必须走 bridge 兜底。
+    const outer = msg({ chatType: 2, peerUid: 'group://7' })
+        .forward({ resId: 'fw_002' })
+        .at_time(T + 120)
+        .build();
+    const [parsed] = await parser.parseMessages([outer]);
+    const fw = parsed.content.elements[0];
+    assert.equal(fw.type, 'forward');
+    assert.equal(fw.data.messageCount, 1);
+    assert.equal(fw.data.messages[0].sender.name, 'Carol');
+    assert.equal(fw.data.messages[0].content.text, '远程inner');
+});
+
+test('forward element falls back gracefully when bridge cannot resolve content (#161)', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    // resId 不存在于 mock core，bridge 找不到 → messages 为空，但不应抛错。
+    const m = msg({ chatType: 2, peerUid: 'group://9' })
+        .forward({ resId: 'fw_unknown', xmlContent: '<msg>没有内容</msg>' })
+        .at_time(T)
+        .build();
+    const [parsed] = await parser.parseMessages([m]);
+    const fw = parsed.content.elements[0];
+    assert.equal(fw.type, 'forward');
+    assert.equal(fw.data.summary, '<msg>没有内容</msg>');
+    assert.equal(fw.data.messageCount, 0);
+    assert.deepEqual(fw.data.messages, []);
+    // 文本仍然有 [转发消息] 占位，不会丢空。
+    assert.match(parsed.content.text, /\[转发消息\]/);
+});
+
+test('forward element renders preview lines in content.text (#161)', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const inner = [
+        msg().sender({ uid: 'u_a', uin: '1', nick: 'A' }).text('一句话').at_time(T).build(),
+        msg().sender({ uid: 'u_b', uin: '2', nick: 'B' }).text('另一句').at_time(T + 1).build()
+    ];
+    const m = msg().forward({ resId: 'fw_preview', records: inner }).at_time(T + 5).build();
+    const [parsed] = await parser.parseMessages([m]);
+    assert.match(parsed.content.text, /\[转发消息: 2条\]/);
+    assert.match(parsed.content.text, /A: 一句话/);
+    assert.match(parsed.content.text, /B: 另一句/);
+});
+
 test('senderTitleResolver populates sender.title in group chats (#331)', async () => {
     const { SimpleMessageParser } = await loadParser();
     const titleMap = new Map<string, string>([

--- a/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
@@ -1661,9 +1661,23 @@ export class ModernHtmlExporter {
         const title = data?.title || '聊天记录';
         const summary = data?.summary || data?.content || '查看转发消息';
         const preview = data?.preview || [];
+        // issue #161：解析器现在会把合并转发卡片里的真实子消息塞进 data.messages，
+        // 优先用它渲染完整列表，老数据 / fallback 再退回 preview / summary。
+        const innerMessages: Array<{
+            sender?: { name?: string; uin?: string };
+            content?: { text?: string };
+        }> = Array.isArray(data?.messages) ? data.messages : [];
+        const messageCount: number = typeof data?.messageCount === 'number' ? data.messageCount : innerMessages.length;
 
         let previewHtml = '';
-        if (Array.isArray(preview) && preview.length > 0) {
+        if (innerMessages.length > 0) {
+            previewHtml = innerMessages.slice(0, 5).map((m) => {
+                const name = this.escapeHtml(m?.sender?.name || (m?.sender?.uin ? String(m.sender.uin) : '未知'));
+                const text = (m?.content?.text || '').replace(/\s+/g, ' ').trim();
+                const trimmed = text.length > 60 ? text.slice(0, 60) + '…' : text;
+                return `<div class="forward-card-line"><span class="forward-card-sender">${name}:</span> <span class="forward-card-body">${this.escapeHtml(trimmed)}</span></div>`;
+            }).join('');
+        } else if (Array.isArray(preview) && preview.length > 0) {
             previewHtml = preview.slice(0, 3).map((line: any) => {
                 const text = typeof line === 'string' ? line : (line?.text || '');
                 return this.escapeHtml(text);
@@ -1673,6 +1687,8 @@ export class ModernHtmlExporter {
             const lines = summary.split('\n').slice(0, 3);
             previewHtml = lines.map(l => this.escapeHtml(l)).join('<br>');
         }
+
+        const footerLabel = messageCount > 0 ? `转发消息 · ${messageCount}条` : '转发消息';
 
         return `<div class="forward-card">
             <div class="forward-card-header">
@@ -1684,7 +1700,7 @@ export class ModernHtmlExporter {
             <div class="forward-card-content">
                 ${previewHtml || '点击查看转发的聊天记录'}
             </div>
-            <div class="forward-card-footer">转发消息</div>
+            <div class="forward-card-footer">${this.escapeHtml(footerLabel)}</div>
         </div>`;
     }
 
@@ -1763,9 +1779,20 @@ export class ModernHtmlExporter {
                 case 'json':
                     parts.push(`${d?.title || d?.summary || 'JSON'} ${d?.description || ''} ${d?.url || ''}`.trim());
                     break;
-                case 'forward':
+                case 'forward': {
+                    // issue #161：搜索时把合并转发卡片里的子消息内容也带上，否则
+                    // 只能搜到外壳标题，搜不到真实文本。
                     parts.push(`${d?.title || '转发'} ${d?.summary || d?.content || ''}`.trim());
+                    if (Array.isArray(d?.messages)) {
+                        for (const m of d.messages) {
+                            const name = m?.sender?.name || (m?.sender?.uin ? String(m.sender.uin) : '');
+                            const text = m?.content?.text || '';
+                            if (name) parts.push(String(name));
+                            if (text) parts.push(String(text));
+                        }
+                    }
                     break;
+                }
                 case 'location':
                     parts.push(`${d?.name || '位置'} ${d?.address || ''}`.trim());
                     break;

--- a/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
@@ -197,6 +197,28 @@ export interface MessageElementData {
   data: any;
 }
 
+/**
+ * 合并转发卡片里嵌套的子消息。
+ * 字段刻意保持扁平，方便直接序列化到 JSON / JSONL，也方便 TXT 导出按行渲染。
+ */
+export interface ForwardInnerMessage {
+  /** 子消息的 msgId，缺失时为空字符串 */
+  id: string;
+  /** 子消息时间戳（ms），无法解析时为 0 */
+  timestamp: number;
+  /** ISO 时间，缺失时退到 UNIX 0 */
+  time: string;
+  sender: {
+    uid?: string;
+    uin?: string;
+    name: string;
+  };
+  content: {
+    text: string;
+    elements: MessageElementData[];
+  };
+}
+
 export interface ResourceData {
   type: string;
   filename: string;
@@ -253,6 +275,9 @@ const DEFAULT_SIMPLE_OPTIONS: Required<Omit<SimpleParserOptions, 'onProgress' | 
 /* ---------------------------------- 主类 ---------------------------------- */
 
 export class SimpleMessageParser {
+  /** 嵌套合并转发递归深度上限。三层基本足够，再深就不展开避免栈/性能爆炸。 */
+  private static readonly MAX_FORWARD_DEPTH = 3;
+
   private readonly options: Required<Omit<SimpleParserOptions, 'onProgress' | 'senderTitleResolver'>> & {
     senderTitleResolver?: SenderTitleResolver;
   };
@@ -522,7 +547,7 @@ export class SimpleMessageParser {
   /**
    * 单趟解析消息内容
    */
-  private async parseMessageContent(message: RawMessage): Promise<MessageContent> {
+  private async parseMessageContent(message: RawMessage, forwardDepth: number = 0): Promise<MessageContent> {
     const elements = message.elements || [];
     const parsedElements: MessageElementData[] = new Array(elements.length);
     const resources: ResourceData[] = [];
@@ -535,7 +560,7 @@ export class SimpleMessageParser {
     let count = 0;
     for (let i = 0; i < elements.length; i++) {
       const element = elements[i]!;
-      const parsed = await this.parseElement(element, message);
+      const parsed = await this.parseElement(element, message, forwardDepth);
       if (!parsed) continue;
       parsedElements[count++] = parsed;
 
@@ -572,8 +597,15 @@ export class SimpleMessageParser {
 
   /**
    * 元素解析（尽量同步，无额外中间对象）
+   *
+   * forwardDepth 用于跟踪当前消息已经嵌套在多少层合并转发里，超过 MAX_FORWARD_DEPTH
+   * 后再遇到 multiForwardMsgElement 时只保留外壳信息，不再递归拉取内层消息。
    */
-  private async parseElement(element: MessageElement, message: RawMessage): Promise<MessageElementData | null> {
+  private async parseElement(
+    element: MessageElement,
+    message: RawMessage,
+    forwardDepth: number = 0
+  ): Promise<MessageElementData | null> {
     // 文本 / @ 提及
     if (element.textElement) {
       const te = element.textElement;
@@ -708,12 +740,24 @@ export class SimpleMessageParser {
 
     // 转发
     if (element.multiForwardMsgElement) {
+      const resId = element.multiForwardMsgElement.resId || '';
+      const xmlContent = element.multiForwardMsgElement.xmlContent || '';
+
+      // 拉合并转发卡片里的真实消息列表，导出 JSON / TXT 时把内容也带上（issue #161）。
+      // 失败时降级为只保留 XML summary，绝不阻断主导出；嵌套过深也直接停在外壳。
+      const innerMessages =
+        forwardDepth >= SimpleMessageParser.MAX_FORWARD_DEPTH
+          ? []
+          : await this.fetchForwardInnerMessages(message, resId, forwardDepth + 1);
+
       return {
         type: 'forward',
         data: {
           title: '转发消息',
-          resId: element.multiForwardMsgElement.resId || '',
-          summary: element.multiForwardMsgElement.xmlContent || ''
+          resId,
+          summary: xmlContent,
+          messageCount: innerMessages.length,
+          messages: innerMessages
         }
       };
     }
@@ -974,8 +1018,38 @@ export class SimpleMessageParser {
         return { text: t, html: htmlEnabled ? `<div class="reply">${t}</div>` : '' };
       }
       case 'forward': {
-        const t = `[转发消息]`;
-        return { text: t, html: htmlEnabled ? `<div class="forward">${t}</div>` : '' };
+        const inner: ForwardInnerMessage[] = Array.isArray(element.data?.messages) ? element.data.messages : [];
+        const count = element.data?.messageCount ?? inner.length;
+
+        // 预览前几条作者+文本，方便扫一眼能看到合并转发里到底是什么内容。
+        const previewLines = inner.slice(0, 3).map((m) => {
+          const name = m?.sender?.name || (m?.sender?.uin ? String(m.sender.uin) : '');
+          const body = (m?.content?.text || '').replace(/\s+/g, ' ').trim();
+          const trimmedBody = body.length > 40 ? body.slice(0, 40) + '…' : body;
+          if (name && trimmedBody) return `${name}: ${trimmedBody}`;
+          if (name) return name;
+          return trimmedBody;
+        }).filter(Boolean);
+
+        const header = count > 0 ? `[转发消息: ${count}条]` : `[转发消息]`;
+        const text = previewLines.length > 0 ? `${header}\n${previewLines.map((l) => `  ${l}`).join('\n')}` : header;
+
+        if (!htmlEnabled) {
+          return { text, html: '' };
+        }
+
+        let innerHtml = '';
+        if (inner.length > 0) {
+          innerHtml = `<ul class="forward-inner">${inner.map((m) => {
+            const name = escapeHtmlFast(m?.sender?.name || (m?.sender?.uin ? String(m.sender.uin) : '未知'));
+            const body = escapeHtmlFast((m?.content?.text || '').replace(/\s+/g, ' ').trim());
+            return `<li><span class="forward-inner-sender">${name}</span><span class="forward-inner-text">${body}</span></li>`;
+          }).join('')}</ul>`;
+        }
+        return {
+          text,
+          html: `<div class="forward">${escapeHtmlFast(header)}${innerHtml}</div>`
+        };
       }
       case 'location': {
         const t = `[位置消息]`;
@@ -1051,6 +1125,98 @@ export class SimpleMessageParser {
       return Number.isFinite(n) ? n : 0;
     }
     return 0;
+  }
+
+  /**
+   * 拉合并转发卡片里的子消息列表，并把每条子消息扁平化成 ForwardInnerMessage（issue #161）。
+   *
+   * 数据来源优先级：
+   *   1) message.records（NapCat 推消息时偶尔会顺手填上）
+   *   2) bridge 的 NapCatCore.apis.MsgApi.getMultiMsg(...)
+   *
+   * 任何一步抛错都吞掉返回空数组，外层在 summary / xmlContent 上还是有兜底信息。
+   */
+  private async fetchForwardInnerMessages(
+    message: RawMessage,
+    resId: string,
+    depth: number
+  ): Promise<ForwardInnerMessage[]> {
+    if (depth > SimpleMessageParser.MAX_FORWARD_DEPTH) return [];
+
+    let raws: RawMessage[] = [];
+    const inlineRecords = (message as any).records;
+    if (Array.isArray(inlineRecords) && inlineRecords.length > 0) {
+      raws = inlineRecords;
+    }
+
+    if (raws.length === 0) {
+      try {
+        const bridge = (globalThis as any).__NAPCAT_BRIDGE__;
+        const core = bridge?.core;
+        const msgApi = core?.apis?.MsgApi || core?.apis?.msg;
+        if (msgApi && typeof msgApi.getMultiMsg === 'function') {
+          const peer = {
+            chatType: message.chatType,
+            peerUid: message.peerUid,
+            guildId: ''
+          };
+          const result = await msgApi.getMultiMsg({
+            peer,
+            rootMsgId: message.msgId,
+            parentMsgId: message.msgId,
+            forwardId: resId,
+            resId
+          });
+          if (result && Array.isArray(result.msgList)) {
+            raws = result.msgList;
+          }
+        }
+      } catch {
+        // 拉取失败时只能丢掉子消息，外层卡片仍然会给出 [转发消息: N条] 占位。
+      }
+    }
+
+    if (raws.length === 0) return [];
+
+    const out: ForwardInnerMessage[] = [];
+    for (const raw of raws) {
+      if (!raw) continue;
+      try {
+        const tsMs = millisFromUnixSeconds(raw.msgTime as any);
+        this.cacheSenderInfo(raw);
+        const senderInfo = this.getSenderDisplayInfo(raw);
+
+        const elementsArr: MessageElementData[] = [];
+        const textParts: string[] = [];
+
+        const els = raw.elements || [];
+        for (const el of els) {
+          const parsed = await this.parseElement(el, raw, depth);
+          if (!parsed) continue;
+          elementsArr.push(parsed);
+          const rendered = this.elementToText(parsed, false);
+          if (rendered.text) textParts.push(rendered.text);
+        }
+
+        out.push({
+          id: raw.msgId || '',
+          timestamp: tsMs,
+          time: rfc3339FromMillis(tsMs),
+          sender: {
+            uid: raw.senderUid || undefined,
+            uin: raw.senderUin || undefined,
+            name: senderInfo.name
+          },
+          content: {
+            text: textParts.join(''),
+            elements: elementsArr
+          }
+        });
+      } catch {
+        // 单条子消息解析失败时跳过，避免拖死整批。
+      }
+    }
+    return out;
   }
 
   private isSystemMessage(message: RawMessage): boolean {


### PR DESCRIPTION
## 背景

issue #161：合并转发的卡片在导出时只剩一段 `<msg>...</msg>` 外壳 XML，里面真正的若干条子消息（谁说的、说了什么）全部丢了。JSON / TXT 导出对二次分析尤其不友好。

## 改动

`SimpleMessageParser`：
- 解析 `multiForwardMsgElement` 时，把卡片内每条子消息的发送人、时间戳、文本和扁平 elements 列表抽出来，放进 `forward` 元素的 `data.messages`，同时给一个 `data.messageCount` 方便 UI 直接用。
- 子消息优先取 `message.records` 内联数据；没有就走 `globalThis.__NAPCAT_BRIDGE__` 的 `MsgApi.getMultiMsg(peer, rootMsgId, parentMsgId, forwardId, resId)` 兜底拉取。两条路都失败时只丢子消息，不影响整条消息正常导出，外壳 XML 仍保留在 `data.summary` 里。
- 引入 `MAX_FORWARD_DEPTH = 3`，递归解析嵌套合并转发，超过 3 层就停止继续展开（避免恶意构造的循环转发把栈打爆 / 拖慢导出）。
- 新增 `ForwardInnerMessage` 类型；`parseElement` / `parseMessageContent` 增加可选 `forwardDepth` 参数，纯叠加，老调用点不受影响。
- `elementToText` 的 `forward` 分支输出从单行 `[转发消息]` 升级为 `[转发消息: N条]` + 前 3 条预览（`发件人: 文本(40字截断)`），TXT 导出可读性显著提升。

`ModernHtmlExporter`：
- `renderForwardElement` 优先使用 `data.messages` 渲染前 5 条 `发件人: 文本(60字截断)` 列表；老 preview / summary 路径作为兜底保留。卡片底部加上 `转发消息 · N条` 计数。
- `extractElementText`（搜索索引）的 `forward` 分支把子消息的发送人和文本也并进搜索文本，否则站内搜索还是只能命中外壳标题。

## 测试

`__tests__/unit/SimpleMessageParser.test.ts` 新增 4 个用例：

1. inline `message.records` 直接展开为 `messages` 列表；
2. 没有 records 时通过 `MsgApi.getMultiMsg(resId)` 命中 mock core；
3. resId 在 mock 里查不到 → `messages = []`，外壳 XML 仍在 `summary`，`content.text` 不丢；
4. `content.text` 渲染出 `[转发消息: 2条]` + 预览行。

`pnpm run test:unit` 全部 126/126 通过。

## 兼容性

- 仅在 `forward` 元素 `data` 上新增字段，未删改任何已有字段。老导出器 / 老前端读到的字段仍然是原来那些。
- 子消息抓取失败 / 无 bridge 时整条消息照常落盘，行为退化到改动前的“只有 XML 摘要”，不会回退失败。

closes #161