### PR TITLE
feat(gallery): 资源画廊按文件名搜索 (#294)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/galleryFilter.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/galleryFilter.test.ts
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    MAX_NAME_SEARCH_LENGTH,
+    buildNameSearchPredicate,
+    normalizeNameSearch,
+} from '../../lib/api/galleryFilter.js';
+
+test('galleryFilter: normalizeNameSearch 空 / undefined / null 返回 null（不过滤）', () => {
+    assert.equal(normalizeNameSearch(undefined), null);
+    assert.equal(normalizeNameSearch(null), null);
+    assert.equal(normalizeNameSearch(''), null);
+    assert.equal(normalizeNameSearch('   '), null);
+    assert.equal(normalizeNameSearch('\t\n'), null);
+});
+
+test('galleryFilter: normalizeNameSearch 非字符串异常入参视为不过滤', () => {
+    assert.equal(normalizeNameSearch(123 as unknown), null);
+    assert.equal(normalizeNameSearch([] as unknown), null);
+    assert.equal(normalizeNameSearch({} as unknown), null);
+    assert.equal(normalizeNameSearch(['foo', 'bar'] as unknown), null);
+});
+
+test('galleryFilter: normalizeNameSearch 正常字符串走 trim + toLowerCase', () => {
+    assert.equal(normalizeNameSearch('Hello'), 'hello');
+    assert.equal(normalizeNameSearch('  WORLD  '), 'world');
+    assert.equal(normalizeNameSearch('PreFix-Mid-SUFFIX'), 'prefix-mid-suffix');
+});
+
+test('galleryFilter: normalizeNameSearch 中文 / 标点 / 数字保留', () => {
+    assert.equal(normalizeNameSearch('图片'), '图片');
+    assert.equal(normalizeNameSearch('IMG_2024_03'), 'img_2024_03');
+    assert.equal(normalizeNameSearch('  截图.jpg  '), '截图.jpg');
+});
+
+test('galleryFilter: normalizeNameSearch 超长字符串被截断到 MAX_NAME_SEARCH_LENGTH', () => {
+    const long = 'a'.repeat(MAX_NAME_SEARCH_LENGTH + 50);
+    const out = normalizeNameSearch(long);
+    assert.notEqual(out, null);
+    assert.equal((out as string).length, MAX_NAME_SEARCH_LENGTH);
+});
+
+test('galleryFilter: buildNameSearchPredicate 不过滤时永远返回 true', () => {
+    const match = buildNameSearchPredicate(undefined);
+    assert.equal(match('anything.png'), true);
+    assert.equal(match(''), true);
+    assert.equal(match('IMG_2024_截图.jpg'), true);
+});
+
+test('galleryFilter: buildNameSearchPredicate 大小写不敏感子串匹配', () => {
+    const match = buildNameSearchPredicate('IMG');
+    assert.equal(match('img_2024_03_15.jpg'), true);
+    assert.equal(match('IMG_2024_03_15.jpg'), true);
+    assert.equal(match('vacation_img_001.png'), true);
+    assert.equal(match('screenshot.jpg'), false);
+});
+
+test('galleryFilter: buildNameSearchPredicate 中文子串能匹配文件名', () => {
+    const match = buildNameSearchPredicate('截图');
+    assert.equal(match('微信截图_20240315.png'), true);
+    assert.equal(match('IMG_2024.jpg'), false);
+});
+
+test('galleryFilter: buildNameSearchPredicate 异常 fileName（空 / 非字符串）安全返回 false', () => {
+    const match = buildNameSearchPredicate('foo');
+    assert.equal(match(''), false);
+    assert.equal(match(undefined as unknown as string), false);
+    assert.equal(match(null as unknown as string), false);
+    assert.equal(match(123 as unknown as string), false);
+});
+
+test('galleryFilter: buildNameSearchPredicate 子串首尾空白被 trim 掉，搜索词照常工作', () => {
+    const match = buildNameSearchPredicate('   .mp4  ');
+    assert.equal(match('vacation.mp4'), true);
+    assert.equal(match('clip.mov'), false);
+});
+
+test('galleryFilter: buildNameSearchPredicate 长查询截断后仍然能匹配前缀', () => {
+    const long = 'a'.repeat(MAX_NAME_SEARCH_LENGTH + 50);
+    const match = buildNameSearchPredicate(long);
+    // 截断后是 200 个 'a'，文件名里有 250 个 'a' 也能命中
+    assert.equal(match('a'.repeat(MAX_NAME_SEARCH_LENGTH + 50) + '.bin'), true);
+    // 文件名里只有 100 个 'a'，命不中（长度不够）
+    assert.equal(match('a'.repeat(100) + '.bin'), false);
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -62,6 +62,7 @@ import {
     reconcileOrphanedTask,
     buildTaskResyncPayload,
 } from './orphanTaskReconciler.js';
+import { buildNameSearchPredicate } from './galleryFilter.js';
 
 // 导入类型定义
 import type { RawMessage } from 'NapCatQQ/src/core/types.js';
@@ -3371,7 +3372,8 @@ export class QQChatExporterApiServer {
                 const type = req.query['type'] as string || 'all'; // all, images, videos, audios, files
                 const page = parseInt(req.query['page'] as string) || 1;
                 const limit = parseInt(req.query['limit'] as string) || 50;
-                const resources = await this.getGlobalResourceFiles(type, page, limit);
+                const nameSearch = req.query['nameSearch'];
+                const resources = await this.getGlobalResourceFiles(type, page, limit, nameSearch);
                 this.sendSuccessResponse(res, resources, (req as any).requestId);
             } catch (error) {
                 this.sendErrorResponse(res, error, (req as any).requestId);
@@ -6793,7 +6795,8 @@ export class QQChatExporterApiServer {
     private async getGlobalResourceFiles(
         type: string,
         page: number,
-        limit: number
+        limit: number,
+        nameSearch?: unknown
     ): Promise<{
         files: Array<{
             type: string;
@@ -6810,7 +6813,8 @@ export class QQChatExporterApiServer {
     }> {
         const userProfile = process.env['USERPROFILE'] || process.cwd();
         const resourcesDir = path.join(userProfile, '.qq-chat-exporter', 'resources');
-        
+        const matchesName = buildNameSearchPredicate(nameSearch);
+
         const files: Array<{
             type: string;
             fileName: string;
@@ -6845,7 +6849,8 @@ export class QQChatExporterApiServer {
                 
                 for (const entry of entries) {
                     if (!entry.isFile()) continue;
-                    
+                    if (!matchesName(entry.name)) continue;
+
                     const fullPath = path.join(dir, entry.name);
                     try {
                         const stats = fs.statSync(fullPath);

--- a/plugins/qq-chat-exporter/lib/api/StandaloneServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/StandaloneServer.ts
@@ -20,6 +20,7 @@ import os from 'os';
 // 导入前端服务管理器
 import { FrontendBuilder } from '../webui/FrontendBuilder.js';
 import { VERSION, APP_INFO } from '../version.js';
+import { buildNameSearchPredicate } from './galleryFilter.js';
 
 /**
  * API响应接口
@@ -295,7 +296,8 @@ export class QCEStandaloneServer {
                 const type = req.query['type'] as string || 'all';
                 const page = parseInt(req.query['page'] as string) || 1;
                 const limit = parseInt(req.query['limit'] as string) || 50;
-                const resources = await this.getGlobalResourceFiles(type, page, limit);
+                const nameSearch = req.query['nameSearch'];
+                const resources = await this.getGlobalResourceFiles(type, page, limit, nameSearch);
                 this.sendSuccessResponse(res, resources, (req as any).requestId);
             } catch (error) {
                 this.sendErrorResponse(res, error, (req as any).requestId);
@@ -761,9 +763,15 @@ export class QCEStandaloneServer {
     /**
      * 获取全局资源文件列表
      */
-    private async getGlobalResourceFiles(type: string, page: number, limit: number): Promise<any> {
+    private async getGlobalResourceFiles(
+        type: string,
+        page: number,
+        limit: number,
+        nameSearch?: unknown
+    ): Promise<any> {
         const files: any[] = [];
         const resourceTypes = type === 'all' ? ['images', 'videos', 'audios', 'files'] : [type];
+        const matchesName = buildNameSearchPredicate(nameSearch);
 
         for (const resourceType of resourceTypes) {
             const dirPath = path.join(this.resourcesDir, resourceType);
@@ -771,6 +779,7 @@ export class QCEStandaloneServer {
 
             const entries = fs.readdirSync(dirPath);
             for (const entry of entries) {
+                if (!matchesName(entry)) continue;
                 const filePath = path.join(dirPath, entry);
                 const stats = fs.statSync(filePath);
                 if (stats.isFile()) {

--- a/plugins/qq-chat-exporter/lib/api/galleryFilter.ts
+++ b/plugins/qq-chat-exporter/lib/api/galleryFilter.ts
@@ -1,0 +1,59 @@
+/**
+ * 资源画廊文件名搜索辅助函数。
+ *
+ * `/api/resources/files` 在文件名上接受可选的 `nameSearch` 子串过滤，配合
+ * 现有的类型 / 分页参数一起使用。逻辑独立成模块的好处是 `ApiServer` 和
+ * `StandaloneServer` 两边的实现可以共用，且能针对边界情况单独写单测。
+ *
+ * 行为约定：
+ * - 空串 / 仅空白 / `undefined` / `null` 视为「不过滤」，返回的判定函数总是返回 `true`。
+ * - 非字符串（数组、对象、数字等异常入参）也视为「不过滤」，避免上游 query 解析翻车时
+ *   把整库筛空。
+ * - 长度上限 `MAX_NAME_SEARCH_LENGTH = 200`。超过部分截断，防止恶意超长字符串拖慢扫描。
+ * - 大小写不敏感：`includes` 比较前两边都 `toLowerCase()`。
+ */
+
+/** `nameSearch` 子串最大长度，超过的部分会被截断。 */
+export const MAX_NAME_SEARCH_LENGTH = 200;
+
+/**
+ * 把上游传进来的 `nameSearch` query 参数标准化成可用的搜索词。
+ *
+ * 返回 `null` 表示「不过滤」（空 / 空白 / 类型异常 / 截断后仍然为空）。返回的字符串
+ * 已经 `trim` + `toLowerCase`，调用方直接拿去做 `includes` 比较即可。
+ */
+export function normalizeNameSearch(raw: unknown): string | null {
+    if (typeof raw !== 'string') return null;
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) return null;
+    const truncated = trimmed.slice(0, MAX_NAME_SEARCH_LENGTH);
+    const lower = truncated.toLowerCase();
+    return lower.length === 0 ? null : lower;
+}
+
+/**
+ * 构造一个 `(fileName) => boolean` 的判定函数。
+ *
+ * - `nameSearch` 为 `null` 时永远返回 `true`（不过滤）。
+ * - 否则返回 `fileName.toLowerCase().includes(nameSearch)`。
+ *
+ * 用法示例：
+ *
+ * ```ts
+ * const match = buildNameSearchPredicate(req.query['nameSearch']);
+ * for (const entry of entries) {
+ *     if (!match(entry.name)) continue;
+ *     ...
+ * }
+ * ```
+ */
+export function buildNameSearchPredicate(raw: unknown): (fileName: string) => boolean {
+    const term = normalizeNameSearch(raw);
+    if (term === null) {
+        return () => true;
+    }
+    return (fileName: string) => {
+        if (typeof fileName !== 'string' || fileName.length === 0) return false;
+        return fileName.toLowerCase().includes(term);
+    };
+}

--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -63,6 +63,7 @@ import {
   PanelLeftClose,
   PanelLeftOpen,
   ChevronRight,
+  Search,
 } from "lucide-react"
 import type { CreateTaskForm, CreateScheduledExportForm } from "@/types/api"
 import { useQCE } from "@/hooks/use-qce"
@@ -484,6 +485,10 @@ export default function QCEDashboard() {
   const [historySubTab, setHistorySubTab] = useState<'records' | 'gallery'>('records')
   const [galleryType, setGalleryType] = useState<'all' | 'images' | 'videos' | 'audios' | 'files'>('all')
   const [galleryPage, setGalleryPage] = useState(1)
+  // issue #294 子项 1：画廊文件名搜索。输入值是受控的，外加一份 debounce 后真正发请求的值，
+  // 避免每敲一个字就打一次后端。
+  const [gallerySearchInput, setGallerySearchInput] = useState('')
+  const [gallerySearchActive, setGallerySearchActive] = useState('')
 
   const handleOpenTaskWizard = (preset?: Partial<CreateTaskForm>) => {
     setSelectedPreset(preset)
@@ -613,6 +618,24 @@ export default function QCEDashboard() {
       })
     }
   }, [activeTab, loadTasks])
+
+  // issue #294 子项 1：画廊搜索框 debounce。用户停止输入 250ms 之后，才把
+  // input 值同步到 active 值上，避免每敲一个字就打一次后端。
+  useEffect(() => {
+    if (gallerySearchInput === gallerySearchActive) return
+    const timer = setTimeout(() => {
+      setGallerySearchActive(gallerySearchInput)
+    }, 250)
+    return () => clearTimeout(timer)
+  }, [gallerySearchInput, gallerySearchActive])
+
+  // 画廊搜索：active 关键词变化时回到第一页重新拉数据。仅在 gallery 子页激活时触发，
+  // 避免用户根本没切到画廊时被多余请求打扰。
+  useEffect(() => {
+    if (historySubTab !== 'gallery') return
+    setGalleryPage(1)
+    loadResourceFiles(galleryType, 1, 50, false, gallerySearchActive)
+  }, [gallerySearchActive, historySubTab, galleryType, loadResourceFiles])
   
   // 定时导出加载
   useEffect(() => {
@@ -1996,10 +2019,9 @@ export default function QCEDashboard() {
                   </button>
                   <button
                     onClick={() => {
+                      // 切到画廊后由专门的 useEffect 监听 historySubTab / galleryType /
+                      // gallerySearchActive 触发首次加载；这里只切 sub tab，避免重复打后端。
                       setHistorySubTab('gallery')
-                      if (resourceFiles.length === 0) {
-                        loadResourceFiles(galleryType, 1, 50)
-                      }
                     }}
                     className={`px-2.5 py-1 rounded-md text-[12px] transition-colors ${
                       historySubTab === 'gallery'
@@ -2174,9 +2196,9 @@ export default function QCEDashboard() {
                           <button
                             key={tab.id}
                             onClick={() => {
+                              // 切类型后由 useEffect（依赖 galleryType / gallerySearchActive）
+                              // 自动重新加载，避免和 effect 各打一次。
                               setGalleryType(tab.id as typeof galleryType)
-                              setGalleryPage(1)
-                              loadResourceFiles(tab.id as typeof galleryType, 1, 50)
                             }}
                             className={`px-2.5 py-1 rounded-md text-[12px] transition-colors ${
                               isActive 
@@ -2191,6 +2213,30 @@ export default function QCEDashboard() {
                       <span className="text-[11px] text-muted-foreground/40 ml-2">
                         {resourceFilesTotal} 个
                       </span>
+                    </div>
+
+                    {/* issue #294 子项 1：文件名搜索。后端按子串过滤后再分页，
+                        匹配数会跟着「N 个」一起变。 */}
+                    <div className="px-1">
+                      <div className="relative max-w-md">
+                        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground/40" />
+                        <input
+                          type="text"
+                          value={gallerySearchInput}
+                          onChange={(e) => setGallerySearchInput(e.target.value)}
+                          placeholder="按文件名搜索..."
+                          className="w-full pl-8 pr-8 py-1.5 text-[12px] rounded-md bg-black/[0.02] dark:bg-white/[0.02] border border-transparent focus:border-black/[0.08] dark:focus:border-white/[0.08] focus:bg-black/[0.03] dark:focus:bg-white/[0.03] outline-none transition-colors"
+                        />
+                        {gallerySearchInput && (
+                          <button
+                            onClick={() => setGallerySearchInput('')}
+                            className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded text-muted-foreground/40 hover:text-muted-foreground transition-colors"
+                            title="清空"
+                          >
+                            <X className="w-3 h-3" />
+                          </button>
+                        )}
+                      </div>
                     </div>
 
                     {/* Loading */}
@@ -2257,7 +2303,7 @@ export default function QCEDashboard() {
                           onClick={() => {
                             const nextPage = galleryPage + 1
                             setGalleryPage(nextPage)
-                            loadResourceFiles(galleryType, nextPage, 50, true)
+                            loadResourceFiles(galleryType, nextPage, 50, true, gallerySearchActive)
                           }}
                           disabled={resourceFilesLoading}
                         >
@@ -2270,8 +2316,19 @@ export default function QCEDashboard() {
                     {!resourceFilesLoading && resourceFiles.length === 0 && (
                       <div className="flex flex-col items-center justify-center py-16 text-center">
                         <Image className="w-8 h-8 text-muted-foreground/20 mb-3" />
-                        <p className="text-[13px] text-foreground font-medium">暂无资源</p>
-                        <p className="text-[12px] text-muted-foreground/60 mt-1">导出聊天记录后，资源将显示在这里</p>
+                        {gallerySearchActive ? (
+                          <>
+                            <p className="text-[13px] text-foreground font-medium">没有匹配的资源</p>
+                            <p className="text-[12px] text-muted-foreground/60 mt-1">
+                              没有文件名包含「{gallerySearchActive}」的资源
+                            </p>
+                          </>
+                        ) : (
+                          <>
+                            <p className="text-[13px] text-foreground font-medium">暂无资源</p>
+                            <p className="text-[12px] text-muted-foreground/60 mt-1">导出聊天记录后，资源将显示在这里</p>
+                          </>
+                        )}
                       </div>
                     )}
                   </div>

--- a/qce-v4-tool/hooks/use-resource-index.ts
+++ b/qce-v4-tool/hooks/use-resource-index.ts
@@ -94,13 +94,23 @@ export function useResourceIndex() {
     type: 'all' | 'images' | 'videos' | 'audios' | 'files' = 'all',
     page: number = 1,
     limit: number = 50,
-    append: boolean = false
+    append: boolean = false,
+    nameSearch?: string
   ) => {
     try {
       setFilesLoading(true);
       setError(null);
 
-      const response = await fetch(`/api/resources/files?type=${type}&page=${page}&limit=${limit}`);
+      const params = new URLSearchParams({
+        type,
+        page: String(page),
+        limit: String(limit),
+      });
+      const trimmedSearch = nameSearch?.trim();
+      if (trimmedSearch) {
+        params.set('nameSearch', trimmedSearch);
+      }
+      const response = await fetch(`/api/resources/files?${params.toString()}`);
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }


### PR DESCRIPTION
部分关 #294，在资源画廊上加文件名子串搜索。子项 1（按 QQ 号筛选）原本想一起做，但需要在存储层补一份 md5 → selfUin 的属归索引、还要把每个 selfUin 的资源目录拆开，体量太大，单独跟。

`/api/resources/files` 新增可选 query 参数 `nameSearch`：传入子串后端在扫目录时按文件名 `toLowerCase().includes(...)` 过滤，过滤完再按修改时间倒序、再分页。返回的 `total / hasMore / page / limit` 都是「过滤后」的结果，前端不需要二次裁剪。

- 空串 / 仅空白 / 类型异常视为「不过滤」，避免上游 query 解析翻车时把整库筛空。
- 大小写不敏感、支持中文（`微信截图_*` 这种）。
- 子串长度上限 200 字符，超过部分截断，防恶意超长字符串拖慢扫描。
- `ApiServer` 和独立模式 `StandaloneServer` 各自的 `getGlobalResourceFiles` 共用同一个 `lib/api/galleryFilter.ts` 助手，行为一致。

前端在画廊类型 tab 下面加了一行搜索框（Search 图标 + input + 一键清空 X），值用 `gallerySearchInput` 受控；用户停止输入 250ms 后再把值同步给 `gallerySearchActive`，避免每敲一个字打一次后端。`gallerySearchActive` 变化时由专门的 `useEffect` 触发 `loadResourceFiles(galleryType, 1, 50, false, gallerySearchActive)`，回到第一页拉新数据；同样的 effect 也接管了「切类型」「切到画廊子页」两条原本各自打一次的路径，整个画廊只剩这一条 effect 在打后端。

「加载更多」按钮带上当前 `gallerySearchActive` 一起传给后端，分页时不会丢搜索词。空态文案区分了「确实没资源」和「搜索没匹配项」两种情况，后者会回显当前搜索词。

新增 `__tests__/unit/galleryFilter.test.ts` 11 条用例，覆盖：

- `normalizeNameSearch` 空 / undefined / null / 空白 / 非字符串异常入参 → 一律 `null`
- 正常字符串 trim + toLowerCase；中文 / 标点 / 数字保留
- 超长字符串截断到 `MAX_NAME_SEARCH_LENGTH (200)`
- `buildNameSearchPredicate` 不过滤模式永远返回 true
- 大小写不敏感子串匹配；中文文件名匹配
- 异常 fileName（空 / undefined / null / 数字）安全返回 false
- 子串首尾空白被 trim 掉之后照常工作
- 长查询截断后仍然能匹配前缀

本地 `npm run test:unit` 220 条全绿。
