### PR TITLE
feat(gallery): 资源画廊里的音视频/文件 tile 直接显示文件名 (#294)

### DIFF
--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -2231,6 +2231,17 @@ export default function QCEDashboard() {
                               </div>
                             )}
                             <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors" />
+                            {/* issue #294 子项 3：音视频/文件 tile 直接把文件名摆在底栏，
+                                免得用户必须点开才能看出来这是哪个资源。图片自身就说明
+                                了内容，不强制塞文件名。 */}
+                            {file.type !== 'image' && file.fileName && (
+                              <div
+                                className="absolute inset-x-0 bottom-0 px-1.5 py-1 bg-gradient-to-t from-black/55 to-transparent text-[10px] leading-tight text-white truncate"
+                                title={file.fileName}
+                              >
+                                {file.fileName}
+                              </div>
+                            )}
                           </div>
                         ))}
                       </div>


### PR DESCRIPTION
关 #294 子项 3。资源画廊里非图片资源（音乐 / 视频 / 文件）之前只露一个图标，长列表里完全没法定位。给非图片 tile 在底部加一条渐变字幕栏，把 fileName 直接显示出来，配合 `title` 属性给浏览器自带 tooltip 兜底长名截断。

图片 tile 不动 — 图片本身就是它要表达的内容，硬塞文件名反而会盖住主体；预览模态框里的文件名也已经在了。

#294 剩余子项另开 PR：

- 资源画廊 / 聊天记录内按 QQ 号筛选（需要存储层多账号 attribution）
- 查看同对象的聊天记录中加入资源画廊（需要 `/api/resources/files` 加 peer / session 过滤）
- 独立模式资源画廊接入

仅前端改动，CI 自动跑前端构建。
