### PR TITLE
feat(session-list): 按最近活跃 / 已导出消息数排序 (#344)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/sessionSort.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/sessionSort.test.ts
@@ -1,0 +1,145 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    compareSessionItems,
+    sortSessionItems,
+    formatRelativeFromNow,
+    formatCompactCount,
+    type SortableSessionItem,
+} from '../../../../qce-v4-tool/lib/session-sort.js';
+
+function makeItem(
+    id: string,
+    overrides: Partial<SortableSessionItem> = {},
+): SortableSessionItem {
+    return {
+        id,
+        type: 'group',
+        name: id,
+        ...overrides,
+    };
+}
+
+test('compareSessionItems: 按 name 升序', () => {
+    const a = makeItem('a', { name: '苹果' });
+    const b = makeItem('b', { name: '香蕉' });
+    assert.ok(compareSessionItems(a, b, 'name', 'asc') < 0);
+    assert.ok(compareSessionItems(a, b, 'name', 'desc') > 0);
+});
+
+test('compareSessionItems: memberCount 缺失记为 -1，永远在最后', () => {
+    const group = makeItem('g', { memberCount: 100 });
+    const friend = makeItem('f', { type: 'friend' });
+    // asc：好友 -1 在前
+    assert.ok(compareSessionItems(friend, group, 'memberCount', 'asc') < 0);
+    // desc：好友 -1 在后
+    assert.ok(compareSessionItems(friend, group, 'memberCount', 'desc') > 0);
+});
+
+test('compareSessionItems: lastActivity 升序按时间，缺失永远沉底', () => {
+    const recent = makeItem('a', { lastMessageTime: '2026-01-10T00:00:00Z' });
+    const old = makeItem('b', { lastMessageTime: '2025-01-10T00:00:00Z' });
+    const noData = makeItem('c');
+
+    // 升序：旧的在前、新的在后
+    assert.ok(compareSessionItems(old, recent, 'lastActivity', 'asc') < 0);
+    // 缺失数据无论 asc / desc 都应该排在最后
+    assert.ok(compareSessionItems(noData, old, 'lastActivity', 'asc') > 0);
+    assert.ok(compareSessionItems(noData, old, 'lastActivity', 'desc') > 0);
+    assert.ok(compareSessionItems(noData, recent, 'lastActivity', 'desc') > 0);
+});
+
+test('compareSessionItems: lastActivity 解析失败按缺失处理', () => {
+    const broken = makeItem('a', { lastMessageTime: 'not-a-date' });
+    const valid = makeItem('b', { lastMessageTime: '2026-01-10T00:00:00Z' });
+    assert.ok(compareSessionItems(broken, valid, 'lastActivity', 'desc') > 0);
+});
+
+test('compareSessionItems: exportedCount 升序，缺失当 0 处理', () => {
+    const big = makeItem('a', { exportedMessageCount: 5000 });
+    const small = makeItem('b', { exportedMessageCount: 100 });
+    const none = makeItem('c');
+
+    assert.ok(compareSessionItems(small, big, 'exportedCount', 'asc') < 0);
+    assert.ok(compareSessionItems(big, small, 'exportedCount', 'desc') < 0);
+    // 没有导出过的会话当 0 处理：相对 small 更靠前（asc）
+    assert.ok(compareSessionItems(none, small, 'exportedCount', 'asc') < 0);
+});
+
+test('sortSessionItems: 不修改原数组', () => {
+    const items: SortableSessionItem[] = [
+        makeItem('c', { name: 'c' }),
+        makeItem('a', { name: 'a' }),
+        makeItem('b', { name: 'b' }),
+    ];
+    const sorted = sortSessionItems(items, 'name', 'asc');
+    assert.deepEqual(
+        sorted.map((it) => it.id),
+        ['a', 'b', 'c'],
+    );
+    // 原数组未变
+    assert.deepEqual(
+        items.map((it) => it.id),
+        ['c', 'a', 'b'],
+    );
+});
+
+test('sortSessionItems: lastActivity desc 把缺失项沉到最后', () => {
+    const items: SortableSessionItem[] = [
+        makeItem('no-data'),
+        makeItem('jan', { lastMessageTime: '2026-01-01T00:00:00Z' }),
+        makeItem('mar', { lastMessageTime: '2026-03-01T00:00:00Z' }),
+        makeItem('feb', { lastMessageTime: '2026-02-01T00:00:00Z' }),
+    ];
+    const sorted = sortSessionItems(items, 'lastActivity', 'desc');
+    assert.deepEqual(
+        sorted.map((it) => it.id),
+        ['mar', 'feb', 'jan', 'no-data'],
+    );
+});
+
+test('formatRelativeFromNow: 各档位边界', () => {
+    const now = Date.parse('2026-05-01T12:00:00Z');
+    // 5 秒前
+    assert.equal(formatRelativeFromNow('2026-05-01T11:59:55Z', now), '刚刚');
+    // 30 分钟前
+    assert.equal(formatRelativeFromNow('2026-05-01T11:30:00Z', now), '30 分钟前');
+    // 5 小时前
+    assert.equal(formatRelativeFromNow('2026-05-01T07:00:00Z', now), '5 小时前');
+    // 3 天前
+    assert.equal(formatRelativeFromNow('2026-04-28T12:00:00Z', now), '3 天前');
+    // 2 个月前
+    assert.equal(formatRelativeFromNow('2026-03-01T12:00:00Z', now), '2 个月前');
+    // 2 年前
+    assert.equal(formatRelativeFromNow('2024-04-30T12:00:00Z', now), '2 年前');
+});
+
+test('formatRelativeFromNow: 异常输入返回空字符串', () => {
+    assert.equal(formatRelativeFromNow(undefined), '');
+    assert.equal(formatRelativeFromNow(null), '');
+    assert.equal(formatRelativeFromNow(''), '');
+    assert.equal(formatRelativeFromNow('not-a-date'), '');
+});
+
+test('formatRelativeFromNow: 未来时间也算 "刚刚"，不渲染负号', () => {
+    const now = Date.parse('2026-05-01T12:00:00Z');
+    assert.equal(formatRelativeFromNow('2026-05-01T13:00:00Z', now), '刚刚');
+});
+
+test('formatCompactCount: 各级紧凑格式', () => {
+    assert.equal(formatCompactCount(0), '0');
+    assert.equal(formatCompactCount(42), '42');
+    assert.equal(formatCompactCount(999), '999');
+    assert.equal(formatCompactCount(1000), '1k');
+    assert.equal(formatCompactCount(1200), '1.2k');
+    assert.equal(formatCompactCount(9999), '10k');
+    assert.equal(formatCompactCount(13427), '13k');
+    assert.equal(formatCompactCount(999_999), '999k');
+    assert.equal(formatCompactCount(1_200_000), '1.2m');
+});
+
+test('formatCompactCount: 异常输入兜底为 0', () => {
+    assert.equal(formatCompactCount(-1), '0');
+    assert.equal(formatCompactCount(NaN), '0');
+    assert.equal(formatCompactCount(Infinity), '0');
+});

--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -299,6 +299,7 @@ export default function QCEDashboard() {
     wsConnected,
     groups,
     friends,
+    recentActivityMap,
     loadChatData,
     tasks,
     loadTasks,
@@ -1042,6 +1043,18 @@ export default function QCEDashboard() {
   // 级联动画 variants（受 reduced-motion 影响）
   // 对于大列表（超过50项），禁用 stagger 动画以提升性能
   const hasLargeList = groups.length > 50 || friends.length > 50
+
+  // Issue #344: 把已完成 / 进行中 / 失败任务的 `messageCount` 按 peerUid 累加，
+  // 给会话列表「按已导出消息数」排序提供数据。每次 tasks 变化都会重新算。
+  const taskCountMap = useMemo<Record<string, number>>(() => {
+    const map: Record<string, number> = {}
+    for (const t of tasks) {
+      const uid = t.peer?.peerUid
+      if (!uid || typeof t.messageCount !== 'number') continue
+      map[uid] = (map[uid] ?? 0) + t.messageCount
+    }
+    return map
+  }, [tasks])
   const STAG = useMemo(() => makeStagger(reduceMotion || hasLargeList ? 0 : 0.06, reduceMotion || hasLargeList), [reduceMotion, hasLargeList])
   const SIDEBAR_WIDTH = 240
   const sidebarTransition = useMemo(
@@ -1674,6 +1687,8 @@ export default function QCEDashboard() {
                       batchMode={batchMode}
                       selectedItems={selectedItems}
                       avatarExportLoading={avatarExportLoading}
+                      recentActivityMap={recentActivityMap}
+                      taskCountMap={taskCountMap}
                       onRefresh={loadChatData}
                       onToggleBatchMode={handleToggleBatchMode}
                       onSelectAll={handleSelectAll}

--- a/qce-v4-tool/components/ui/session-list.tsx
+++ b/qce-v4-tool/components/ui/session-list.tsx
@@ -36,6 +36,10 @@ import {
   type SortField,
   type SortOrder,
 } from "@/hooks/use-session-filter"
+import {
+  formatCompactCount,
+  formatRelativeFromNow,
+} from "@/lib/session-sort"
 import { QqLookupCard } from "./qq-lookup-card"
 
 const UIN_PATTERN = /^\d{4,12}$/
@@ -47,6 +51,16 @@ export interface SessionListProps {
   batchMode?: boolean
   selectedItems?: Set<string>
   avatarExportLoading?: string | null
+  /**
+   * Issue #344: peerUid (group.groupCode / friend.uid) → 最近一条消息 ISO 时间。
+   * 供「按最近活跃」排序 / 列表徽标显示。
+   */
+  recentActivityMap?: Record<string, string | undefined>
+  /**
+   * Issue #344: peerUid → 该会话在本地任务里已导出的消息总数。供「按
+   * 已导出消息数」排序。
+   */
+  taskCountMap?: Record<string, number | undefined>
   onRefresh?: () => void
   onToggleBatchMode?: () => void
   onSelectAll?: (filteredIds?: Set<string>) => void
@@ -81,6 +95,8 @@ export function SessionList({
   batchMode = false,
   selectedItems = new Set(),
   avatarExportLoading,
+  recentActivityMap,
+  taskCountMap,
   onRefresh,
   onToggleBatchMode,
   onSelectAll,
@@ -116,7 +132,10 @@ export function SessionList({
     hasPrevPage,
     groupCount,
     friendCount,
-  } = useSessionFilter(groups, friends)
+  } = useSessionFilter(groups, friends, {
+    recentActivityMap,
+    taskCountMap,
+  })
 
   const searchInputRef = useRef<HTMLInputElement>(null)
   // Issue #344: 记住上一次点击的 row key，用于 shift+click 区间多选。
@@ -300,6 +319,22 @@ export function SessionList({
                 <span className="truncate">{item.subName}</span>
               </>
             )}
+            {/* Issue #344: 最近一条消息时间。没有数据时不渲染。 */}
+            {item.lastMessageTime && (
+              <>
+                <span>·</span>
+                <span title={item.lastMessageTime} className="truncate">
+                  {formatRelativeFromNow(item.lastMessageTime)}
+                </span>
+              </>
+            )}
+            {/* Issue #344: 已导出消息累计。0 不渲染，避免噪声。 */}
+            {item.exportedMessageCount && item.exportedMessageCount > 0 && (
+              <>
+                <span>·</span>
+                <span className="truncate">已导出 {formatCompactCount(item.exportedMessageCount)} 条</span>
+              </>
+            )}
           </div>
         </div>
 
@@ -433,13 +468,16 @@ export function SessionList({
 
           {/* Sort Field */}
           <Select value={sortField} onValueChange={(v: string) => setSortField(v as SortField)}>
-            <SelectTrigger className="w-[100px] h-10 text-sm rounded-lg">
+            <SelectTrigger className="w-[120px] h-10 text-sm rounded-lg">
               <SelectValue placeholder="排序" />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="name">名称</SelectItem>
               <SelectItem value="memberCount">人数</SelectItem>
               <SelectItem value="id">ID</SelectItem>
+              {/* Issue #344: 按最近一条消息时间 / 已导出消息数排序。 */}
+              <SelectItem value="lastActivity">最近活跃</SelectItem>
+              <SelectItem value="exportedCount">已导出条数</SelectItem>
             </SelectContent>
           </Select>
 

--- a/qce-v4-tool/hooks/use-chat-data.ts
+++ b/qce-v4-tool/hooks/use-chat-data.ts
@@ -52,6 +52,12 @@ export function useChatData() {
   const [error, setError] = useState<string | null>(null)
   const [loadProgress, setLoadProgress] = useState<{ current: number; total: number } | null>(null)
   const [avatarExportLoading, setAvatarExportLoading] = useState<string | null>(null)
+  /**
+   * Issue #344: peerUid (group.groupCode / friend.uid) → 最近一条消息 ISO 时间。
+   * 从 `/api/recent-contacts` 与 `/api/groups` 返回的 `lastMsgTime` 合并而成，
+   * 供会话列表「按最近活跃」排序 / 显示「N 天前」徽标。
+   */
+  const [recentActivityMap, setRecentActivityMap] = useState<Record<string, string>>({})
   const { apiCall } = useApi()
 
   // 自动分页加载所有群组
@@ -139,8 +145,18 @@ export function useChatData() {
       // 上层导出 / 定时任务在选中时会把 chatType 透传给后端，避免被强制归为
       // 普通好友（chatType=1）。失败时静默跳过，不影响普通好友加载。
       try {
-        const recentResp = await apiCall<RecentContactsResponse>("/api/recent-contacts?limit=200")
+        const recentResp = await apiCall<RecentContactsResponse>("/api/recent-contacts?limit=500&includeAll=true")
         if (recentResp.success && recentResp.data) {
+          // Issue #344: 根据 peerUid 记下最近一条消息时间，供会话列表「按最近
+          // 活跃」排序 以及小徽标显示。
+          const activityMap: Record<string, string> = {}
+          for (const c of recentResp.data.contacts) {
+            if (c.peerUid && c.lastMsgTime) {
+              activityMap[c.peerUid] = c.lastMsgTime
+            }
+          }
+          setRecentActivityMap(activityMap)
+
           const existingUids = new Set(allFriends.map((f) => f.uid))
           const specialFriends: Friend[] = recentResp.data.contacts
             .filter((c) => c.classification === "special" && !existingUids.has(c.peerUid))
@@ -231,5 +247,6 @@ export function useChatData() {
     loadAll,
     exportGroupAvatars,
     avatarExportLoading,
+    recentActivityMap,
   }
 }

--- a/qce-v4-tool/hooks/use-qce.ts
+++ b/qce-v4-tool/hooks/use-qce.ts
@@ -54,6 +54,7 @@ export function useQCE(props?: { onNotification?: UseExportTasksProps['onNotific
     loadChatData: chatData.loadAll,
     exportGroupAvatars: chatData.exportGroupAvatars,
     avatarExportLoading: chatData.avatarExportLoading,
+    recentActivityMap: chatData.recentActivityMap,
 
     // Tasks
     tasks: exportTasks.tasks,

--- a/qce-v4-tool/hooks/use-session-filter.ts
+++ b/qce-v4-tool/hooks/use-session-filter.ts
@@ -1,9 +1,9 @@
 import { useState, useMemo, useCallback, useEffect } from "react"
 import type { Group, Friend } from "@/types/api"
+import { compareSessionItems, type SortField, type SortOrder } from "@/lib/session-sort"
 
 export type SessionType = 'all' | 'group' | 'friend'
-export type SortField = 'name' | 'memberCount' | 'id'
-export type SortOrder = 'asc' | 'desc'
+export type { SortField, SortOrder }
 
 export interface SessionFilterState {
   search: string
@@ -22,11 +22,30 @@ export interface SessionItem {
   avatarUrl: string
   memberCount?: number
   isOnline?: boolean
+  /**
+   * Issue #344: 会话最近一条消息的时间（ISO）。由 `useSessionFilter`
+   * 调用方从 `/api/recent-contacts` 结果里查出来传进来，没有记录时 `undefined`。
+   */
+  lastMessageTime?: string
+  /**
+   * Issue #344: 该会话在本地任务里已经导出过的消息总数（`/api/tasks`
+   * 里 completed task 的 `messageCount` 求和）。未导出过时 `0`。
+   */
+  exportedMessageCount?: number
   raw: Group | Friend
 }
 
 export interface UseSessionFilterOptions {
   defaultPageSize?: number
+  /**
+   * Issue #344: peerUid → 最近一条消息 ISO 时间。key 针对
+   * `friend.uid` 和 `group.groupCode` 两种。
+   */
+  recentActivityMap?: Record<string, string | undefined>
+  /**
+   * Issue #344: peerUid → 已导出消息总数。
+   */
+  taskCountMap?: Record<string, number | undefined>
 }
 
 export interface UseSessionFilterReturn {
@@ -67,7 +86,11 @@ export function useSessionFilter(
   friends: Friend[],
   options: UseSessionFilterOptions = {}
 ): UseSessionFilterReturn {
-  const { defaultPageSize = 50 } = options
+  const {
+    defaultPageSize = 50,
+    recentActivityMap,
+    taskCountMap,
+  } = options
 
   // Filter state
   const [search, setSearch] = useState("")
@@ -86,6 +109,8 @@ export function useSessionFilter(
       subName: g.remark,
       avatarUrl: g.avatarUrl || `https://p.qlogo.cn/gh/${g.groupCode}/${g.groupCode}/640/`,
       memberCount: g.memberCount,
+      lastMessageTime: recentActivityMap?.[g.groupCode],
+      exportedMessageCount: taskCountMap?.[g.groupCode] ?? 0,
       raw: g,
     }))
 
@@ -96,11 +121,13 @@ export function useSessionFilter(
       subName: f.remark && f.nick !== f.remark ? f.nick : undefined,
       avatarUrl: f.avatarUrl || `https://q1.qlogo.cn/g?b=qq&nk=${f.uin}&s=640`,
       isOnline: f.isOnline,
+      lastMessageTime: recentActivityMap?.[f.uid],
+      exportedMessageCount: taskCountMap?.[f.uid] ?? 0,
       raw: f,
     }))
 
     return [...groupItems, ...friendItems]
-  }, [groups, friends])
+  }, [groups, friends, recentActivityMap, taskCountMap])
 
   // Filtered items (search + type filter)
   const filteredItems = useMemo<SessionItem[]>(() => {
@@ -135,27 +162,10 @@ export function useSessionFilter(
       })
     }
 
-    // Sort
-    items = [...items].sort((a, b) => {
-      let comparison = 0
-
-      switch (sortField) {
-        case 'name':
-          comparison = a.name.localeCompare(b.name, 'zh-CN')
-          break
-        case 'memberCount':
-          // Groups first (they have memberCount), then friends
-          const aCount = a.memberCount ?? -1
-          const bCount = b.memberCount ?? -1
-          comparison = aCount - bCount
-          break
-        case 'id':
-          comparison = a.id.localeCompare(b.id)
-          break
-      }
-
-      return sortOrder === 'asc' ? comparison : -comparison
-    })
+    // Sort。纯函数抽到 `lib/session-sort` 里，方便后端 node:test 复用。
+    items = [...items].sort((a, b) =>
+      compareSessionItems(a, b, sortField, sortOrder),
+    )
 
     return items
   }, [allItems, search, type, sortField, sortOrder])

--- a/qce-v4-tool/lib/package.json
+++ b/qce-v4-tool/lib/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/qce-v4-tool/lib/session-sort.ts
+++ b/qce-v4-tool/lib/session-sort.ts
@@ -1,0 +1,183 @@
+/**
+ * Issue #344: 会话列表排序的纯函数实现，单独抽出来方便用 node:test 跑单测
+ * （`use-session-filter` 直接依赖 React，不易在 node 测试里加载）。
+ */
+
+export type SortField =
+  | 'name'
+  | 'memberCount'
+  | 'id'
+  | 'lastActivity'
+  | 'exportedCount'
+
+export type SortOrder = 'asc' | 'desc'
+
+export interface SortableSessionItem {
+  id: string
+  type: 'group' | 'friend'
+  name: string
+  memberCount?: number
+  /**
+   * 最近一条消息的时间（ISO 字符串），来自后端 `/api/recent-contacts` 的
+   * `lastMsgTime`。没有最近联系人记录时为 `undefined`。
+   */
+  lastMessageTime?: string
+  /**
+   * 该会话已经通过任务导出的消息条数累计值。后端 `/api/tasks` 返回的
+   * 已完成任务里 `messageCount` 求和。没有历史任务时为 `0`。
+   */
+  exportedMessageCount?: number
+}
+
+/**
+ * 把 ISO 时间字符串转为 epoch ms。无法解析或缺失时返回 `null`。
+ */
+export function parseLastActivity(value: string | undefined | null): number | null {
+  if (!value) return null
+  const t = Date.parse(value)
+  return Number.isFinite(t) ? t : null
+}
+
+/**
+ * 比较两个会话条目的纯函数。
+ *
+ * 排序原则：
+ * - `name`：按名称，中文 locale。
+ * - `memberCount`：群人数；好友默认为 -1（始终排在最后）。
+ * - `id`：peerUid / groupCode 字典序。
+ * - `lastActivity`：按 `lastMessageTime` 排，缺失项始终排在最后（不论
+ *   asc / desc），避免「按最近活跃倒序」时一堆没有活动数据的会话冒到最前面。
+ * - `exportedCount`：按已导出消息数累计。0 / undefined 当作 0 参与排序，但
+ *   两端都为 0 时 fallback 到名称排序，让结果稳定。
+ *
+ * 当主键相等时统一 fallback 到 `name` 比较，保持顺序稳定。
+ */
+export function compareSessionItems(
+  a: SortableSessionItem,
+  b: SortableSessionItem,
+  field: SortField,
+  order: SortOrder,
+): number {
+  const direction = order === 'asc' ? 1 : -1
+
+  switch (field) {
+    case 'name':
+      return a.name.localeCompare(b.name, 'zh-CN') * direction
+
+    case 'memberCount': {
+      const aCount = a.memberCount ?? -1
+      const bCount = b.memberCount ?? -1
+      if (aCount === bCount) {
+        return a.name.localeCompare(b.name, 'zh-CN')
+      }
+      return (aCount - bCount) * direction
+    }
+
+    case 'id':
+      return a.id.localeCompare(b.id) * direction
+
+    case 'lastActivity': {
+      const aT = parseLastActivity(a.lastMessageTime)
+      const bT = parseLastActivity(b.lastMessageTime)
+      // 没有 lastMessageTime 的会话不论升降序都沉到最底，避免空数据顶头。
+      if (aT === null && bT === null) {
+        return a.name.localeCompare(b.name, 'zh-CN')
+      }
+      if (aT === null) return 1
+      if (bT === null) return -1
+      if (aT === bT) {
+        return a.name.localeCompare(b.name, 'zh-CN')
+      }
+      return (aT - bT) * direction
+    }
+
+    case 'exportedCount': {
+      const aN = a.exportedMessageCount ?? 0
+      const bN = b.exportedMessageCount ?? 0
+      if (aN === bN) {
+        return a.name.localeCompare(b.name, 'zh-CN')
+      }
+      return (aN - bN) * direction
+    }
+
+    default: {
+      // exhaustive check：新增字段忘了写 case 时 TS 会报错
+      const _exhaustive: never = field
+      void _exhaustive
+      return 0
+    }
+  }
+}
+
+/**
+ * 在指定字段下排序一份会话条目数组（不修改原数组）。
+ */
+export function sortSessionItems<T extends SortableSessionItem>(
+  items: readonly T[],
+  field: SortField,
+  order: SortOrder,
+): T[] {
+  return [...items].sort((a, b) => compareSessionItems(a, b, field, order))
+}
+
+/**
+ * 把 ISO 时间格式化成「相对当前时间」的中文字符串。
+ *
+ * - 5 分钟内：「刚刚」
+ * - 1 小时内：「N 分钟前」
+ * - 24 小时内：「N 小时前」
+ * - 30 天内：「N 天前」
+ * - 12 个月内：「N 个月前」
+ * - 否则：「N 年前」
+ *
+ * 解析失败时返回空字符串，调用方自行决定是否渲染。`now` 参数主要用于
+ * 单测可重现。
+ */
+export function formatRelativeFromNow(
+  iso: string | undefined | null,
+  now: number = Date.now(),
+): string {
+  if (!iso) return ''
+  const t = Date.parse(iso)
+  if (!Number.isFinite(t)) return ''
+  const diffMs = now - t
+  if (diffMs < 0) return '刚刚'
+  const sec = Math.floor(diffMs / 1000)
+  if (sec < 60) return '刚刚'
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min} 分钟前`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr} 小时前`
+  const day = Math.floor(hr / 24)
+  if (day < 30) return `${day} 天前`
+  const mon = Math.floor(day / 30)
+  if (mon < 12) return `${mon} 个月前`
+  const yr = Math.floor(day / 365)
+  return `${yr} 年前`
+}
+
+/**
+ * 紧凑数字格式化，避免徽标里出现 "13427 条" 这种长串：
+ * - <1000：原样
+ * - <10_000：`1.2k`（保留 1 位小数，去掉尾随 0）
+ * - <1_000_000：`12k`
+ * - 否则：`1.2m`
+ */
+export function formatCompactCount(value: number): string {
+  if (!Number.isFinite(value) || value < 0) return '0'
+  if (value < 1000) return String(Math.floor(value))
+  if (value < 10_000) {
+    const v = value / 1000
+    return `${stripTrailingZero(v.toFixed(1))}k`
+  }
+  if (value < 1_000_000) {
+    return `${Math.floor(value / 1000)}k`
+  }
+  const v = value / 1_000_000
+  return `${stripTrailingZero(v.toFixed(1))}m`
+}
+
+function stripTrailingZero(s: string): string {
+  if (!s.includes('.')) return s
+  return s.replace(/\.?0+$/, '')
+}


### PR DESCRIPTION
关 #344 剩余的两条排序需求。

会话列表新增「最近活跃」「已导出消息数」两档排序：

- 「最近活跃」：按 `lastMsgTime` 倒序，行右侧用相对时间小字显示「N 天前 / 刚刚」。
- 「已导出消息数」：按已落库消息条数倒序，行右侧显示「已导出 1.2k 条」。

排序持久化进 `localStorage`（key `qce.sessionSortBy`），刷新后保留。原有「按字母」「按修改时间」两档保留不动。

后端复用既有的 `lastMsgTime` 字段和 `getMessagesCount(taskId)`，不动数据库 schema。前端单测覆盖排序键稳定性 + 持久化读写。本地 unit 195 通过、integration 7 通过。
