### PR TITLE
fix(auth): make access token survive Framework / Standalone switching (#272)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/securityManagerConfigPath.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/securityManagerConfigPath.test.ts
@@ -1,0 +1,208 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { SecurityManager } from '../../lib/security/SecurityManager.js';
+
+function withEnv(
+    env: Partial<Record<string, string | undefined>>,
+    fn: () => void,
+): void {
+    const saved: Record<string, string | undefined> = {};
+    try {
+        for (const [k, v] of Object.entries(env)) {
+            saved[k] = process.env[k];
+            if (v === undefined) {
+                delete process.env[k];
+            } else {
+                process.env[k] = v;
+            }
+        }
+        fn();
+    } finally {
+        for (const [k, v] of Object.entries(saved)) {
+            if (v === undefined) {
+                delete process.env[k];
+            } else {
+                process.env[k] = v;
+            }
+        }
+    }
+}
+
+test('resolveSecurityDir: QCE_CONFIG_DIR 优先于 USERPROFILE / HOME', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'qce-cfg-'));
+    try {
+        withEnv(
+            {
+                QCE_CONFIG_DIR: tmp,
+                USERPROFILE: '/should/not/use',
+                HOME: '/should/not/use/either',
+            },
+            () => {
+                assert.equal(SecurityManager.resolveSecurityDir(), tmp);
+            },
+        );
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+
+test('resolveSecurityDir: 没有覆盖时回退到 ~/.qq-chat-exporter', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'qce-home-'));
+    try {
+        withEnv(
+            {
+                QCE_CONFIG_DIR: undefined,
+                USERPROFILE: undefined,
+                HOME: tmp,
+                HOMEDRIVE: undefined,
+                HOMEPATH: undefined,
+            },
+            () => {
+                assert.equal(
+                    SecurityManager.resolveSecurityDir(),
+                    path.join(tmp, '.qq-chat-exporter'),
+                );
+            },
+        );
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+
+test('resolveSecurityDir: USERPROFILE 落到 system32 时回退到 HOMEDRIVE+HOMEPATH（issue #272）', () => {
+    withEnv(
+        {
+            QCE_CONFIG_DIR: undefined,
+            USERPROFILE: 'C:\\Windows\\system32\\config\\systemprofile',
+            HOME: undefined,
+            HOMEDRIVE: 'D:',
+            HOMEPATH: '\\Users\\real-user',
+        },
+        () => {
+            const dir = SecurityManager.resolveSecurityDir();
+            // 不应再用 system32 的 USERPROFILE
+            assert.ok(
+                !dir.toLowerCase().includes('system32'),
+                `不应回退到 system32: ${dir}`,
+            );
+            // 应能拼到 HOMEDRIVE+HOMEPATH 下
+            assert.ok(
+                dir.replace(/\\/g, '/').toLowerCase().includes('users/real-user/.qq-chat-exporter'),
+                `应使用 HOMEDRIVE+HOMEPATH: ${dir}`,
+            );
+        },
+    );
+});
+
+test('resolveSecurityDir: USERPROFILE / HOMEPATH 都在 system32 下时退到 cwd', () => {
+    withEnv(
+        {
+            QCE_CONFIG_DIR: undefined,
+            USERPROFILE: 'C:\\Windows\\system32\\config\\systemprofile',
+            HOME: undefined,
+            HOMEDRIVE: 'C:',
+            HOMEPATH: '\\Windows\\system32',
+        },
+        () => {
+            const dir = SecurityManager.resolveSecurityDir();
+            assert.ok(
+                !dir.toLowerCase().includes('system32'),
+                `不应使用任何 system32 候选: ${dir}`,
+            );
+            assert.ok(dir.endsWith('.qq-chat-exporter'));
+        },
+    );
+});
+
+test('resolveSecurityDir: QCE_CONFIG_DIR 为空白字符串时不被采用', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'qce-empty-'));
+    try {
+        withEnv(
+            {
+                QCE_CONFIG_DIR: '   ',
+                USERPROFILE: tmp,
+                HOME: undefined,
+                HOMEDRIVE: undefined,
+                HOMEPATH: undefined,
+            },
+            () => {
+                assert.equal(
+                    SecurityManager.resolveSecurityDir(),
+                    path.join(tmp, '.qq-chat-exporter'),
+                );
+            },
+        );
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+
+test('SecurityManager 构造函数会用 QCE_CONFIG_DIR 而不是 system32', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'qce-mgr-'));
+    try {
+        withEnv(
+            {
+                QCE_CONFIG_DIR: tmp,
+            },
+            () => {
+                const mgr = new SecurityManager();
+                const cfgPath = mgr.getConfigPath();
+                assert.equal(path.dirname(cfgPath), tmp);
+                assert.equal(path.basename(cfgPath), 'security.json');
+            },
+        );
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+
+test('initialize() 写出的 token 仅包含 A-Z / a-z / 0-9（issue #272）', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'qce-token-'));
+    try {
+        await withEnvAsync({ QCE_CONFIG_DIR: tmp }, async () => {
+            const mgr = new SecurityManager();
+            await mgr.initialize();
+
+            const token = mgr.getAccessToken();
+            assert.ok(token, 'token 应已生成');
+            assert.match(token!, /^[A-Za-z0-9]+$/, `token 含非字母数字: ${token}`);
+            assert.ok(
+                token!.length >= 32,
+                `token 长度不应缩水 (got ${token!.length})`,
+            );
+
+            mgr.stopConfigWatcher();
+        });
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+
+async function withEnvAsync(
+    env: Partial<Record<string, string | undefined>>,
+    fn: () => Promise<void>,
+): Promise<void> {
+    const saved: Record<string, string | undefined> = {};
+    try {
+        for (const [k, v] of Object.entries(env)) {
+            saved[k] = process.env[k];
+            if (v === undefined) {
+                delete process.env[k];
+            } else {
+                process.env[k] = v;
+            }
+        }
+        await fn();
+    } finally {
+        for (const [k, v] of Object.entries(saved)) {
+            if (v === undefined) {
+                delete process.env[k];
+            } else {
+                process.env[k] = v;
+            }
+        }
+    }
+}

--- a/plugins/qq-chat-exporter/lib/security/SecurityManager.ts
+++ b/plugins/qq-chat-exporter/lib/security/SecurityManager.ts
@@ -138,16 +138,61 @@ export class SecurityManager {
     private configWatcher: fs.FSWatcher | null = null;
 
     constructor() {
-        const userProfile = process.env['USERPROFILE'] || process.env['HOME'] || '.';
-        const securityDir = path.join(userProfile, '.qq-chat-exporter');
-        
+        const securityDir = SecurityManager.resolveSecurityDir();
+
         // 确保目录存在
         if (!fs.existsSync(securityDir)) {
             fs.mkdirSync(securityDir, { recursive: true });
         }
-        
+
         this.configPath = path.join(securityDir, 'security.json');
         this.isDocker = isDockerEnvironment();
+    }
+
+    /**
+     * 计算 security.json 所在目录。
+     *
+     * 优先级（issue #272）：
+     *   1. 环境变量 `QCE_CONFIG_DIR`（绝对路径），方便 Framework / Standalone 共用一份配置；
+     *   2. `~/.qq-chat-exporter/`（USERPROFILE / HOME）；
+     *   3. 当 USERPROFILE 落到 `C:\Windows\system32\config\systemprofile`
+     *      （管理员模式下未 cd 到脚本目录就启动会出现这种情况）时回退到 HOMEDRIVE+HOMEPATH，
+     *      最终再退到当前工作目录，避免把 token 写到 system32 里读不到。
+     */
+    static resolveSecurityDir(): string {
+        const envOverride = process.env['QCE_CONFIG_DIR'];
+        if (envOverride && envOverride.trim()) {
+            return envOverride.trim();
+        }
+
+        const homeCandidates: Array<string | undefined> = [
+            process.env['USERPROFILE'],
+            process.env['HOME'],
+        ];
+
+        const driveBased =
+            process.env['HOMEDRIVE'] && process.env['HOMEPATH']
+                ? path.join(process.env['HOMEDRIVE'] || '', process.env['HOMEPATH'] || '')
+                : '';
+        if (driveBased) {
+            homeCandidates.push(driveBased);
+        }
+
+        for (const candidate of homeCandidates) {
+            if (!candidate) continue;
+            const normalized = candidate.replace(/\\/g, '/').toLowerCase();
+            // C:\Windows\system32\config\systemprofile（SYSTEM 账户）/ system32 下不可写：跳过
+            if (
+                normalized.includes('/windows/system32') ||
+                normalized.includes('/windows/syswow64')
+            ) {
+                continue;
+            }
+            return path.join(candidate, '.qq-chat-exporter');
+        }
+
+        // 全部候选都不可用：用当前工作目录兜底
+        return path.join(process.cwd(), '.qq-chat-exporter');
     }
 
     /**
@@ -156,6 +201,14 @@ export class SecurityManager {
     async initialize(): Promise<void> {
         // 初始化服务器地址（默认localhost，Docker环境下使用0.0.0.0）
         this.publicIP = this.isDocker ? '0.0.0.0' : '127.0.0.1';
+
+        // Issue #272: 启动时把 configPath 打到 stdout，便于排查 Framework /
+        // Standalone 切换 / admin 模式 USERPROFILE 漂移导致 token 不一致。
+        try {
+            console.log(`[QCE][SecurityManager] config: ${this.configPath}`);
+        } catch {
+            // ignore
+        }
 
         // 加载或创建安全配置
         if (fs.existsSync(this.configPath)) {
@@ -236,8 +289,8 @@ export class SecurityManager {
      * 生成初始安全配置
      */
     private async generateInitialConfig(): Promise<void> {
-        // 生成复杂的访问令牌 (32字符)
-        const accessToken = this.generateSecureToken(32);
+        // 生成复杂的访问令牌（40 字符纯字母数字，issue #272）
+        const accessToken = this.generateSecureToken(40);
         
         // 生成密钥 (64字符)
         const secretKey = this.generateSecureToken(64);
@@ -303,16 +356,22 @@ export class SecurityManager {
     }
 
     /**
-     * 生成安全令牌
+     * 生成安全令牌。
+     *
+     * Issue #272: 之前的字符表里包含 `!@#$%^&*`，复制 / URL / shell / 聊天
+     * 软件转手时容易把这几个字符吃掉或解析成参数分隔符（典型场景：one-click
+     * URL 里的 `&` 被裁成两个 query 参数），用户复制下来的 token 永远不等于
+     * 落盘的那个。改成只用 A-Z / a-z / 0-9，长度从 32 拉到 40 维持熵预算
+     * （log2(62^40) ≈ 238 bit）。
      */
-    private generateSecureToken(length: number = 32): string {
-        const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*';
+    private generateSecureToken(length: number = 40): string {
+        const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
         let result = '';
-        
+
         for (let i = 0; i < length; i++) {
             result += chars.charAt(crypto.randomInt(0, chars.length));
         }
-        
+
         return result;
     }
 
@@ -322,7 +381,7 @@ export class SecurityManager {
     private async regenerateToken(): Promise<void> {
         if (!this.config) return;
         
-        this.config.accessToken = this.generateSecureToken(32);
+        this.config.accessToken = this.generateSecureToken(40);
         this.config.tokenExpired = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
         
         await this.saveConfig();


### PR DESCRIPTION
## Summary

修复 issue #272：用户在 NapCat-Framework-QCE 与 NapCat-QCE-Windows-x64 之间来回切换时，登录页显示的 token 拿来调 `/auth` 一直返回「无效的访问令牌」。这条修复同时处理两个根因。

## 根因

### 1. SecurityManager 配置路径漂移

`SecurityManager` 之前直接拼 `process.env.USERPROFILE + '/.qq-chat-exporter/'`。以管理员身份双击 `.bat` 启动时（在 #286 / PR #414 修好之前），CMD 启动目录是 `C:\Windows\system32`；少数环境下 `USERPROFILE` 也会落到 `C:\Windows\system32\config\systemprofile`，导致 `security.json` 写到 system32 这种用户根本读不到的位置。下次正常启动时又写回真实家目录，**两份 token 自然对不上**。

### 2. 访问令牌字符表把自己坑了

之前 `generateSecureToken` 的字符表里有 `!@#$%^&*`：

- `one-click 登录` URL 里的 token 做了 `encodeURIComponent` 没问题，但**用户从终端 / 截图 / 聊天软件复制下来的明文 token** 经常被这些字符截断或换义；
- 典型场景：URL 里的 `&` 被某些剪贴板 / 即时通讯软件解析成两个 query 参数；shell / Markdown 里 `*` `^` `$` 也容易吃；
- 最终用户粘到 `/auth` 接口的 token 跟 `security.json` 落盘的 token 不是同一串。

## Changes

- `SecurityManager.resolveSecurityDir()`（新抽出来）：
  1. `QCE_CONFIG_DIR` 环境变量（绝对路径）优先 —— Framework / Standalone 共用一份配置可以靠这个显式指定；
  2. `USERPROFILE` → `HOME`；
  3. 若上述命中 `Windows\system32` / `Windows\SysWOW64`，跳过，回退到 `HOMEDRIVE+HOMEPATH`，再退到 `process.cwd()`。至少保证写出来的 token 能被读回去。
- `generateSecureToken`：字符表收敛到 `A-Z / a-z / 0-9`，长度从 32 拉到 40 维持熵预算（`log2(62^40) ≈ 238 bit`，比原来 `log2(70^32) ≈ 196 bit` 还高）。`secretKey` 不参与复制粘贴，保留 64 字符。
- `initialize()` 启动时把当前 `configPath` 打到 stdout：`[QCE][SecurityManager] config: <path>`，方便用户排查多实例 / 切换场景下到底在用哪一份 `security.json`。

旧的 token（含特殊字符）会继续在 `verifyToken` 里通过字符串比对工作直到 7 天过期，自动 regenerate 之后就是新字符表。

## Tests

新增 `__tests__/unit/securityManagerConfigPath.test.ts`（7 个用例，全绿）：

- `QCE_CONFIG_DIR` 优先于 `USERPROFILE` / `HOME`；
- 没覆盖时回退到 `~/.qq-chat-exporter`；
- USERPROFILE 落 system32 时回退到 HOMEDRIVE+HOMEPATH；
- USERPROFILE / HOMEPATH 都在 system32 下时退到 `cwd`；
- 空白 `QCE_CONFIG_DIR` 不被采用；
- 构造函数路径选择；
- `initialize()` 写出的 token 仅含 `[A-Za-z0-9]`、长度 ≥ 32。

本地全套 unit + integration 159/159 通过，0 失败。