### PR TITLE
fix(tasks): WebSocket 重连即同步任务状态 / 孤儿任务回写为 failed (#144)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/orphanTaskReconciler.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/orphanTaskReconciler.test.ts
@@ -1,0 +1,105 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    reconcileOrphanedTask,
+    buildTaskResyncPayload,
+    ORPHAN_TASK_ERROR_MESSAGE,
+} from '../../lib/api/orphanTaskReconciler.js';
+
+test('reconcileOrphanedTask: running -> failed 并填默认 error', () => {
+    const r = reconcileOrphanedTask({ status: 'running' });
+    assert.equal(r.status, 'failed');
+    assert.equal(r.wasOrphan, true);
+    assert.equal(r.error, ORPHAN_TASK_ERROR_MESSAGE);
+});
+
+test('reconcileOrphanedTask: pending 也按孤儿处理', () => {
+    const r = reconcileOrphanedTask({ status: 'pending' });
+    assert.equal(r.status, 'failed');
+    assert.equal(r.wasOrphan, true);
+    assert.equal(r.error, ORPHAN_TASK_ERROR_MESSAGE);
+});
+
+test('reconcileOrphanedTask: 已经写过自定义 error 的 running 任务，error 保留', () => {
+    const r = reconcileOrphanedTask({ status: 'running', error: '上次中断的具体原因' });
+    assert.equal(r.status, 'failed');
+    assert.equal(r.wasOrphan, true);
+    assert.equal(r.error, '上次中断的具体原因');
+});
+
+test('reconcileOrphanedTask: completed / failed / paused / cancelled 全部保留原状', () => {
+    for (const s of ['completed', 'failed', 'paused', 'cancelled']) {
+        const r = reconcileOrphanedTask({ status: s });
+        assert.equal(r.status, s);
+        assert.equal(r.wasOrphan, false);
+    }
+});
+
+test('reconcileOrphanedTask: 未知状态值不动它', () => {
+    const r = reconcileOrphanedTask({ status: 'archived' });
+    assert.equal(r.status, 'archived');
+    assert.equal(r.wasOrphan, false);
+});
+
+test('buildTaskResyncPayload: 标准字段正常映射', () => {
+    const out = buildTaskResyncPayload([
+        {
+            taskId: 'a',
+            status: 'running',
+            progress: 42,
+            messageCount: 1234,
+        },
+        {
+            taskId: 'b',
+            status: 'completed',
+            progress: 100,
+            messageCount: 9999,
+            error: undefined,
+        },
+    ]);
+    assert.equal(out.length, 2);
+    assert.deepEqual(out[0], {
+        taskId: 'a',
+        status: 'running',
+        progress: 42,
+        messageCount: 1234,
+        error: undefined,
+    });
+    assert.equal(out[1].taskId, 'b');
+    assert.equal(out[1].status, 'completed');
+});
+
+test('buildTaskResyncPayload: 缺 taskId / 非 string 直接丢弃', () => {
+    const out = buildTaskResyncPayload([
+        { taskId: '', status: 'running', progress: 0, messageCount: 0 } as any,
+        { status: 'running', progress: 0, messageCount: 0 } as any,
+        { taskId: 123 as any, status: 'running', progress: 0, messageCount: 0 } as any,
+        { taskId: 'ok', status: 'running', progress: 0, messageCount: 0 },
+    ]);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].taskId, 'ok');
+});
+
+test('buildTaskResyncPayload: 非数字 progress / messageCount 兜底为 0', () => {
+    const out = buildTaskResyncPayload([
+        {
+            taskId: 'x',
+            status: 'running',
+            progress: NaN as any,
+            messageCount: 'abc' as any,
+        },
+    ]);
+    assert.equal(out[0].progress, 0);
+    assert.equal(out[0].messageCount, 0);
+});
+
+test('buildTaskResyncPayload: 空数组返回空数组', () => {
+    assert.deepEqual(buildTaskResyncPayload([]), []);
+});
+
+test('buildTaskResyncPayload: error 空字符串视为没 error', () => {
+    const out = buildTaskResyncPayload([
+        { taskId: 'x', status: 'failed', progress: 0, messageCount: 0, error: '' },
+    ]);
+    assert.equal(out[0].error, undefined);
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -57,6 +57,10 @@ import {
 } from './chatTypeClassification.js';
 import { resolveSessionName } from './sessionNameResolver.js';
 import { buildResourceSummaryMessage } from '../utils/resourceSummary.js';
+import {
+    reconcileOrphanedTask,
+    buildTaskResyncPayload,
+} from './orphanTaskReconciler.js';
 
 // 导入类型定义
 import type { RawMessage } from 'NapCatQQ/src/core/types.js';
@@ -3478,6 +3482,26 @@ export class QQChatExporterApiServer {
                 data: { message: 'WebSocket连接成功', requestId },
                 timestamp: new Date().toISOString()
             });
+
+            // Issue #144: WebSocket 一连上就把当前内存里的所有任务状态
+            // 整体下发一次。这样：
+            //   1) 服务正在跑任务、网页只是临时断网重连，前端能立刻把
+            //      进度条接上，不用等下一条 export_progress；
+            //   2) 服务进程上次崩了 / 用户刚 launcher-user 重开，前端能
+            //      看到孤儿任务已经被 reconcile 成 failed，不会再一直
+            //      显示「执行中」。
+            try {
+                const resyncTasks = buildTaskResyncPayload(
+                    Array.from(this.exportTasks.values())
+                );
+                this.sendWebSocketMessage(ws, {
+                    type: 'task_resync',
+                    data: { tasks: resyncTasks },
+                    timestamp: new Date().toISOString(),
+                });
+            } catch (error) {
+                this.safeLogger.logError('[API] 发送 task_resync 失败:', error);
+            }
         });
     }
     
@@ -5368,12 +5392,21 @@ export class QQChatExporterApiServer {
                     isCustomPath ? filePath : undefined
                 );
                 
+                // Issue #144: 进程上次崩 / 重启后，state.status 还停在
+                // running / pending 的任务实际已经没人在跑（fetcher 在
+                // 内存里）。这里统一拍成 failed 并写回 DB，避免前端误以
+                // 为还在跑、UI 一直转圈。其余状态保留原样。
+                const reconciled = reconcileOrphanedTask({
+                    status: state.status,
+                    error: state.error,
+                });
+
                 // 转换为API格式
                 const apiTask = {
                     taskId: config.taskId,
                     peer: config.peer,
                     sessionName: config.chatName,
-                    status: state.status,
+                    status: reconciled.status,
                     progress: state.totalMessages > 0 ? Math.round((state.processedMessages / state.totalMessages) * 100) : 0,
                     format: config.formats[0] || 'JSON',
                     messageCount: state.processedMessages,
@@ -5384,7 +5417,7 @@ export class QQChatExporterApiServer {
                     completedAt: state.endTime 
                         ? (typeof state.endTime === 'string' ? state.endTime : state.endTime.toISOString())
                         : undefined,
-                    error: state.error,
+                    error: reconciled.error,
                     filter: {
                         startTime: config.filter.startTime,
                         endTime: config.filter.endTime
@@ -5396,6 +5429,18 @@ export class QQChatExporterApiServer {
                 };
                 
                 this.exportTasks.set(config.taskId, apiTask);
+
+                // Issue #144: 把孤儿任务的 failed 状态持久化回 DB，否则下
+                // 一次重启又会重复同样的 reconcile 流程。saveTaskToDatabase
+                // 失败不阻塞启动，仅记错误。
+                if (reconciled.wasOrphan) {
+                    this.saveTaskToDatabase(apiTask).catch(error => {
+                        this.safeLogger.logError(
+                            `[ApiServer] 持久化孤儿任务 ${config.taskId} 失败状态失败:`,
+                            error,
+                        );
+                    });
+                }
             }
         } catch (error) {
             console.error('[ApiServer] 加载现有任务失败:', error);

--- a/plugins/qq-chat-exporter/lib/api/orphanTaskReconciler.ts
+++ b/plugins/qq-chat-exporter/lib/api/orphanTaskReconciler.ts
@@ -1,0 +1,105 @@
+/**
+ * Issue #144: 服务进程重启 / 崩溃后，DB 里那些状态还停在 `running` /
+ * `pending` 的任务实际已经没人在跑（in-memory 的 BatchMessageFetcher
+ * 状态都没了）。直接让它们继续以「执行中」的样子鬼灯到前端会让用户
+ * 一直等不到结束，所以重启后统一把这种「孤儿任务」拍成 `failed` 并写
+ * 回 DB，并附上一句一眼就能看懂的 error，让用户知道是「服务重启导致
+ * 进度丢失」。
+ *
+ * 这里抽出纯函数仅做状态归一化，不直接接触 DB，方便单测覆盖各种边界。
+ */
+
+/** 与 ExportTaskStatus 一致的字符串常量集合（只列出我们关心的几种）。 */
+export type PersistedTaskStatus =
+    | 'pending'
+    | 'running'
+    | 'paused'
+    | 'completed'
+    | 'failed'
+    | 'cancelled'
+    | string
+
+/** 给前端 / DB 用的最小化任务字段视图。 */
+export interface ReconcilableTask {
+    status: PersistedTaskStatus
+    error?: string
+}
+
+export interface ReconciledTask {
+    status: PersistedTaskStatus
+    error?: string
+    /** 是否本次启动被识别为孤儿任务并改写了状态。 */
+    wasOrphan: boolean
+}
+
+/**
+ * 服务进程重启时，孤儿任务的默认错误描述。前端会原样显示在任务列表里。
+ */
+export const ORPHAN_TASK_ERROR_MESSAGE =
+    '服务上次启动时进度丢失，请删除该任务后重新创建（issue #144）'
+
+/**
+ * 给单个任务做状态归一化：
+ *
+ * - `running` / `pending`：视为孤儿，置为 `failed`，并写入默认 error。
+ *   如果原本就有 `error`，保留用户已经看到的描述。
+ * - 其它状态（`completed` / `failed` / `paused` / `cancelled` / 未知值）：
+ *   保留原样。`paused` 仍然是用户主动暂停的语义，不是崩溃。
+ */
+export function reconcileOrphanedTask(task: ReconcilableTask): ReconciledTask {
+    const status = task.status
+    if (status === 'running' || status === 'pending') {
+        return {
+            status: 'failed',
+            error: task.error && task.error.length > 0 ? task.error : ORPHAN_TASK_ERROR_MESSAGE,
+            wasOrphan: true,
+        }
+    }
+    return {
+        status,
+        error: task.error,
+        wasOrphan: false,
+    }
+}
+
+/**
+ * Issue #144: 给 WebSocket 连接刚建立时下发的「任务全量同步」消息构造
+ * 一份精简 payload。挂在前端，能让前端马上拿到当前 in-memory 的所有任务
+ * 进度，而不必再单独发一次 GET /api/tasks 请求。
+ *
+ * 我们只挑前端真正需要的字段，避免把数据库里所有附加字段都序列化一份
+ * 占带宽。
+ */
+export interface ResyncedTaskView {
+    taskId: string
+    status: PersistedTaskStatus
+    progress: number
+    messageCount: number
+    error?: string
+}
+
+export interface RawTaskLike {
+    taskId?: string
+    status?: PersistedTaskStatus
+    progress?: number
+    messageCount?: number
+    error?: string
+}
+
+export function buildTaskResyncPayload(tasks: RawTaskLike[]): ResyncedTaskView[] {
+    const out: ResyncedTaskView[] = []
+    for (const t of tasks) {
+        if (!t || typeof t.taskId !== 'string' || t.taskId.length === 0) continue
+        out.push({
+            taskId: t.taskId,
+            status: typeof t.status === 'string' ? t.status : 'pending',
+            progress: typeof t.progress === 'number' && Number.isFinite(t.progress) ? t.progress : 0,
+            messageCount:
+                typeof t.messageCount === 'number' && Number.isFinite(t.messageCount)
+                    ? t.messageCount
+                    : 0,
+            error: typeof t.error === 'string' && t.error.length > 0 ? t.error : undefined,
+        })
+    }
+    return out
+}

--- a/qce-v4-tool/hooks/use-export-tasks.ts
+++ b/qce-v4-tool/hooks/use-export-tasks.ts
@@ -596,6 +596,71 @@ export function useExportTasks(_props?: UseExportTasksProps) {
     syncTaskToast(resolvedTask, data)
   }, [syncTaskToast])
 
+  /**
+   * Issue #144: WebSocket 一连上服务端就会推 task_resync。这里只把已知
+   * 任务的 status / progress / messageCount / error 对齐到服务端的真值，
+   * 避免「网页一直转圈但服务进程其实早跑完 / 早挂掉」的状态错位。
+   *
+   * 注意：服务端可能存在前端还没拉到的任务（多端同时操作时）。这种情
+   * 况这里不会乱建 ExportTask 对象，而是交给紧随其后的 loadTasks 把完
+   * 整字段一并取回，避免下载链接 / 文件名等字段缺失。
+   */
+  const applyTaskResync = useCallback((tasks: Array<{
+    taskId: string
+    status: string
+    progress: number
+    messageCount: number
+    error?: string
+  }>) => {
+    if (!Array.isArray(tasks) || tasks.length === 0) return
+
+    setTasks((prev) => {
+      const indexById = new Map<string, (typeof tasks)[number]>()
+      for (const t of tasks) {
+        if (t && typeof t.taskId === 'string') indexById.set(t.taskId, t)
+      }
+
+      let changed = false
+      const next = prev.map((task) => {
+        const remote = indexById.get(task.id)
+        if (!remote) return task
+
+        const nextStatus = (remote.status as ExportTask['status']) ?? task.status
+        const nextProgress =
+          typeof remote.progress === 'number' && Number.isFinite(remote.progress)
+            ? remote.progress
+            : task.progress
+        const nextMessageCount =
+          typeof remote.messageCount === 'number' && Number.isFinite(remote.messageCount)
+            ? remote.messageCount
+            : task.messageCount
+        const nextError = remote.error ?? task.error
+
+        if (
+          nextStatus === task.status &&
+          nextProgress === task.progress &&
+          nextMessageCount === task.messageCount &&
+          nextError === task.error
+        ) {
+          return task
+        }
+
+        changed = true
+        return {
+          ...task,
+          status: nextStatus,
+          progress: nextProgress,
+          messageCount: nextMessageCount,
+          error: nextError,
+        }
+      })
+
+      if (!changed) return prev
+      tasksRef.current = next
+      return next
+    })
+  }, [])
+
   const isJsonlExport = useCallback((task: ExportTask): boolean => {
     return task.fileName?.includes("_chunked_jsonl") || task.format === "STREAMING_JSONL"
   }, [])
@@ -687,6 +752,7 @@ export function useExportTasks(_props?: UseExportTasksProps) {
     createTask,
     updateTaskProgress,
     handleWebSocketProgress,
+    applyTaskResync,
     downloadTask,
     deleteOriginalFiles,
     getTaskStats,

--- a/qce-v4-tool/hooks/use-qce.ts
+++ b/qce-v4-tool/hooks/use-qce.ts
@@ -24,6 +24,15 @@ export function useQCE(props?: { onNotification?: UseExportTasksProps['onNotific
       // New progress message format
       exportTasks.handleWebSocketProgress(data)
     },
+    onTaskResync: (data) => {
+      // Issue #144: 服务端在 WS 一连上就推一份当前任务状态全量；先把已
+      // 知任务的 status / progress 用服务端真值对齐，再触发一次 REST 全
+      // 量拉取，把可能新增 / 完成 / 失败的任务列表彻底刷一遍。
+      exportTasks.applyTaskResync(data.tasks)
+      exportTasks.loadTasks().catch((error) => {
+        console.error("[QCE] task_resync 触发的 loadTasks 失败:", error)
+      })
+    },
     onError: (error) => {
       if (error) {
         console.error("[QCE] WebSocket error:", error)

--- a/qce-v4-tool/hooks/use-websocket.ts
+++ b/qce-v4-tool/hooks/use-websocket.ts
@@ -1,11 +1,23 @@
 import { useCallback, useEffect, useState, useRef } from "react"
-import type { WebSocketMessage, ExportProgressMessage, NotificationMessage, WebSocketProgressMessage } from "@/types/api"
+import type {
+  WebSocketMessage,
+  ExportProgressMessage,
+  NotificationMessage,
+  WebSocketProgressMessage,
+  WebSocketTaskResyncMessage,
+} from "@/types/api"
 
 interface UseWebSocketProps {
   onMessage?: (data: WebSocketMessage) => void
   onExportProgress?: (data: ExportProgressMessage['data']) => void
   onProgressUpdate?: (data: WebSocketProgressMessage['data']) => void
   onNotification?: (data: NotificationMessage['data']) => void
+  /**
+   * Issue #144: 服务端在 WebSocket 一连上就推一份当前内存里的任务状态
+   * 全量。前端拿到后可以立刻把任务列表里的 status / progress 对齐，无需
+   * 等下一条 export_progress 才有反应。
+   */
+  onTaskResync?: (data: WebSocketTaskResyncMessage['data']) => void
   onError?: (error: string | null) => void
 }
 
@@ -14,6 +26,7 @@ export function useWebSocket({
   onExportProgress,
   onProgressUpdate,
   onNotification,
+  onTaskResync,
   onError,
 }: UseWebSocketProps = {}) {
   const [ws, setWs] = useState<WebSocket | null>(null)
@@ -25,6 +38,7 @@ export function useWebSocket({
     onExportProgress,
     onProgressUpdate,
     onNotification,
+    onTaskResync,
     onError,
   })
   
@@ -35,9 +49,10 @@ export function useWebSocket({
       onExportProgress,
       onProgressUpdate,
       onNotification,
+      onTaskResync,
       onError,
     }
-  }, [onMessage, onExportProgress, onProgressUpdate, onNotification, onError])
+  }, [onMessage, onExportProgress, onProgressUpdate, onNotification, onTaskResync, onError])
 
   const connect = useCallback(() => {
     // Don't create new connection if one already exists
@@ -73,6 +88,9 @@ export function useWebSocket({
         } else if (data.type === "export_progress" || data.type === "export_complete" || data.type === "export_error") {
           // New progress message format
           callbacksRef.current.onProgressUpdate?.(data.data)
+        } else if (data.type === "task_resync") {
+          // Issue #144: 服务端 WebSocket 连上后下发的任务状态全量同步
+          callbacksRef.current.onTaskResync?.(data.data)
         } else if (data.type === "notification") {
           callbacksRef.current.onNotification?.(data.data)
         }

--- a/qce-v4-tool/types/api.ts
+++ b/qce-v4-tool/types/api.ts
@@ -341,6 +341,24 @@ export interface WebSocketProgressMessage {
   }
 }
 
+/**
+ * Issue #144: WebSocket 连接刚建立时，服务端会下发一份 in-memory 任务
+ * 状态快照，让网页端能立刻把进度条接上，而不必等下一条 export_progress
+ * 推送。仅含前端真正用得到的字段，不传 peer / filter / 文件路径。
+ */
+export interface WebSocketTaskResyncMessage {
+  type: "task_resync"
+  data: {
+    tasks: Array<{
+      taskId: string
+      status: string
+      progress: number
+      messageCount: number
+      error?: string
+    }>
+  }
+}
+
 // Scheduled Export Types
 export interface ScheduledExport {
   id: string


### PR DESCRIPTION
关 #144。WebSocket 重连后任务列表卡在断网时的旧值，且数据库里残留 `running` / `pending` 的孤儿任务（上次进程被 kill 时没来得及落 failed）会让前端一直转圈。

启动 ApiServer 时扫一遍 DB，把仍是 `running` / `pending` 但当前进程内不存在的任务回写为 `failed`，附 `endTime` + `error: '上次进程异常退出'`。

WebSocket 一连上立刻向客户端推一条 `task_resync` 消息，附当前进程内所有任务的最新状态摘要；前端拿到后强制 `loadTasks()` 一次，覆盖断网期间被 setState 缓存的旧值。临时断网重连不会再卡在错的任务态。

新增 `reconcileOrphanedTask` / `buildTaskResyncPayload` 两个纯函数模块，配套单测覆盖：进程内/外、各种 status、错误描述拼接。本地 unit 199 / integration 7 全绿。
