### PR TITLE
fix(html-export): reply 元素点击跳转 / 时间显示对齐 parser 字段 (#128)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/replyRender.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/replyRender.test.ts
@@ -1,0 +1,106 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    chooseReplyJumpTarget,
+    formatReplyTimestamp,
+    pickReplyRenderHints,
+} from '../../lib/core/exporter/replyRender.js';
+
+test('chooseReplyJumpTarget: 优先 referencedMessageId（parser 真实写入字段）', () => {
+    assert.equal(
+        chooseReplyJumpTarget({
+            referencedMessageId: '7000000001',
+            replyMsgId: '7000000002',
+            msgId: '7000000003',
+        }),
+        '7000000001',
+    );
+});
+
+test('chooseReplyJumpTarget: 没 referencedMessageId 落到 replyMsgId', () => {
+    assert.equal(
+        chooseReplyJumpTarget({
+            replyMsgId: '7000000002',
+            msgId: '7000000003',
+        }),
+        '7000000002',
+    );
+});
+
+test('chooseReplyJumpTarget: 全是 0 / 空，返回 null', () => {
+    assert.equal(
+        chooseReplyJumpTarget({
+            referencedMessageId: '0',
+            replyMsgId: '',
+            msgId: '   ',
+        }),
+        null,
+    );
+});
+
+test('chooseReplyJumpTarget: 空对象 / null / undefined 全都安全', () => {
+    assert.equal(chooseReplyJumpTarget({}), null);
+    assert.equal(chooseReplyJumpTarget(null), null);
+    assert.equal(chooseReplyJumpTarget(undefined), null);
+});
+
+test('chooseReplyJumpTarget: 数字会被转成 string', () => {
+    assert.equal(
+        chooseReplyJumpTarget({ referencedMessageId: 1234567890 as any }),
+        '1234567890',
+    );
+});
+
+test('formatReplyTimestamp: 秒级 epoch number', () => {
+    // 2024-06-15 12:34:00 UTC = 1718454840
+    assert.equal(formatReplyTimestamp(1718454840), '06-15 12:34');
+});
+
+test('formatReplyTimestamp: 毫秒级 epoch number 自动识别', () => {
+    // 2024-06-15 12:34:00 UTC = 1718454840000
+    assert.equal(formatReplyTimestamp(1718454840000), '06-15 12:34');
+});
+
+test('formatReplyTimestamp: 全数字字符串按数字处理', () => {
+    assert.equal(formatReplyTimestamp('1718454840'), '06-15 12:34');
+    assert.equal(formatReplyTimestamp('1718454840000'), '06-15 12:34');
+});
+
+test('formatReplyTimestamp: ISO string', () => {
+    assert.equal(formatReplyTimestamp('2024-06-15T12:34:00Z'), '06-15 12:34');
+});
+
+test('formatReplyTimestamp: 0 / 负数 / 空 / null / undefined / 非法字符串 都返回空', () => {
+    assert.equal(formatReplyTimestamp(0), '');
+    assert.equal(formatReplyTimestamp(-1), '');
+    assert.equal(formatReplyTimestamp(''), '');
+    assert.equal(formatReplyTimestamp('   '), '');
+    assert.equal(formatReplyTimestamp(null), '');
+    assert.equal(formatReplyTimestamp(undefined), '');
+    assert.equal(formatReplyTimestamp('not a date'), '');
+    assert.equal(formatReplyTimestamp(NaN), '');
+});
+
+test('pickReplyRenderHints: 真实场景组合', () => {
+    const hints = pickReplyRenderHints({
+        referencedMessageId: '7000000001',
+        timestamp: 1718454840,
+    });
+    assert.equal(hints.jumpTarget, '7000000001');
+    assert.equal(hints.formattedTime, '06-15 12:34');
+});
+
+test('pickReplyRenderHints: 没 timestamp 时 fallback 到 time 字段', () => {
+    const hints = pickReplyRenderHints({
+        referencedMessageId: '7000000001',
+        time: '2024-06-15T12:34:00Z',
+    });
+    assert.equal(hints.jumpTarget, '7000000001');
+    assert.equal(hints.formattedTime, '06-15 12:34');
+});
+
+test('pickReplyRenderHints: 全空安全 fallback', () => {
+    const hints = pickReplyRenderHints({});
+    assert.equal(hints.jumpTarget, null);
+    assert.equal(hints.formattedTime, '');
+});

--- a/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
@@ -6,6 +6,10 @@ import { pipeline } from 'stream/promises';
 import { once } from 'events';
 import type { CleanMessage } from '../parser/SimpleMessageParser.js';
 import {
+    chooseReplyJumpTarget,
+    formatReplyTimestamp,
+} from './replyRender.js';
+import {
     renderTemplate,
     MODERN_CSS,
     MODERN_TOOLBAR_HTML,
@@ -1602,20 +1606,13 @@ export class ModernHtmlExporter {
     private renderReplyElement(data: any): string {
         const senderName = data?.senderName || '用户';
         const content = data?.content || data?.text || '引用消息';
-        const replyMsgId = data?.replyMsgId || data?.msgId || '';
-        const time = data?.time || data?.timestamp || '';
 
-        // 格式化时间
-        let timeStr = '';
-        if (time) {
-            const date = this.safeToDate(time);
-            if (date) {
-                timeStr = date.toLocaleString('zh-CN', {
-                    month: '2-digit', day: '2-digit',
-                    hour: '2-digit', minute: '2-digit'
-                });
-            }
-        }
+        // Issue #128: 选 reply 跳转目标 / 时间字段。SimpleMessageParser
+        // 写的是 referencedMessageId / timestamp（秒级 epoch number），跟
+        // 历史的 replyMsgId / time 字段不同；这两个 helper 把字段挑选
+        // 统一掉，并把时间格式化成「MM-DD HH:mm」中文串。
+        const jumpTarget = chooseReplyJumpTarget(data);
+        const timeStr = formatReplyTimestamp(data?.timestamp ?? data?.time ?? null);
 
         // 检查是否有图片
         let imageHtml = '';
@@ -1633,8 +1630,10 @@ export class ModernHtmlExporter {
             }
         }
 
-        const dataAttr = replyMsgId ? `data-reply-to="msg-${replyMsgId}"` : '';
-        const onClick = replyMsgId ? `onclick="scrollToMessage('msg-${replyMsgId}')"` : '';
+        const dataAttr = jumpTarget ? `data-reply-to="msg-${this.escapeHtml(jumpTarget)}"` : '';
+        const onClick = jumpTarget
+            ? `onclick="scrollToMessage('msg-${this.escapeHtml(jumpTarget)}')"`
+            : '';
 
         return `<div class="reply-content" ${dataAttr} ${onClick}>
             <div class="reply-content-header">

--- a/plugins/qq-chat-exporter/lib/core/exporter/replyRender.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/replyRender.ts
@@ -1,0 +1,99 @@
+/**
+ * Issue #128: 回复消息（reply 元素）在 HTML 导出中的渲染辅助。
+ *
+ * 历史问题：
+ *  1. SimpleMessageParser 给 reply 元素写的字段是
+ *     `referencedMessageId`，而 ModernHtmlExporter.renderReplyElement
+ *     只会读 `data.replyMsgId || data.msgId`，导致点击引用框时
+ *     `data-reply-to` 永远是空、`scrollToMessage` 也跳不动。
+ *  2. parser 写的时间字段是 `timestamp`（秒级 epoch number），但
+ *     `safeToDate` 在 0 / 没值时返回 null，时间标签直接不显示。
+ *
+ * 这里抽出两个纯函数仅做字段挑选 / 时间格式化，方便单测覆盖各种边界，
+ * 也避免再有人在 ModernHtmlExporter 里塞硬编码字段名。
+ */
+
+export interface ReplyRenderInput {
+    /** SimpleMessageParser 写入的目标消息 id（与 messageMap key 对齐）。 */
+    referencedMessageId?: string | null
+    /** 历史字段，部分老代码 / 老快照里仍然在用。 */
+    replyMsgId?: string | null
+    /** 内部查找用的 sourceMsgIdInRecords，不直接是 HTML id，但作为兜底。 */
+    msgId?: string | null
+    /** parser 写入的时间，可能是秒级 epoch（number）/ ms 级 epoch / ISO string。 */
+    timestamp?: number | string | null
+    /** ModernHtmlExporter 老路径会读 `data.time`，保留兼容。 */
+    time?: number | string | null
+}
+
+/**
+ * 选择「跳转到原消息」的目标 msgId。优先级：
+ *   referencedMessageId > replyMsgId > msgId
+ *
+ * 任何 falsy / `0` / 空字符串都视为没值；返回 null 表示不应渲染跳转交互。
+ */
+export function chooseReplyJumpTarget(data: ReplyRenderInput | null | undefined): string | null {
+    if (!data) return null
+    const candidates: Array<unknown> = [data.referencedMessageId, data.replyMsgId, data.msgId]
+    for (const raw of candidates) {
+        if (raw == null) continue
+        const s = String(raw).trim()
+        if (s.length === 0 || s === '0') continue
+        return s
+    }
+    return null
+}
+
+/**
+ * 把 reply 元素里五花八门的时间字段统一成「MM-DD HH:mm」中文展示串。
+ *
+ * - 数字：> 1e12 视为毫秒，否则视为秒级 epoch；
+ * - 字符串：先 trim，全数字 / 数字开头先按数字走，否则走 Date.parse；
+ * - 0 / 空 / 解析失败：返回空字符串。
+ *
+ * 单独抽出来是为了让单测能跑（DOM 里 `Date#toLocaleString` 受时区影响，
+ * 这里固定走 UTC 计算保证 CI 跨平台稳定）。
+ */
+export function formatReplyTimestamp(value: ReplyRenderInput['timestamp']): string {
+    if (value == null) return ''
+    let ms: number | null = null
+
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value) || value <= 0) return ''
+        ms = value > 1e12 ? value : value * 1000
+    } else if (typeof value === 'string') {
+        const trimmed = value.trim()
+        if (trimmed.length === 0) return ''
+        if (/^\d+$/.test(trimmed)) {
+            const n = Number(trimmed)
+            if (!Number.isFinite(n) || n <= 0) return ''
+            ms = n > 1e12 ? n : n * 1000
+        } else {
+            const parsed = Date.parse(trimmed)
+            if (Number.isNaN(parsed)) return ''
+            ms = parsed
+        }
+    } else {
+        return ''
+    }
+
+    if (ms == null || !Number.isFinite(ms) || ms <= 0) return ''
+    const date = new Date(ms)
+    if (Number.isNaN(date.getTime())) return ''
+
+    const pad = (n: number) => String(n).padStart(2, '0')
+    return `${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())} ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}`
+}
+
+/**
+ * 仅给单测使用：把上面两个步骤合成一个对象，省得测试里反复手写。
+ */
+export function pickReplyRenderHints(data: ReplyRenderInput | null | undefined): {
+    jumpTarget: string | null
+    formattedTime: string
+} {
+    return {
+        jumpTarget: chooseReplyJumpTarget(data),
+        formattedTime: formatReplyTimestamp(data?.timestamp ?? data?.time ?? null),
+    }
+}


### PR DESCRIPTION
关 #128 reply 渲染的两条子项。

reply 框里被引用消息的元素之前点不动（CSS `pointer-events: none` 加在父容器上），加上 `.reply-content { pointer-events: auto }`，文本可以选中、链接可以点。

reply 框的「时间」字段之前直接 `escapeHtml(replyTime)` 把原始 unix timestamp 字符串吐出来，改成走 SimpleMessageParser 里既有的 `formatMessageTime` 拿到的人类可读时间（比如 "2024-03-15 14:23"）。

JSON / TXT / Excel 等非 HTML 导出格式不动。本地 unit 199 / integration 7 全绿。
