### PR TITLE
feat(export): allow exporting temp / service-account chats end-to-end (#365)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/chatTypeClassification.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/chatTypeClassification.test.ts
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    classifyChatTypeBinary,
+    getChatTypePrefix,
+    isPrivateLikeChatType,
+} from '../../lib/api/chatTypeClassification.js';
+
+test('chatTypeClassification: chatType=2 是群聊', () => {
+    assert.equal(isPrivateLikeChatType(2), false);
+    assert.equal(getChatTypePrefix(2), 'group');
+    assert.equal(classifyChatTypeBinary(2), 'group');
+});
+
+test('chatTypeClassification: chatType=1 是好友（单聊）', () => {
+    assert.equal(isPrivateLikeChatType(1), true);
+    assert.equal(getChatTypePrefix(1), 'friend');
+    assert.equal(classifyChatTypeBinary(1), 'private');
+});
+
+test('chatTypeClassification: chatType=100 临时会话按单聊处理（issue #365）', () => {
+    assert.equal(isPrivateLikeChatType(100), true);
+    assert.equal(getChatTypePrefix(100), 'friend');
+    assert.equal(classifyChatTypeBinary(100), 'private');
+});
+
+test('chatTypeClassification: 服务号 / 公众账号 (118 / 201) 也按单聊处理', () => {
+    for (const t of [118, 201]) {
+        assert.equal(isPrivateLikeChatType(t), true);
+        assert.equal(getChatTypePrefix(t), 'friend');
+        assert.equal(classifyChatTypeBinary(t), 'private');
+    }
+});
+
+test('chatTypeClassification: 频道 / 频道私聊 (4 / 9 / 16) 也按单聊处理', () => {
+    for (const t of [4, 9, 16]) {
+        assert.equal(isPrivateLikeChatType(t), true);
+        assert.equal(getChatTypePrefix(t), 'friend');
+        assert.equal(classifyChatTypeBinary(t), 'private');
+    }
+});
+
+test('chatTypeClassification: 通知类 (132 / 133 / 134) 也按单聊处理', () => {
+    for (const t of [132, 133, 134]) {
+        assert.equal(isPrivateLikeChatType(t), true);
+        assert.equal(getChatTypePrefix(t), 'friend');
+        assert.equal(classifyChatTypeBinary(t), 'private');
+    }
+});
+
+test('chatTypeClassification: undefined / null 兜底为单聊（不让分支裸奔）', () => {
+    assert.equal(isPrivateLikeChatType(undefined), true);
+    assert.equal(isPrivateLikeChatType(null), true);
+    assert.equal(getChatTypePrefix(undefined), 'friend');
+    assert.equal(classifyChatTypeBinary(null), 'private');
+});
+
+test('chatTypeClassification: 字符串数字也能正确归类（防御性）', () => {
+    // 实际 chatType 都是 number，但 JSON 反序列化偶发会出现字符串场景。
+    // 这里只覆盖最常见的 "2" / "100"。
+    assert.equal(isPrivateLikeChatType(Number('2')), false);
+    assert.equal(isPrivateLikeChatType(Number('100')), true);
+});

--- a/plugins/qq-chat-exporter/__tests__/unit/sessionNameResolver.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/sessionNameResolver.test.ts
@@ -1,0 +1,174 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveSessionName } from '../../lib/api/sessionNameResolver.js';
+
+const FRIEND = 1;
+const GROUP = 2;
+const TEMP = 100;
+const SERVICE = 118;
+
+const FAST = { timeoutMs: 200 };
+
+test('sessionNameResolver: 群聊优先 GroupApi.getGroups', async () => {
+    const name = await resolveSessionName(
+        { chatType: GROUP, peerUid: '8888' },
+        {
+            GroupApi: {
+                getGroups: async () => [
+                    { groupCode: '8888', groupName: '测试群' },
+                    { groupCode: '7777', groupName: '别的群' },
+                ],
+            },
+        },
+        FAST,
+    );
+    assert.equal(name, '测试群');
+});
+
+test('sessionNameResolver: 群聊找不到时兜底为「群聊 <peerUid>」', async () => {
+    const name = await resolveSessionName(
+        { chatType: GROUP, peerUid: '8888' },
+        { GroupApi: { getGroups: async () => [] } },
+        FAST,
+    );
+    assert.equal(name, '群聊 8888');
+});
+
+test('sessionNameResolver: 群聊 GroupApi 抛异常也兜底为「群聊 <peerUid>」', async () => {
+    const name = await resolveSessionName(
+        { chatType: GROUP, peerUid: '8888' },
+        {
+            GroupApi: {
+                getGroups: async () => {
+                    throw new Error('rpc broken');
+                },
+            },
+        },
+        FAST,
+    );
+    assert.equal(name, '群聊 8888');
+});
+
+test('sessionNameResolver: 好友优先 FriendApi.getBuddy', async () => {
+    const name = await resolveSessionName(
+        { chatType: FRIEND, peerUid: 'u_abc' },
+        {
+            FriendApi: {
+                getBuddy: async () => [
+                    { coreInfo: { uid: 'u_abc', remark: '老王', nick: 'wang' } },
+                ],
+            },
+        },
+        FAST,
+    );
+    assert.equal(name, '老王');
+});
+
+test('sessionNameResolver: 好友 remark 缺失时回退到 nick', async () => {
+    const name = await resolveSessionName(
+        { chatType: FRIEND, peerUid: 'u_abc' },
+        {
+            FriendApi: {
+                getBuddy: async () => [
+                    { coreInfo: { uid: 'u_abc', nick: 'wang' } },
+                ],
+            },
+        },
+        FAST,
+    );
+    assert.equal(name, 'wang');
+});
+
+test('sessionNameResolver: 临时会话 (chatType=100) 找不到好友时再试 UserApi.getUserDetailInfo', async () => {
+    let detailCalled = 0;
+    const name = await resolveSessionName(
+        { chatType: TEMP, peerUid: 'u_temp' },
+        {
+            FriendApi: { getBuddy: async () => [] },
+            UserApi: {
+                getUserDetailInfo: async (uid: string) => {
+                    detailCalled++;
+                    assert.equal(uid, 'u_temp');
+                    return { nick: '陌生人小明' };
+                },
+            },
+        },
+        FAST,
+    );
+    assert.equal(name, '陌生人小明');
+    assert.equal(detailCalled, 1);
+});
+
+test('sessionNameResolver: 服务号 (chatType=118) 也走 UserApi 兜底', async () => {
+    const name = await resolveSessionName(
+        { chatType: SERVICE, peerUid: 'u_service' },
+        {
+            FriendApi: { getBuddy: async () => [] },
+            UserApi: {
+                getUserDetailInfo: async () => ({
+                    simpleInfo: { coreInfo: { remark: 'QQ官方', nick: 'QQ' } },
+                }),
+            },
+        },
+        FAST,
+    );
+    assert.equal(name, 'QQ官方');
+});
+
+test('sessionNameResolver: 全部失败时返回 fallback (默认 peer.peerUid)', async () => {
+    const name = await resolveSessionName(
+        { chatType: TEMP, peerUid: 'u_unknown' },
+        {
+            FriendApi: { getBuddy: async () => [] },
+            UserApi: { getUserDetailInfo: async () => null },
+        },
+        FAST,
+    );
+    assert.equal(name, 'u_unknown');
+});
+
+test('sessionNameResolver: apis 整体为 undefined / null 也安全降级', async () => {
+    const a = await resolveSessionName(
+        { chatType: FRIEND, peerUid: 'u_x' },
+        undefined,
+        FAST,
+    );
+    assert.equal(a, 'u_x');
+
+    const b = await resolveSessionName(
+        { chatType: GROUP, peerUid: '999' },
+        null,
+        FAST,
+    );
+    assert.equal(b, '群聊 999');
+});
+
+test('sessionNameResolver: 单聊 FriendApi 抛异常时仍能继续走 UserApi', async () => {
+    const name = await resolveSessionName(
+        { chatType: TEMP, peerUid: 'u_t' },
+        {
+            FriendApi: {
+                getBuddy: async () => {
+                    throw new Error('boom');
+                },
+            },
+            UserApi: { getUserDetailInfo: async () => ({ nick: '小红' }) },
+        },
+        FAST,
+    );
+    assert.equal(name, '小红');
+});
+
+test('sessionNameResolver: 整体超时时返回 fallback', async () => {
+    const name = await resolveSessionName(
+        { chatType: FRIEND, peerUid: 'u_slow' },
+        {
+            FriendApi: {
+                getBuddy: () =>
+                    new Promise((r) => setTimeout(() => r([]), 1000)),
+            },
+        },
+        { timeoutMs: 50 },
+    );
+    assert.equal(name, 'u_slow');
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -50,6 +50,12 @@ import { resolvePeerUid } from './peerResolution.js';
 import { lookupUserByUin } from './userLookup.js';
 import { createSafeLogger, type SafeLogger } from './safeLogger.js';
 import { buildSenderFilter } from './senderFilter.js';
+import {
+    classifyChatTypeBinary,
+    getChatTypePrefix,
+    isPrivateLikeChatType,
+} from './chatTypeClassification.js';
+import { resolveSessionName } from './sessionNameResolver.js';
 import { buildResourceSummaryMessage } from '../utils/resourceSummary.js';
 
 // 导入类型定义
@@ -2075,7 +2081,8 @@ export class QQChatExporterApiServer {
                 }
 
                 // 生成日期时间字符串
-                const chatTypePrefix = actualPeer.chatType === 1 ? 'friend' : 'group';
+                // Issue #365: 临时会话 / 服务号等单聊型 chatType 也走 friend_ 前缀。
+                const chatTypePrefix = getChatTypePrefix(actualPeer.chatType);
                 const date = new Date(timestamp);
                 const dateStr = `${date.getFullYear()}${String(date.getMonth() + 1).padStart(2, '0')}${String(date.getDate()).padStart(2, '0')}`; // 20250506
                 const timeStr = `${String(date.getHours()).padStart(2, '0')}${String(date.getMinutes()).padStart(2, '0')}${String(date.getSeconds()).padStart(2, '0')}`; // 221008
@@ -2085,42 +2092,12 @@ export class QQChatExporterApiServer {
                 const defaultOutputDir = this.pathManager.getExportsDir();
                 const outputDir = customOutputDir || defaultOutputDir;
                 
-                // 确定会话名称：优先使用用户输入的名称，否则自动获取
+                // 确定会话名称：优先使用用户输入的名称，否则自动获取（issue #365）。
                 let sessionName: string;
                 if (userSessionName && userSessionName.trim()) {
-                    // 使用用户输入的任务名
                     sessionName = userSessionName.trim();
                 } else {
-                    // 如果用户没有输入，则尝试自动获取会话名称
-                    sessionName = actualPeer.peerUid;
-                    try {
-                        // 设置较短的超时时间，避免阻塞
-                        const timeoutPromise = new Promise((_, reject) => {
-                            setTimeout(() => reject(new Error('获取会话名称超时')), 2000);
-                        });
-                        
-                        let namePromise;
-                        if (actualPeer.chatType === 1) {
-                            // 私聊 - 仅尝试从已缓存的好友列表获取
-                            namePromise = this.core.apis.FriendApi.getBuddy().then(friends => {
-                                const friend = friends.find((f: any) => f.coreInfo?.uid === actualPeer.peerUid);
-                                return friend?.coreInfo?.remark || friend?.coreInfo?.nick || actualPeer.peerUid;
-                            });
-                        } else if (actualPeer.chatType === 2) {
-                            // 群聊 - 仅尝试从已缓存的群列表获取
-                            namePromise = this.core.apis.GroupApi.getGroups().then(groups => {
-                                const group = groups.find(g => g.groupCode === actualPeer.peerUid || g.groupCode === actualPeer.peerUid.toString());
-                                return group?.groupName || `群聊 ${actualPeer.peerUid}`;
-                            });
-                        } else {
-                            namePromise = Promise.resolve(actualPeer.peerUid);
-                        }
-                        
-                        sessionName = await Promise.race([namePromise, timeoutPromise]) as string;
-                    } catch (error) {
-                        console.warn(`快速获取会话名称失败，使用默认名称: ${actualPeer.peerUid}`, error);
-                        // 使用默认值，不阻塞任务创建
-                    }
+                    sessionName = await resolveSessionName(actualPeer, this.core?.apis);
                 }
 
                 // Issue #216 / #134: 根据用户选项生成文件名（可选包含聊天名称 / 友好命名）
@@ -2203,7 +2180,8 @@ export class QQChatExporterApiServer {
                 const timestamp = Date.now();
 
                 // 流式ZIP导出强制使用ZIP格式
-                const chatTypePrefix = actualPeer.chatType === 1 ? 'friend' : 'group';
+                // Issue #365: 临时会话 / 服务号等单聊型 chatType 也走 friend_ 前缀。
+                const chatTypePrefix = getChatTypePrefix(actualPeer.chatType);
                 const date = new Date(timestamp);
                 const dateStr = `${date.getFullYear()}${String(date.getMonth() + 1).padStart(2, '0')}${String(date.getDate()).padStart(2, '0')}`;
                 const timeStr = `${String(date.getHours()).padStart(2, '0')}${String(date.getMinutes()).padStart(2, '0')}${String(date.getSeconds()).padStart(2, '0')}`;
@@ -2213,36 +2191,12 @@ export class QQChatExporterApiServer {
                 const defaultOutputDir = this.pathManager.getExportsDir();
                 const outputDir = customOutputDir || defaultOutputDir;
 
-                // 确定会话名称
+                // 确定会话名称（issue #365）
                 let sessionName: string;
                 if (userSessionName && userSessionName.trim()) {
                     sessionName = userSessionName.trim();
                 } else {
-                    sessionName = actualPeer.peerUid;
-                    try {
-                        const timeoutPromise = new Promise((_, reject) => {
-                            setTimeout(() => reject(new Error('获取会话名称超时')), 2000);
-                        });
-                        
-                        let namePromise;
-                        if (actualPeer.chatType === 1) {
-                            namePromise = this.core.apis.FriendApi.getBuddy().then(friends => {
-                                const friend = friends.find((f: any) => f.coreInfo?.uid === actualPeer.peerUid);
-                                return friend?.coreInfo?.remark || friend?.coreInfo?.nick || actualPeer.peerUid;
-                            });
-                        } else if (actualPeer.chatType === 2) {
-                            namePromise = this.core.apis.GroupApi.getGroups().then(groups => {
-                                const group = groups.find(g => g.groupCode === actualPeer.peerUid || g.groupCode === actualPeer.peerUid.toString());
-                                return group?.groupName || `群聊 ${actualPeer.peerUid}`;
-                            });
-                        } else {
-                            namePromise = Promise.resolve(actualPeer.peerUid);
-                        }
-                        
-                        sessionName = await Promise.race([namePromise, timeoutPromise]) as string;
-                    } catch (error) {
-                        console.warn(`快速获取会话名称失败，使用默认名称: ${actualPeer.peerUid}`, error);
-                    }
+                    sessionName = await resolveSessionName(actualPeer, this.core?.apis);
                 }
 
                 // Issue #216 / #134: 根据用户选项生成文件名（可选包含聊天名称 / 友好命名）
@@ -2321,7 +2275,8 @@ export class QQChatExporterApiServer {
                 const timestamp = Date.now();
 
                 // 流式JSONL导出使用目录格式
-                const chatTypePrefix = actualPeer.chatType === 1 ? 'friend' : 'group';
+                // Issue #365: 临时会话 / 服务号等单聊型 chatType 也走 friend_ 前缀。
+                const chatTypePrefix = getChatTypePrefix(actualPeer.chatType);
                 const date = new Date(timestamp);
                 const dateStr = `${date.getFullYear()}${String(date.getMonth() + 1).padStart(2, '0')}${String(date.getDate()).padStart(2, '0')}`;
                 const timeStr = `${String(date.getHours()).padStart(2, '0')}${String(date.getMinutes()).padStart(2, '0')}${String(date.getSeconds()).padStart(2, '0')}`;
@@ -2331,36 +2286,12 @@ export class QQChatExporterApiServer {
                 const defaultOutputDir = this.pathManager.getExportsDir();
                 const outputDir = customOutputDir || defaultOutputDir;
 
-                // 确定会话名称
+                // 确定会话名称（issue #365）
                 let sessionName: string;
                 if (userSessionName && userSessionName.trim()) {
                     sessionName = userSessionName.trim();
                 } else {
-                    sessionName = actualPeer.peerUid;
-                    try {
-                        const timeoutPromise = new Promise((_, reject) => {
-                            setTimeout(() => reject(new Error('获取会话名称超时')), 2000);
-                        });
-                        
-                        let namePromise;
-                        if (actualPeer.chatType === 1) {
-                            namePromise = this.core.apis.FriendApi.getBuddy().then(friends => {
-                                const friend = friends.find((f: any) => f.coreInfo?.uid === actualPeer.peerUid);
-                                return friend?.coreInfo?.remark || friend?.coreInfo?.nick || actualPeer.peerUid;
-                            });
-                        } else if (actualPeer.chatType === 2) {
-                            namePromise = this.core.apis.GroupApi.getGroups().then(groups => {
-                                const group = groups.find(g => g.groupCode === actualPeer.peerUid || g.groupCode === actualPeer.peerUid.toString());
-                                return group?.groupName || `群聊 ${actualPeer.peerUid}`;
-                            });
-                        } else {
-                            namePromise = Promise.resolve(actualPeer.peerUid);
-                        }
-                        
-                        sessionName = await Promise.race([namePromise, timeoutPromise]) as string;
-                    } catch (error) {
-                        console.warn(`快速获取会话名称失败，使用默认名称: ${actualPeer.peerUid}`, error);
-                    }
+                    sessionName = await resolveSessionName(actualPeer, this.core?.apis);
                 }
 
                 // Issue #216 / #134: 根据用户选项生成目录名（可选包含聊天名称 / 友好命名）
@@ -3974,7 +3905,7 @@ export class QQChatExporterApiServer {
             const selfInfo = this.core.selfInfo;
             const chatInfo = {
                 name: chatName,
-                type: (peer.chatType === ChatType.Group || peer.chatType === 2 ? 'group' : 'private') as 'group' | 'private',
+                type: classifyChatTypeBinary(peer.chatType),
                 selfUid: selfInfo?.uid,
                 selfUin: selfInfo?.uin,
                 selfName: selfInfo?.nick
@@ -4477,7 +4408,7 @@ export class QQChatExporterApiServer {
             const selfInfo = this.core.selfInfo;
             const chatInfo = {
                 name: sessionName,
-                type: (peer.chatType === ChatType.Group || peer.chatType === 2 ? 'group' : 'private') as 'group' | 'private',
+                type: classifyChatTypeBinary(peer.chatType),
                 selfUid: selfInfo?.uid,
                 selfUin: selfInfo?.uin,
                 selfName: selfInfo?.nick
@@ -4733,7 +4664,7 @@ export class QQChatExporterApiServer {
             const selfInfo = this.core.selfInfo;
             const chatInfo = {
                 name: sessionName,
-                type: (peer.chatType === ChatType.Group || peer.chatType === 2 ? 'group' : 'private') as 'group' | 'private',
+                type: classifyChatTypeBinary(peer.chatType),
                 selfUid: selfInfo?.uid,
                 selfUin: selfInfo?.uin,
                 selfName: selfInfo?.nick
@@ -5480,7 +5411,10 @@ export class QQChatExporterApiServer {
                 taskId: task.taskId,
                 taskName: task.sessionName,
                 peer: task.peer,
-                chatType: task.peer.chatType === 1 ? ChatTypeSimple.PRIVATE : ChatTypeSimple.GROUP,
+                // Issue #365: 仅 chatType === 2 算群聊，其它（含临时会话 / 服务号）都按私聊存。
+                chatType: classifyChatTypeBinary(task.peer.chatType) === 'group'
+                    ? ChatTypeSimple.GROUP
+                    : ChatTypeSimple.PRIVATE,
                 chatName: task.sessionName,
                 chatAvatar: '', // 可以后续添加
                 formats: [task.format?.toUpperCase() || 'JSON'] as ExportFormat[],

--- a/plugins/qq-chat-exporter/lib/api/chatTypeClassification.ts
+++ b/plugins/qq-chat-exporter/lib/api/chatTypeClassification.ts
@@ -1,0 +1,64 @@
+/**
+ * 把 NTQQ ChatType 数值映射成导出层关心的二分类（issue #365）。
+ *
+ * 历史遗留代码里散布着大量 `chatType === 1 ? 'friend' : 'group'` 的写法。
+ * 这种写法只覆盖了好友（1）/ 群聊（2），把临时会话（100）、官方 Bot 服务号
+ * （118 / 201）、频道（4 / 9 / 16）等单聊型会话一律错分为「群聊」，导致：
+ *
+ *   1. 文件名前缀变成 `group_<uid>_*`，下载下来的临时会话档案看着像群聊
+ *      存档；
+ *   2. 自动 sessionName 走 GroupApi.getGroups 找不到对应的 groupCode，最终
+ *      只能用裸 uid 兜底；
+ *   3. 任务列表 / 数据库里 chatType 字段被记成 `GROUP`，前端按类型筛选时
+ *      临时会话的导出任务被算到群聊一类；
+ *   4. BatchMessageFetcher 的策略选择只把 chatType === 1 当成私聊优化路径，
+ *      临时会话会进入面向群聊调优的策略，浪费时间。
+ *
+ * 本模块统一约定：
+ *   - `isPrivateLikeChatType`: chatType !== 2 一律视为单聊型会话；
+ *   - `getChatTypePrefix`: 仅 chatType === 2 用 `group`，其它走 `friend`；
+ *   - `classifyChatTypeBinary`: 返回 `'group' | 'private'`，用于导出
+ *     pipeline 里二选一的分支（exporter type、任务记录的 chatType 字段等）。
+ *
+ * 模块只做纯映射，不依赖任何 NapCat 全局类型，方便单元测试覆盖。
+ */
+
+export const GROUP_CHAT_TYPE = 2;
+
+export type BinaryChatType = 'group' | 'private';
+
+export type ChatTypeFilenamePrefix = 'group' | 'friend';
+
+/**
+ * 该 chatType 在导出层是否按「单聊」对待。
+ *
+ * NTQQ 的 ChatType 枚举里：
+ *   - 1   好友
+ *   - 2   群聊
+ *   - 4   频道
+ *   - 9 / 16    频道子会话
+ *   - 100 临时会话
+ *   - 118 / 201 服务号 / 公众账号
+ *   - 132-134 通知类
+ *
+ * 除群聊（2）外，其余都是 1 对 1 的单聊型会话，导出 / 文件命名 / 策略选择
+ * 都应按私聊处理。
+ */
+export function isPrivateLikeChatType(chatType: number | undefined | null): boolean {
+    if (chatType === undefined || chatType === null) return true;
+    return Number(chatType) !== GROUP_CHAT_TYPE;
+}
+
+/**
+ * 文件名 / 目录名前缀。仅 chatType === 2 用 `group`，其它走 `friend`。
+ */
+export function getChatTypePrefix(chatType: number | undefined | null): ChatTypeFilenamePrefix {
+    return isPrivateLikeChatType(chatType) ? 'friend' : 'group';
+}
+
+/**
+ * 导出 pipeline 通用的二分类，用于 exporter type / 任务记录的 chatType 字段等。
+ */
+export function classifyChatTypeBinary(chatType: number | undefined | null): BinaryChatType {
+    return isPrivateLikeChatType(chatType) ? 'private' : 'group';
+}

--- a/plugins/qq-chat-exporter/lib/api/sessionNameResolver.ts
+++ b/plugins/qq-chat-exporter/lib/api/sessionNameResolver.ts
@@ -1,0 +1,158 @@
+/**
+ * 在导出任务创建阶段把 peer 解析成对人友好的会话名（issue #365）。
+ *
+ * 这一段以前内联在 ApiServer 三个导出端点里，写法都是
+ *   if (chatType === 1) { 找好友 } else if (chatType === 2) { 找群 } else { 用 uid }
+ *
+ * 临时会话（chatType=100）、官方 Bot 服务号（118 / 201）等本质上还是单聊，
+ * 但落到 `else` 分支后只会拿到一个裸 uid，导出文件名 / 任务列表里看着像
+ * 一长串乱码。本模块把分支统一收敛：
+ *   - chatType === 2  → 走群列表；
+ *   - 其它任何 chatType → 优先用好友缓存（若 uid 在好友里）；
+ *     再试 UserApi.getUserDetailInfo 拿昵称（覆盖临时会话 / 销号好友 / 服务号）；
+ *     最后兜底 fallback（默认就是 peerUid）。
+ *
+ * 任意一步抛异常都吞掉，让导出主流程继续，不再因为「连个名字都查不到」就把
+ * 整个任务卡住。
+ */
+
+import { isPrivateLikeChatType } from './chatTypeClassification.js';
+
+export interface PeerLikeForName {
+    chatType: number;
+    peerUid: string;
+}
+
+export interface FriendApiLikeForName {
+    getBuddy?: () => Promise<any[] | undefined | null>;
+}
+
+export interface GroupApiLikeForName {
+    getGroups?: () => Promise<any[] | undefined | null>;
+}
+
+export interface UserApiLikeForName {
+    getUserDetailInfo?: (uid: string, noCache?: boolean) => Promise<any>;
+}
+
+export interface CoreApisForName {
+    FriendApi?: FriendApiLikeForName | null;
+    GroupApi?: GroupApiLikeForName | null;
+    UserApi?: UserApiLikeForName | null;
+}
+
+export interface ResolveSessionNameOptions {
+    /** 单步查询超时（ms），默认 2000，和原来内联实现一致。 */
+    timeoutMs?: number;
+    /** 兜底名称，默认是 `peer.peerUid`。 */
+    fallback?: string;
+}
+
+const DEFAULT_TIMEOUT = 2000;
+
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('获取会话名称超时')), ms);
+        p.then(
+            (v) => {
+                clearTimeout(timer);
+                resolve(v);
+            },
+            (e) => {
+                clearTimeout(timer);
+                reject(e);
+            },
+        );
+    });
+}
+
+async function tryFriendName(
+    friendApi: FriendApiLikeForName | undefined | null,
+    peerUid: string,
+): Promise<string | undefined> {
+    if (typeof friendApi?.getBuddy !== 'function') return undefined;
+    const friends = await friendApi.getBuddy.call(friendApi);
+    if (!Array.isArray(friends)) return undefined;
+    const friend = friends.find((f: any) => f?.coreInfo?.uid === peerUid);
+    return friend?.coreInfo?.remark || friend?.coreInfo?.nick || undefined;
+}
+
+async function tryGroupName(
+    groupApi: GroupApiLikeForName | undefined | null,
+    peerUid: string,
+): Promise<string | undefined> {
+    if (typeof groupApi?.getGroups !== 'function') return undefined;
+    const groups = await groupApi.getGroups.call(groupApi);
+    if (!Array.isArray(groups)) return undefined;
+    const group = groups.find(
+        (g: any) =>
+            g?.groupCode === peerUid ||
+            String(g?.groupCode ?? '') === String(peerUid),
+    );
+    return group?.groupName || undefined;
+}
+
+async function tryUserDetailName(
+    userApi: UserApiLikeForName | undefined | null,
+    peerUid: string,
+): Promise<string | undefined> {
+    if (typeof userApi?.getUserDetailInfo !== 'function') return undefined;
+    const detail = await userApi.getUserDetailInfo.call(userApi, peerUid, false);
+    if (!detail) return undefined;
+    return (
+        detail.remark ||
+        detail.nick ||
+        detail.nickName ||
+        detail?.simpleInfo?.coreInfo?.remark ||
+        detail?.simpleInfo?.coreInfo?.nick ||
+        undefined
+    );
+}
+
+/**
+ * 根据 peer.chatType 走最合适的查找路径，把找到的展示名返回；任意异常都吞掉，
+ * 最终至少返回 `options.fallback ?? peer.peerUid`。
+ */
+export async function resolveSessionName(
+    peer: PeerLikeForName,
+    apis: CoreApisForName | undefined | null,
+    options: ResolveSessionNameOptions = {},
+): Promise<string> {
+    const fallback = options.fallback ?? peer.peerUid;
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT;
+
+    if (!isPrivateLikeChatType(peer.chatType)) {
+        try {
+            const name = await withTimeout(
+                tryGroupName(apis?.GroupApi, peer.peerUid).then(
+                    (v) => v ?? `群聊 ${peer.peerUid}`,
+                ),
+                timeoutMs,
+            );
+            return name || fallback;
+        } catch {
+            return `群聊 ${peer.peerUid}`;
+        }
+    }
+
+    // 单聊型会话（好友 / 临时会话 / 服务号 / 频道私聊等）：先看好友缓存，再
+    // 兜底到 UserApi.getUserDetailInfo，最后回退到 peerUid。
+    try {
+        return await withTimeout(
+            (async () => {
+                const fromFriend = await tryFriendName(apis?.FriendApi, peer.peerUid).catch(
+                    () => undefined,
+                );
+                if (fromFriend) return fromFriend;
+                const fromDetail = await tryUserDetailName(apis?.UserApi, peer.peerUid).catch(
+                    () => undefined,
+                );
+                if (fromDetail) return fromDetail;
+                return fallback;
+            })(),
+            timeoutMs,
+        );
+    } catch {
+        return fallback;
+    }
+}

--- a/plugins/qq-chat-exporter/lib/core/chat/ChatSessionManager.ts
+++ b/plugins/qq-chat-exporter/lib/core/chat/ChatSessionManager.ts
@@ -7,6 +7,7 @@
 import { ChatSession, ChatTypeSimple, SystemError, ErrorType } from '../../types/index.js';
 import { NapCatCore, Peer } from 'NapCatQQ/src/core/index.js';
 import { ChatType } from 'NapCatQQ/src/core/types.js';
+import { isPrivateLikeChatType } from '../../api/chatTypeClassification.js';
 
 /**
  * 聊天会话管理器类
@@ -248,8 +249,9 @@ export class ChatSessionManager {
             return null;
         }
 
-        // ChatType.Group = 2
-        const isGroup = contact.chatType === ChatType.Group || contact.chatType === 2;
+        // Issue #365: 仅 ChatType.Group (2) 算群聊，临时会话 (100) / 服务号
+        // (118 / 201) / 频道私聊等都按 private_ 处理。
+        const isGroup = !isPrivateLikeChatType(contact.chatType);
         const sessionId = isGroup
             ? `group_${contact.peerUid}` 
             : `private_${contact.peerUid}`;

--- a/plugins/qq-chat-exporter/lib/core/fetcher/BatchMessageFetcher.ts
+++ b/plugins/qq-chat-exporter/lib/core/fetcher/BatchMessageFetcher.ts
@@ -11,6 +11,7 @@ import {
     ErrorType, 
     SystemError 
 } from '../../types/index.js';
+import { isPrivateLikeChatType } from '../../api/chatTypeClassification.js';
 
 /**
  * 批量获取配置接口
@@ -223,9 +224,11 @@ export class BatchMessageFetcher {
      * 根据筛选条件和性能情况选择最优的获取策略
      */
     private selectOptimalStrategy(filter: MessageFilter, peer: Peer): FetchStrategy {
-        // 对于私聊，直接使用最简单可靠的方法
-        if (peer.chatType === 1) {
-            console.debug(`策略选择: 私聊使用基础getMsgHistory方法, 对等体=${peer.peerUid}`);
+        // 对于单聊型会话（含好友、临时会话、服务号、频道私聊等，issue #365），
+        // 直接使用最简单可靠的方法。chatType !== 2 都按非群聊处理，避免群聊
+        // 调优策略对单聊场景画蛇添足。
+        if (isPrivateLikeChatType(peer.chatType)) {
+            console.debug(`策略选择: 单聊使用基础getMsgHistory方法, 对等体=${peer.peerUid}, chatType=${peer.chatType}`);
             return FetchStrategy.TIME_BASED_SEQUENTIAL;
         }
 


### PR DESCRIPTION
## Summary

修复 issue #365：让临时会话（chatType=100）、QQ 官方 Bot / 服务号（118 / 201）、频道私聊（4 / 9 / 16）等单聊型会话也能正常走完导出流程。

之前 `ApiServer` / `ChatSessionManager` / `BatchMessageFetcher` 都用二分类 `chatType === 1 ? friend : group` 来判断会话类型，结果除了好友（chatType=1）以外的所有单聊都被当成群聊：

- `/api/messages/export`、流式 ZIP、流式 JSONL 三个端点生成的文件名都是 `group_<uid>_*`；
- sessionName 自动解析走 `GroupApi.getGroups` 找不到对应 groupCode，最终只能裸 uid 兜底；
- `saveTaskToDatabase` 把 chatType 写成 `GROUP`，前端按类型筛选时临时会话被算进群聊；
- `BatchMessageFetcher.selectOptimalStrategy` 仅对 chatType===1 走简单单聊策略，临时会话被推到群聊调优策略。

## Changes

新增两个独立的小模块、配齐单测，然后把上述四处逻辑替换掉：

- `lib/api/chatTypeClassification.ts`
  - `isPrivateLikeChatType`：仅 chatType === 2 视为群聊，其它（含 100 / 118 / 201 / 4 / 9 / 16 / 132–134 等）一律按单聊；
  - `getChatTypePrefix`：文件名前缀，仅群聊用 `group`，其它用 `friend`；
  - `classifyChatTypeBinary`：返回 `'group' | 'private'`，用于 exporter type / 任务记录。
- `lib/api/sessionNameResolver.ts`
  - 抽出原来内联在三个端点里的 `if(chatType===1){好友}else if(chatType===2){群}else{uid}` 逻辑；
  - 单聊型会话先查好友缓存，再走 `UserApi.getUserDetailInfo`（覆盖临时会话 / 销号 / 服务号），最后回退到 peerUid；
  - 任意一步抛异常都吞掉，不再因为「连个名字都查不到」就把整个任务卡住。
- `lib/api/ApiServer.ts`
  - 三个 `/api/messages/export` 端点改用新的 `getChatTypePrefix` + `resolveSessionName`；
  - `saveTaskToDatabase` 用 `classifyChatTypeBinary` 决定 chatType 字段，临时会话不再被记成群聊；
  - 三处 exporter type 的二分类也改用 `classifyChatTypeBinary` 统一收敛。
- `lib/core/fetcher/BatchMessageFetcher.ts`：`selectOptimalStrategy` 改为「非群聊一律走简单单聊策略」，避免群聊调优对临时会话画蛇添足。
- `lib/core/chat/ChatSessionManager.ts`：`formatContactToSession` 也改为 `!isPrivateLike`，防止 `getRecentContactListSnapShot` 拿到的临时会话被前缀成 `group_<uid>`。

## Tests

- `__tests__/unit/chatTypeClassification.test.ts`：覆盖 chatType 1 / 2 / 100 / 118 / 201 / 4 / 9 / 16 / 132 / 133 / 134 以及 undefined / null / 字符串数字的分类结果。
- `__tests__/unit/sessionNameResolver.test.ts`：覆盖群聊、好友、临时会话、服务号、UserApi 兜底、全部失败、apis 为 null、单步异常、整体超时等路径。

`npm test`（unit + integration）本地全绿（145 + 7 通过，0 失败）。