### PR TITLE
fix(html-export): reply 框图片渲染成缩略图 (#128 子项)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/SimpleMessageParser.replyPreview.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/SimpleMessageParser.replyPreview.test.ts
@@ -1,0 +1,149 @@
+/**
+ * issue #128 子项：reply 元素的 previewElements 字段。
+ *
+ * 这里只覆盖 backfillReplyPreviewLocalPaths 的行为：在所有消息的资源
+ * 路径已经被写好之后，回头把 reply 元素引用到的图片也补上 localPath。
+ *
+ * extractReplyContent 自身需要 NapCat overlay 的 messageMap 上下文，跨进程
+ * mock 比较重，所以这里直接构造 CleanMessage 列表 + 手工填好 elements 来
+ * 校验 backfill 的匹配规则（md5 优先、其次顺序、缺失留空）。
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { SimpleMessageParser, type CleanMessage } from '../../lib/core/parser/SimpleMessageParser.js';
+
+function makeImageMessage(id: string, images: Array<{ md5: string; localPath: string }>): CleanMessage {
+    return {
+        id,
+        seq: id,
+        timestamp: 1700000000,
+        time: '2023-11-14T22:13:20Z',
+        sender: { uid: 'u_1', name: 'A' },
+        type: 'normal',
+        content: {
+            text: '',
+            html: '',
+            elements: images.map((img) => ({
+                type: 'image',
+                data: { filename: 'pic', md5: img.md5, localPath: img.localPath, url: `resources/${img.localPath}` },
+            })),
+            resources: [],
+            mentions: [],
+        },
+        recalled: false,
+        system: false,
+    };
+}
+
+function makeReplyMessage(
+    id: string,
+    referencedMessageId: string,
+    previewElements: any[],
+): CleanMessage {
+    return {
+        id,
+        seq: id,
+        timestamp: 1700000001,
+        time: '2023-11-14T22:13:21Z',
+        sender: { uid: 'u_2', name: 'B' },
+        type: 'normal',
+        content: {
+            text: '[图片]',
+            html: '',
+            elements: [
+                {
+                    type: 'reply',
+                    data: {
+                        messageId: id,
+                        referencedMessageId,
+                        senderName: 'A',
+                        content: '[图片]',
+                        timestamp: 1700000000,
+                        previewElements,
+                    },
+                },
+            ],
+            resources: [],
+            mentions: [],
+        },
+        recalled: false,
+        system: false,
+    };
+}
+
+test('backfillReplyPreviewLocalPaths: md5 命中时把 localPath 拉过来', () => {
+    const parser = new SimpleMessageParser();
+    const original = makeImageMessage('100', [
+        { md5: 'aaa', localPath: 'images/aaa.jpg' },
+    ]);
+    const reply = makeReplyMessage('101', '100', [
+        { type: 'image', text: '[图片]', md5: 'aaa', originUrl: 'http://q.qq/aaa', fileName: 'a.jpg' },
+    ]);
+    parser.backfillReplyPreviewLocalPaths([original, reply]);
+    const previewElements = (reply.content.elements[0]!.data as any).previewElements;
+    assert.equal(previewElements[0].localPath, 'images/aaa.jpg');
+});
+
+test('backfillReplyPreviewLocalPaths: md5 缺失时按顺序匹配', () => {
+    const parser = new SimpleMessageParser();
+    const original = makeImageMessage('100', [
+        { md5: 'aaa', localPath: 'images/aaa.jpg' },
+        { md5: 'bbb', localPath: 'images/bbb.jpg' },
+    ]);
+    const reply = makeReplyMessage('101', '100', [
+        { type: 'text', text: 'hi' },
+        { type: 'image', text: '[图片]' },
+        { type: 'image', text: '[图片]' },
+    ]);
+    parser.backfillReplyPreviewLocalPaths([original, reply]);
+    const previewElements = (reply.content.elements[0]!.data as any).previewElements;
+    // text 不动
+    assert.equal(previewElements[0].localPath, undefined);
+    // 第一个 image 拿 fallbackIdx=0 的 localPath
+    assert.equal(previewElements[1].localPath, 'images/aaa.jpg');
+    // 第二个 image 拿 fallbackIdx=1 的 localPath（注意 fallbackIdx 在每个 image 后都自增）
+    assert.equal(previewElements[2].localPath, 'images/bbb.jpg');
+});
+
+test('backfillReplyPreviewLocalPaths: 引用消息不在导出范围内时不写 localPath', () => {
+    const parser = new SimpleMessageParser();
+    const reply = makeReplyMessage('101', '999', [
+        { type: 'image', text: '[图片]', md5: 'xxx', originUrl: 'http://q.qq/xxx' },
+    ]);
+    parser.backfillReplyPreviewLocalPaths([reply]);
+    const previewElements = (reply.content.elements[0]!.data as any).previewElements;
+    assert.equal(previewElements[0].localPath, undefined);
+    // originUrl 仍然保留，让 HTML 端走 onerror 兜底
+    assert.equal(previewElements[0].originUrl, 'http://q.qq/xxx');
+});
+
+test('backfillReplyPreviewLocalPaths: previewElements 缺失或非数组时不爆', () => {
+    const parser = new SimpleMessageParser();
+    const reply: CleanMessage = makeReplyMessage('101', '100', []);
+    (reply.content.elements[0]!.data as any).previewElements = null;
+    const original = makeImageMessage('100', [{ md5: 'aaa', localPath: 'images/aaa.jpg' }]);
+    parser.backfillReplyPreviewLocalPaths([original, reply]);
+    // 不抛异常即可
+    assert.equal((reply.content.elements[0]!.data as any).previewElements, null);
+});
+
+test('backfillReplyPreviewLocalPaths: 空 messages 列表直接 no-op', () => {
+    const parser = new SimpleMessageParser();
+    parser.backfillReplyPreviewLocalPaths([]);
+    // 不抛异常即可
+    assert.ok(true);
+});
+
+test('backfillReplyPreviewLocalPaths: 原消息没图片资源时不动 reply', () => {
+    const parser = new SimpleMessageParser();
+    const original: CleanMessage = makeImageMessage('100', []);
+    // 故意把 elements 都搞掉，确保不会 build 出 imagesByMsgId
+    original.content.elements = [{ type: 'text', data: { content: 'hi' } }];
+    const reply = makeReplyMessage('101', '100', [
+        { type: 'image', text: '[图片]', md5: 'aaa' },
+    ]);
+    parser.backfillReplyPreviewLocalPaths([original, reply]);
+    const previewElements = (reply.content.elements[0]!.data as any).previewElements;
+    assert.equal(previewElements[0].localPath, undefined);
+});

--- a/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
@@ -1614,20 +1614,56 @@ export class ModernHtmlExporter {
         const jumpTarget = chooseReplyJumpTarget(data);
         const timeStr = formatReplyTimestamp(data?.timestamp ?? data?.time ?? null);
 
-        // 检查是否有图片
-        let imageHtml = '';
-        if (data?.imageUrl || data?.image) {
-            const imgSrc = data?.imageUrl || data?.image;
-            imageHtml = `<img src="${imgSrc}" class="reply-content-image" alt="引用图片">`;
-        } else if (String(content).includes('[图片]') && data?.elements) {
-            // 尝试从elements中找到图片
-            const imgElement = data.elements.find((el: any) => el?.type === 'image');
-            if (imgElement?.data?.localPath) {
-                const baseName = path.basename(imgElement.data.localPath);
-                const dataUri = this.lookupDataUri('images', baseName);
-                const imgSrc = dataUri || `${this.resourceBaseHref}/images/${baseName}`;
-                imageHtml = `<img src="${imgSrc}" class="reply-content-image" alt="引用图片" loading="lazy">`;
+        // Issue #128 子项：被引用消息里如果带图片 / 表情，HTML 里把它们当
+        // 缩略图渲染出来，纯文字部分用 escape 后的 text 拼接。previewElements
+        // 是 SimpleMessageParser 在 referencedMessage 命中后写进来的结构化
+        // 数组（updateResourcePaths 里又跑了一遍 backfillReplyPreviewLocalPaths
+        // 把 image 的 localPath 拉齐）。命中时整段 reply-content-text 都换成
+        // 缩略图 + 文本混排，免去再跟 `[图片]` 占位符贴一次。
+        const previewElements: any[] = Array.isArray(data?.previewElements) ? data.previewElements : [];
+        let bodyHtml: string;
+        if (previewElements.length > 0) {
+            const parts: string[] = [];
+            for (const pe of previewElements) {
+                if (!pe || typeof pe !== 'object') continue;
+                if (pe.type === 'image') {
+                    const localPath: string = pe.localPath || '';
+                    if (localPath) {
+                        const baseName = path.basename(localPath);
+                        const dataUri = this.lookupDataUri('images', baseName);
+                        const imgSrc = dataUri || `${this.resourceBaseHref}/${localPath}`;
+                        parts.push(`<img src="${imgSrc}" class="reply-content-thumb" alt="引用图片" loading="lazy">`);
+                    } else if (pe.originUrl) {
+                        // 兜底：原消息没在导出范围内，但 NT 给了带签名的 originImageUrl。
+                        // QQ 的 URL 会过期、可能跨域；标 onerror 让浏览器在加载失败时退回到 [图片] 文本。
+                        const url = String(pe.originUrl);
+                        parts.push(`<img src="${this.escapeHtml(url)}" class="reply-content-thumb" alt="引用图片" loading="lazy" onerror="this.replaceWith(document.createTextNode('[图片]'))">`);
+                    } else {
+                        parts.push(this.escapeHtml(pe.text || '[图片]'));
+                    }
+                } else if (pe.type === 'marketFace' && pe.url) {
+                    parts.push(`<img src="${this.escapeHtml(String(pe.url))}" class="reply-content-emoji" alt="${this.escapeHtml(pe.faceName || '表情')}" loading="lazy">`);
+                } else {
+                    parts.push(this.escapeHtml(pe.text || ''));
+                }
             }
+            bodyHtml = parts.join('');
+        } else {
+            // 兼容老路径：data.imageUrl / data.elements 上有人手动塞过的图片
+            let imageHtml = '';
+            if (data?.imageUrl || data?.image) {
+                const imgSrc = data?.imageUrl || data?.image;
+                imageHtml = `<img src="${imgSrc}" class="reply-content-thumb" alt="引用图片">`;
+            } else if (String(content).includes('[图片]') && data?.elements) {
+                const imgElement = data.elements.find((el: any) => el?.type === 'image');
+                if (imgElement?.data?.localPath) {
+                    const baseName = path.basename(imgElement.data.localPath);
+                    const dataUri = this.lookupDataUri('images', baseName);
+                    const imgSrc = dataUri || `${this.resourceBaseHref}/images/${baseName}`;
+                    imageHtml = `<img src="${imgSrc}" class="reply-content-thumb" alt="引用图片" loading="lazy">`;
+                }
+            }
+            bodyHtml = `${this.escapeHtml(content)}${imageHtml}`;
         }
 
         const dataAttr = jumpTarget ? `data-reply-to="msg-${this.escapeHtml(jumpTarget)}"` : '';
@@ -1640,8 +1676,7 @@ export class ModernHtmlExporter {
                 <strong>${this.escapeHtml(senderName)}</strong>
                 ${timeStr ? `<span class="reply-content-time">${this.escapeHtml(timeStr)}</span>` : ''}
             </div>
-            <div class="reply-content-text">${this.escapeHtml(content)}</div>
-            ${imageHtml}
+            <div class="reply-content-text">${bodyHtml}</div>
         </div>`;
     }
 

--- a/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlTemplates.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlTemplates.ts
@@ -922,6 +922,24 @@ export const MODERN_CSS = `
             border-radius: 6px;
             object-fit: cover;
         }
+
+        /* issue #128: 引用框里跟文字混排的缩略图 / 表情 */
+        .reply-content-thumb {
+            display: inline-block;
+            vertical-align: middle;
+            max-width: 64px;
+            max-height: 64px;
+            border-radius: 4px;
+            object-fit: cover;
+            margin: 0 4px;
+        }
+        .reply-content-emoji {
+            display: inline-block;
+            vertical-align: middle;
+            width: 20px;
+            height: 20px;
+            margin: 0 2px;
+        }
         
         .message.self .reply-content {
             background: rgba(0, 0, 0, 0.08);

--- a/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
@@ -198,6 +198,35 @@ export interface MessageElementData {
 }
 
 /**
+ * issue #128 子项：回复框（reply 元素）里被引用消息的结构化预览片段。
+ * 文本字段 `content` 仍保持「[图片]」「[表情341]」等占位串以兼容
+ * JSON / TXT / Excel 等纯文本导出；HTML 导出额外消费 previewElements
+ * 来渲染图片缩略图 / 表情图等。
+ *
+ * `localPath` / `url` 字段在解析阶段写不进来——picElement.sourcePath 是 NT
+ * 自身的缓存路径，而不是导出的 resources/ 路径。这两个字段会在
+ * `updateSingleMessageResourcePaths` 的二次回填里被写上。
+ */
+export interface ReplyPreviewElement {
+  type: 'text' | 'image' | 'video' | 'audio' | 'file' | 'face' | 'marketFace';
+  text: string;
+  /** image: picElement.md5HexStr，用于跨消息匹配下载后的资源条目 */
+  md5?: string;
+  /** image: picElement.originImageUrl，回退兜底（QQ 临时签名 URL，会过期） */
+  originUrl?: string;
+  /** image / video / file: 原始文件名 */
+  fileName?: string;
+  /** marketFace: 表情包名 */
+  faceName?: string;
+  /** marketFace: 表情包静态 URL */
+  url?: string;
+  /** face: 系统小表情 id */
+  faceIndex?: number;
+  /** updateResourcePaths 二次回填出来的导出包内相对路径，例：images/abc.jpg */
+  localPath?: string;
+}
+
+/**
  * 合并转发卡片里嵌套的子消息。
  * 字段刻意保持扁平，方便直接序列化到 JSON / JSONL，也方便 TXT 导出按行渲染。
  */
@@ -733,7 +762,11 @@ export class SimpleMessageParser {
           senderUin: replyData.senderUin,
           senderName: replyData.senderName,
           content: replyData.content,
-          timestamp: replyData.timestamp
+          timestamp: replyData.timestamp,
+          // issue #128 子项：回复框里的图片 / 表情等元素，HTML 导出时拿来
+          // 渲染缩略图。文本字段 `content` 保持「[图片]」「[表情341]」不变，
+          // JSON / TXT / Excel 等纯文本导出零影响。
+          previewElements: replyData.previewElements
         }
       };
     }
@@ -1423,6 +1456,53 @@ export class SimpleMessageParser {
         this.updateSingleMessageResourcePaths(message, resources);
       }
     }
+    // issue #128：所有消息的资源路径写完之后，再回头把 reply 元素里的
+    // previewElements.localPath 拉齐，让 HTML 导出能直接渲染缩略图。
+    this.backfillReplyPreviewLocalPaths(messages);
+  }
+
+  /**
+   * 二次回填：扫一遍 messages，把每条 reply 元素的 previewElements 里的
+   * 图片片段补上 `localPath`，方便 HTML 导出器直接渲染缩略图。
+   *
+   * 匹配规则：先按 md5（picElement.md5HexStr 一对一稳定映射），匹配不到时
+   * 按顺序兜底（极端老快照里 md5 可能缺失）。被引用消息不在导出范围内时
+   * 自然找不到，留空让 HTML 端走「[图片]」文字回退。
+   */
+  public backfillReplyPreviewLocalPaths(messages: CleanMessage[]): void {
+    if (messages.length === 0) return;
+    // 第一步：建 msgId → image[] 索引
+    const imagesByMsgId = new Map<string, Array<{ md5: string; localPath: string }>>();
+    for (const m of messages) {
+      const imgs: Array<{ md5: string; localPath: string }> = [];
+      for (const el of m.content.elements) {
+        if (el.type !== 'image' || !el.data || typeof el.data !== 'object') continue;
+        const data = el.data as { md5?: string; localPath?: string };
+        if (!data.localPath) continue;
+        imgs.push({ md5: String(data.md5 || ''), localPath: data.localPath });
+      }
+      if (imgs.length > 0) imagesByMsgId.set(m.id, imgs);
+    }
+    if (imagesByMsgId.size === 0) return;
+    // 第二步：扫所有 reply 元素，按 referencedMessageId 找回原消息的图片
+    for (const m of messages) {
+      for (const el of m.content.elements) {
+        if (el.type !== 'reply' || !el.data || typeof el.data !== 'object') continue;
+        const data = el.data as { referencedMessageId?: string; previewElements?: ReplyPreviewElement[] };
+        const refId = data.referencedMessageId ? String(data.referencedMessageId) : '';
+        if (!refId || !Array.isArray(data.previewElements)) continue;
+        const refImgs = imagesByMsgId.get(refId);
+        if (!refImgs || refImgs.length === 0) continue;
+        let fallbackIdx = 0;
+        for (const pe of data.previewElements) {
+          if (pe.type !== 'image') continue;
+          const byMd5 = pe.md5 ? refImgs.find(r => r.md5 && r.md5 === pe.md5) : null;
+          const candidate = byMd5 || refImgs[fallbackIdx];
+          if (candidate?.localPath) pe.localPath = candidate.localPath;
+          fallbackIdx++;
+        }
+      }
+    }
   }
 
   /**
@@ -1579,13 +1659,22 @@ export class SimpleMessageParser {
     //     已被 cacheSenderInfo 收录的可读名字；
     //   - 全部失败时优先用 senderUin（QQ 号）而不是 senderUidStr（u_xxx）。
     const senderName = this.resolveReplySenderName(replyElement, message, referencedMessage);
-    const result = {
+    const result: {
+      messageId: string;
+      referencedMessageId: string | undefined;
+      senderUin: string;
+      senderName: string;
+      content: string;
+      timestamp: number;
+      previewElements: ReplyPreviewElement[];
+    } = {
       messageId: sourceMsgId || replyElement.replayMsgId || replyElement.replayMsgSeq || '0',
       referencedMessageId: referencedMessageId || undefined,  // 确保不会是 "0"
       senderUin: replyElement.senderUin || (referencedMessage?.senderUin ?? ''),
       senderName,
       content: '原消息',
-      timestamp: 0
+      timestamp: 0,
+      previewElements: []
     };
 
     // 如果找到了被引用的消息，从中提取内容
@@ -1593,25 +1682,55 @@ export class SimpleMessageParser {
       // 保持messageId为sourceMsgId，referencedMessageId已经在前面设置
       result.senderUin = referencedMessage.senderUin;
 
-      // 提取被引用消息的文本内容
+      // 提取被引用消息的文本内容 + 结构化的 previewElements
       if (referencedMessage.elements && referencedMessage.elements.length > 0) {
-        const parts = [];
+        const parts: string[] = [];
         for (const element of referencedMessage.elements) {
           if (element.textElement?.content) {
             parts.push(element.textElement.content);
+            result.previewElements.push({ type: 'text', text: element.textElement.content });
           } else if (element.picElement) {
             parts.push('[图片]');
+            result.previewElements.push({
+              type: 'image',
+              text: '[图片]',
+              md5: element.picElement.md5HexStr || '',
+              originUrl: element.picElement.originImageUrl || '',
+              fileName: element.picElement.fileName || ''
+            });
           } else if (element.videoElement) {
             parts.push('[视频]');
+            result.previewElements.push({
+              type: 'video',
+              text: '[视频]',
+              fileName: element.videoElement.fileName || ''
+            });
           } else if (element.pttElement) {
             parts.push('[语音]');
+            result.previewElements.push({ type: 'audio', text: '[语音]' });
           } else if (element.fileElement) {
             parts.push('[文件]');
+            result.previewElements.push({
+              type: 'file',
+              text: '[文件]',
+              fileName: element.fileElement.fileName || ''
+            });
           } else if (element.faceElement) {
             parts.push(`[表情${element.faceElement.faceIndex}]`);
+            result.previewElements.push({
+              type: 'face',
+              text: `[表情${element.faceElement.faceIndex}]`,
+              faceIndex: element.faceElement.faceIndex
+            });
           } else if (element.marketFaceElement) {
             const faceName = element.marketFaceElement.faceName || '超级表情';
             parts.push(`[${faceName}]`);
+            result.previewElements.push({
+              type: 'marketFace',
+              text: `[${faceName}]`,
+              faceName,
+              url: this.generateMarketFaceUrl(element.marketFaceElement.emojiId || '')
+            });
           }
         }
         if (parts.length > 0) {

--- a/plugins/qq-chat-exporter/package.json
+++ b/plugins/qq-chat-exporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qq-chat-exporter",
-  "version": "5.5.0",
+  "version": "5.5.57",
   "description": "QQ Chat Exporter Plugin for NapCat - Export QQ chat history with advanced features",
   "main": "index.mjs",
   "type": "module",


### PR DESCRIPTION
关 #128 reply 渲染的最后一条子项。

被引用消息里如果是图片 / 表情，HTML 导出原本只渲染成 `[图片]` / `[表情341]` 这种占位字符串，看不到真正的内容。这条把 reply 的预览扩成结构化数组，HTML 端直接画成缩略图；JSON / TXT / Excel 等纯文本导出格式不动。

`SimpleMessageParser.extractReplyContent` 新增 `previewElements` 字段，按 `text / image / video / audio / file / face / marketFace` 把被引用消息的元素结构化记录下来。文本字段 `content` 保留「[图片]」「[表情341]」占位串，纯文本导出零回归。

`updateResourcePaths` 收尾后调用新的 `backfillReplyPreviewLocalPaths`，扫一遍所有 reply 元素：按 `picElement.md5HexStr` 一对一回填 `previewElements[i].localPath`，md5 缺失时按顺序兜底；引用消息不在导出范围内时不写值，让 HTML 端走 `originUrl` / 文本回退。

`ModernHtmlExporter.renderReplyElement` 优先消费 `previewElements`：图片渲染成 `reply-content-thumb` 缩略图、超级表情渲染成 `reply-content-emoji` 小图，文字片段照旧 `escapeHtml`。`previewElements` 不在时走原来的 `data.imageUrl / data.elements` 兼容分支，老快照不会回归。

`ModernHtmlTemplates` 加了 `.reply-content-thumb` / `.reply-content-emoji` 两条样式。

新增单测 `SimpleMessageParser.replyPreview.test.ts` 覆盖 backfill 的 6 条路径：md5 命中、md5 缺失走顺序兜底、引用消息越界、`previewElements` 为 null、空 messages 列表、原消息没图片资源。本地 unit 207 / integration 7 全绿。
