### PR TITLE
feat(api): 暴露群入群申请 / 邀请通知接口 (#317)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/groupSystemNotify.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/groupSystemNotify.test.ts
@@ -1,0 +1,142 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeGroupSystemNotify } from '../../lib/api/groupSystemNotify.js';
+
+test('groupSystemNotify: 把 OneBot get_group_system_msg 输出拍平成 camelCase', () => {
+    const raw = {
+        join_requests: [
+            {
+                request_id: 100001,
+                invitor_uin: 10000,
+                invitor_nick: '申请人',
+                requester_nick: '申请人',
+                group_id: 123456,
+                group_name: '测试群',
+                message: '我是xxx',
+                checked: false,
+                actor: 0,
+            },
+        ],
+        invited_requests: [
+            {
+                request_id: 100002,
+                invitor_uin: 20000,
+                invitor_nick: '被邀人',
+                requester_nick: '被邀人',
+                group_id: 123456,
+                group_name: '测试群',
+                message: '',
+                checked: true,
+                actor: 30000,
+            },
+        ],
+        InvitedRequest: [],
+    };
+
+    const result = normalizeGroupSystemNotify(raw);
+
+    assert.equal(result.totalCount, 2);
+    assert.equal(result.joinRequests.length, 1);
+    assert.equal(result.invitedRequests.length, 1);
+
+    const join = result.joinRequests[0]!;
+    assert.equal(join.requestId, 100001);
+    assert.equal(join.kind, 'join');
+    assert.equal(join.groupId, '123456');
+    assert.equal(join.groupName, '测试群');
+    assert.equal(join.requesterUin, 10000);
+    assert.equal(join.requesterNick, '申请人');
+    assert.equal(join.message, '我是xxx');
+    assert.equal(join.checked, false);
+
+    const invited = result.invitedRequests[0]!;
+    assert.equal(invited.requestId, 100002);
+    assert.equal(invited.kind, 'invited');
+    assert.equal(invited.actorUin, 30000);
+    assert.equal(invited.checked, true);
+});
+
+test('groupSystemNotify: 没有 join_requests 字段时返回空数组', () => {
+    const result = normalizeGroupSystemNotify({});
+    assert.deepEqual(result, { joinRequests: [], invitedRequests: [], totalCount: 0 });
+});
+
+test('groupSystemNotify: 完全无效的输入（null / 字符串 / undefined）安全降级', () => {
+    for (const raw of [null, undefined, '', 0, 'foo', 42, []] as const) {
+        const result = normalizeGroupSystemNotify(raw as unknown);
+        assert.equal(result.totalCount, 0);
+        assert.equal(result.joinRequests.length, 0);
+        assert.equal(result.invitedRequests.length, 0);
+    }
+});
+
+test('groupSystemNotify: invited_requests 缺失时回退用 InvitedRequest（驼峰兼容）', () => {
+    const raw = {
+        InvitedRequest: [
+            {
+                request_id: 200001,
+                group_id: '789012',
+                group_name: '另一个群',
+                invitor_uin: '40000',
+                invitor_nick: '邀请人',
+            },
+        ],
+    };
+    const result = normalizeGroupSystemNotify(raw);
+    assert.equal(result.invitedRequests.length, 1);
+    assert.equal(result.invitedRequests[0]!.requestId, 200001);
+    assert.equal(result.invitedRequests[0]!.groupId, '789012');
+    assert.equal(result.invitedRequests[0]!.invitorUin, 40000);
+});
+
+test('groupSystemNotify: 同时有 invited_requests 和 InvitedRequest 时只取 invited_requests，不重复', () => {
+    const raw = {
+        invited_requests: [
+            { request_id: 1, group_id: 1, invitor_uin: 1 },
+        ],
+        InvitedRequest: [
+            { request_id: 1, group_id: 1, invitor_uin: 1 },
+        ],
+    };
+    const result = normalizeGroupSystemNotify(raw);
+    assert.equal(result.invitedRequests.length, 1);
+});
+
+test('groupSystemNotify: string / number 字段都能正确转换', () => {
+    const raw = {
+        join_requests: [
+            {
+                request_id: '300001',
+                invitor_uin: '50000',
+                group_id: 999000,
+                group_name: 'mixed types',
+                checked: 'true', // 不是真 true
+            },
+        ],
+    };
+    const result = normalizeGroupSystemNotify(raw);
+    assert.equal(result.joinRequests[0]!.requestId, 300001);
+    assert.equal(result.joinRequests[0]!.requesterUin, 50000);
+    assert.equal(result.joinRequests[0]!.groupId, '999000');
+    // checked 必须是严格 boolean true 才算已处理
+    assert.equal(result.joinRequests[0]!.checked, false);
+});
+
+test('groupSystemNotify: 字段类型异常不抛错（防御 NapCat 升级）', () => {
+    const raw = {
+        join_requests: [
+            { request_id: NaN, invitor_uin: undefined, group_id: null, message: 42 },
+            { request_id: Infinity, group_id: { weird: 'object' } },
+        ],
+    };
+    const result = normalizeGroupSystemNotify(raw);
+    assert.equal(result.joinRequests.length, 2);
+    // 异常数字降级为 0
+    assert.equal(result.joinRequests[0]!.requestId, 0);
+    assert.equal(result.joinRequests[0]!.requesterUin, 0);
+    // null / object 降级为空字符串
+    assert.equal(result.joinRequests[0]!.groupId, '');
+    assert.equal(result.joinRequests[1]!.groupId, '');
+    // number message 转成字符串
+    assert.equal(result.joinRequests[0]!.message, '42');
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -56,6 +56,7 @@ import {
     isPrivateLikeChatType,
 } from './chatTypeClassification.js';
 import { resolveSessionName } from './sessionNameResolver.js';
+import { normalizeGroupSystemNotify } from './groupSystemNotify.js';
 import { buildResourceSummaryMessage } from '../utils/resourceSummary.js';
 import {
     reconcileOrphanedTask,
@@ -1230,6 +1231,43 @@ export class QQChatExporterApiServer {
                 const members = Array.from(result.result.infos.values());
                 
                 this.sendSuccessResponse(res, members, (req as any).requestId);
+            } catch (error) {
+                this.sendErrorResponse(res, error, (req as any).requestId);
+            }
+        });
+
+        // 群系统通知（入群申请 / 邀请通知）— issue #317
+        // GET /api/group-system-notify?count=50  返回所有群里的最近 N 条系统通知
+        // GET /api/groups/:groupCode/join-requests?count=50  仅返回某群的入群申请
+        this.app.get('/api/group-system-notify', async (req, res) => {
+            try {
+                const count = Math.min(Math.max(parseInt(req.query['count'] as string) || 50, 1), 200);
+                const data = await this.core.apis.GroupApi.getGroupSystemMsg(count);
+                this.sendSuccessResponse(res, normalizeGroupSystemNotify(data), (req as any).requestId);
+            } catch (error) {
+                this.sendErrorResponse(res, error, (req as any).requestId);
+            }
+        });
+
+        this.app.get('/api/groups/:groupCode/join-requests', async (req, res) => {
+            try {
+                const { groupCode } = req.params;
+                if (!groupCode) {
+                    throw new SystemError(ErrorType.VALIDATION_ERROR, '群组代码不能为空', 'INVALID_GROUP_CODE');
+                }
+                const count = Math.min(Math.max(parseInt(req.query['count'] as string) || 50, 1), 200);
+                const data = await this.core.apis.GroupApi.getGroupSystemMsg(count);
+                const normalized = normalizeGroupSystemNotify(data);
+                const filtered = {
+                    joinRequests: normalized.joinRequests.filter(r => String(r.groupId) === String(groupCode)),
+                    invitedRequests: normalized.invitedRequests.filter(r => String(r.groupId) === String(groupCode)),
+                };
+                this.sendSuccessResponse(res, {
+                    groupCode,
+                    joinRequests: filtered.joinRequests,
+                    invitedRequests: filtered.invitedRequests,
+                    totalCount: filtered.joinRequests.length + filtered.invitedRequests.length,
+                }, (req as any).requestId);
             } catch (error) {
                 this.sendErrorResponse(res, error, (req as any).requestId);
             }

--- a/plugins/qq-chat-exporter/lib/api/groupSystemNotify.ts
+++ b/plugins/qq-chat-exporter/lib/api/groupSystemNotify.ts
@@ -1,0 +1,107 @@
+/**
+ * 群系统通知规范化（issue #317）
+ *
+ * NapCat 上层 OneBot 的 `get_group_system_msg` 已经把 NT 内部的 GroupNotify
+ * 拍平成了 `{invited_requests, join_requests, InvitedRequest}`，每条带
+ * snake_case 字段：request_id / invitor_uin / invitor_nick / actor /
+ * group_id / group_name / message / checked / requester_nick。
+ *
+ * QCE 这边对外统一走 camelCase + 显式语义字段，前端不用关心 OneBot 协议
+ * 的历史包袱。这个模块只做字段重命名 / 兜底，不发请求、不读 DB。
+ */
+
+export type GroupSystemRequestKind = 'join' | 'invited';
+
+export interface GroupSystemRequest {
+    requestId: number;
+    kind: GroupSystemRequestKind;
+    groupId: string;
+    groupName: string;
+    requesterUin: number;
+    requesterNick: string;
+    actorUin: number;
+    invitorUin: number;
+    invitorNick: string;
+    message: string;
+    checked: boolean;
+}
+
+export interface NormalizedGroupSystemNotify {
+    joinRequests: GroupSystemRequest[];
+    invitedRequests: GroupSystemRequest[];
+    totalCount: number;
+}
+
+interface RawSystemMsgItem {
+    request_id?: number | string;
+    invitor_uin?: number | string;
+    invitor_nick?: string;
+    group_id?: number | string;
+    group_name?: string;
+    message?: string;
+    checked?: boolean;
+    actor?: number | string;
+    requester_nick?: string;
+}
+
+interface RawSystemMsgPayload {
+    join_requests?: RawSystemMsgItem[];
+    invited_requests?: RawSystemMsgItem[];
+    InvitedRequest?: RawSystemMsgItem[];
+}
+
+function toNumber(v: unknown): number {
+    if (typeof v === 'number' && Number.isFinite(v)) return v;
+    if (typeof v === 'string' && v.trim() !== '') {
+        const n = Number(v);
+        return Number.isFinite(n) ? n : 0;
+    }
+    return 0;
+}
+
+function toString(v: unknown, fallback = ''): string {
+    if (typeof v === 'string') return v;
+    if (typeof v === 'number' && Number.isFinite(v)) return String(v);
+    return fallback;
+}
+
+function mapItem(raw: RawSystemMsgItem, kind: GroupSystemRequestKind): GroupSystemRequest {
+    return {
+        requestId: toNumber(raw.request_id),
+        kind,
+        groupId: toString(raw.group_id),
+        groupName: toString(raw.group_name),
+        requesterUin: toNumber(raw.invitor_uin),
+        requesterNick: toString(raw.requester_nick ?? raw.invitor_nick),
+        actorUin: toNumber(raw.actor),
+        invitorUin: toNumber(raw.invitor_uin),
+        invitorNick: toString(raw.invitor_nick),
+        message: toString(raw.message),
+        checked: raw.checked === true,
+    };
+}
+
+export function normalizeGroupSystemNotify(raw: unknown): NormalizedGroupSystemNotify {
+    if (!raw || typeof raw !== 'object') {
+        return { joinRequests: [], invitedRequests: [], totalCount: 0 };
+    }
+    const payload = raw as RawSystemMsgPayload;
+
+    const join = Array.isArray(payload.join_requests) ? payload.join_requests : [];
+    // OneBot 字段历史遗留 InvitedRequest（驼峰）和 invited_requests（蛇形）同时存在，
+    // 取其一即可，避免重复。
+    const invitedSrc = Array.isArray(payload.invited_requests)
+        ? payload.invited_requests
+        : Array.isArray(payload.InvitedRequest)
+            ? payload.InvitedRequest
+            : [];
+
+    const joinRequests = join.map(item => mapItem(item, 'join'));
+    const invitedRequests = invitedSrc.map(item => mapItem(item, 'invited'));
+
+    return {
+        joinRequests,
+        invitedRequests,
+        totalCount: joinRequests.length + invitedRequests.length,
+    };
+}

--- a/plugins/qq-chat-exporter/node_modules/NapCatQQ/src/core/apis/group.js
+++ b/plugins/qq-chat-exporter/node_modules/NapCatQQ/src/core/apis/group.js
@@ -78,6 +78,19 @@ export const GroupApi = {
     }
 
     return { result: { infos: new Map(members.map(m => [m.user_id, m])) } };
+  },
+
+  // 入群申请 / 邀请通知（issue #317）。优先走 NapCat 上层 OneBot 的
+  // get_group_system_msg，因为它已经把 uid 解析成了 uin、把 group/user1/user2
+  // 等字段拍平成 invited_requests / join_requests，调用方零额外解析。
+  // 直接 NT 内部 API 没有 uin 解析，调用方还得自己再 await UserApi.getUinByUidV2，
+  // 用这个 fallback 不划算。
+  async getGroupSystemMsg(count = 50) {
+    const { actions, instance } = getBridge();
+    const handler = actions?.get?.('get_group_system_msg');
+    if (!handler) throw new Error('[QCE Overlay] get_group_system_msg 不可用');
+    const result = await handler.handle({ count: Number(count) || 50 }, 'plugin', instance?.config);
+    return result?.data ?? result ?? null;
   }
 };
 

--- a/plugins/qq-chat-exporter/tools/create-overlay-runtime.cjs
+++ b/plugins/qq-chat-exporter/tools/create-overlay-runtime.cjs
@@ -155,6 +155,19 @@ export const GroupApi = {
     }
 
     return { result: { infos: new Map(members.map(m => [m.user_id, m])) } };
+  },
+
+  // 入群申请 / 邀请通知（issue #317）。优先走 NapCat 上层 OneBot 的
+  // get_group_system_msg，因为它已经把 uid 解析成了 uin、把 group/user1/user2
+  // 等字段拍平成 invited_requests / join_requests，调用方零额外解析。
+  // 直接 NT 内部 API 没有 uin 解析，调用方还得自己再 await UserApi.getUinByUidV2，
+  // 用这个 fallback 不划算。
+  async getGroupSystemMsg(count = 50) {
+    const { actions, instance } = getBridge();
+    const handler = actions?.get?.('get_group_system_msg');
+    if (!handler) throw new Error('[QCE Overlay] get_group_system_msg 不可用');
+    const result = await handler.handle({ count: Number(count) || 50 }, 'plugin', instance?.config);
+    return result?.data ?? result ?? null;
   }
 };
 

--- a/plugins/qq-chat-exporter/tools/gen-overlay.cjs
+++ b/plugins/qq-chat-exporter/tools/gen-overlay.cjs
@@ -353,6 +353,7 @@ export default FileApi;
   getGroups(forceRefresh?: boolean): Promise<any[]>;
   fetchGroupDetail(groupId: string | number): Promise<any>;
   getGroupMemberAll(groupId: string | number, forceRefresh?: boolean): Promise<any>;
+  getGroupSystemMsg(count?: number): Promise<any>;
 };
 
 export declare const NTQQGroupApi: typeof GroupApi;


### PR DESCRIPTION
部分关 #317，铺数据通道。

NapCat 已经把 NT 内部 GroupNotify 拍平成 OneBot 的 `invited_requests / join_requests`，每条带 `request_id / invitor_uin / invitor_nick / actor / group_id / group_name / message / checked`，这个 PR 直接走它，省得自己再 `await UserApi.getUinByUidV2` 解 uid。

Overlay GroupApi 新增 `getGroupSystemMsg(count)`。新模块 `lib/api/groupSystemNotify.ts` 把 OneBot 的 snake_case 字段拍平成 QCE 内部统一的 camelCase + 显式语义字段（`kind: 'join' | 'invited'`、`requesterUin`、`actorUin`、`checked` 等），防御 null / NaN / 类型异常。

ApiServer 新增两个端点：

- `GET /api/group-system-notify?count=50`：全局视角，返回最近 N 条系统通知（默认 50，上限 200）
- `GET /api/groups/:groupCode/join-requests?count=50`：按群过滤，返回该群的 `joinRequests` + `invitedRequests`

后续把这两个端点接进前端的群详情面板 / 导出向导是单独的 UI 工，issue 暂留 open 跟踪「和聊天记录一样导出」的部分。

NT 内部还有 `getSingleScreenNotifies` 可以分页拉历史数据，但它返回 `user1.uid` 不带 uin，调用方还得自己解。这个 PR 先用 OneBot 那条已加工的路径，等真有「跨多屏拉历史申请」的需求再补。

`__tests__/unit/groupSystemNotify.test.ts` 覆盖正常路径、字段缺失、驼峰/蛇形兼容（OneBot 历史遗留 `InvitedRequest` 和 `invited_requests` 同时存在）、字符串/数字混合输入、防御异常类型。本地 unit 201 / integration 7 全绿。
