### PR TITLE
feat(html-exporter): reply 卡片预览支持 face / video / audio / file 类型

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/replyPreviewRenderer.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/replyPreviewRenderer.test.ts
@@ -1,0 +1,224 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    renderReplyPreviewElement,
+    renderReplyPreviewElements,
+    type ReplyPreviewRenderContext,
+} from '../../lib/core/exporter/replyPreviewRenderer.js';
+
+/**
+ * 简化版 escapeHtml：只处理 reply 渲染里实际会出现的几种危险字符。
+ * 真实实现来自 ModernHtmlExporter.escapeHtml，行为对得上即可。
+ */
+function escapeHtml(s: string): string {
+    return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+const baseCtx: ReplyPreviewRenderContext = {
+    resourceBaseHref: 'resources',
+    escapeHtml,
+    lookupDataUri: () => undefined,
+    getFaceName: (id) => {
+        const map: Record<string, string> = {
+            '0': '/微笑',
+            '341': '/奋斗',
+            '14': '/惊讶',
+        };
+        return map[String(id)] || `/表情${id}`;
+    },
+};
+
+test('renderReplyPreviewElement: image 有 localPath 时输出 <img>，src 走相对路径', () => {
+    const html = renderReplyPreviewElement(
+        { type: 'image', localPath: 'images/abc.jpg', md5: 'abc' },
+        baseCtx,
+    );
+    assert.match(html, /<img\s+src="resources\/images\/abc\.jpg"/);
+    assert.match(html, /class="reply-content-thumb"/);
+    assert.match(html, /loading="lazy"/);
+});
+
+test('renderReplyPreviewElement: image 命中 dataUri 时直接用 dataUri，不再拼相对路径', () => {
+    const html = renderReplyPreviewElement(
+        { type: 'image', localPath: 'images/abc.jpg' },
+        {
+            ...baseCtx,
+            lookupDataUri: (kind, name) =>
+                kind === 'images' && name === 'abc.jpg' ? 'data:image/jpeg;base64,Zm9v' : null,
+        },
+    );
+    assert.match(html, /src="data:image\/jpeg;base64,Zm9v"/);
+    assert.doesNotMatch(html, /resources\//);
+});
+
+test('renderReplyPreviewElement: image 没 localPath 但有 originUrl，落到带 onerror 兜底的 <img>', () => {
+    const html = renderReplyPreviewElement(
+        {
+            type: 'image',
+            originUrl: 'https://gchat.qpic.cn/gchatpic_new/123/abc',
+        },
+        baseCtx,
+    );
+    assert.match(html, /src="https:\/\/gchat\.qpic\.cn\/gchatpic_new\/123\/abc"/);
+    assert.match(html, /onerror=/);
+    assert.match(html, /\[图片\]/);
+});
+
+test('renderReplyPreviewElement: image 全无 localPath / originUrl，回退到 text 占位符', () => {
+    const html = renderReplyPreviewElement(
+        { type: 'image', text: '[图片]' },
+        baseCtx,
+    );
+    assert.equal(html, '[图片]');
+});
+
+test('renderReplyPreviewElement: image originUrl 里的 " 会被 escape，避免 HTML 被截断', () => {
+    const html = renderReplyPreviewElement(
+        { type: 'image', originUrl: 'https://x.com/a"onerror="alert(1)' },
+        baseCtx,
+    );
+    assert.match(html, /src="https:\/\/x\.com\/a&quot;onerror=&quot;alert\(1\)"/);
+});
+
+test('renderReplyPreviewElement: marketFace 有 url 输出 <img>，alt 走 faceName', () => {
+    const html = renderReplyPreviewElement(
+        {
+            type: 'marketFace',
+            url: 'https://qq.com/face/abc.png',
+            faceName: '咖啡',
+        },
+        baseCtx,
+    );
+    assert.match(html, /<img\s+src="https:\/\/qq\.com\/face\/abc\.png"/);
+    assert.match(html, /class="reply-content-emoji"/);
+    assert.match(html, /alt="咖啡"/);
+});
+
+test('renderReplyPreviewElement: marketFace 没 url 时回退到文字', () => {
+    const html = renderReplyPreviewElement(
+        { type: 'marketFace', text: '[商城表情]' },
+        baseCtx,
+    );
+    assert.equal(html, '[商城表情]');
+});
+
+test('renderReplyPreviewElement: face 走 getFaceName，把 [表情341] 翻译成 /奋斗', () => {
+    const html = renderReplyPreviewElement(
+        { type: 'face', faceIndex: 341, text: '[表情341]' },
+        baseCtx,
+    );
+    assert.equal(html, '/奋斗');
+});
+
+test('renderReplyPreviewElement: face 表情 ID 是字符串也接得住', () => {
+    const html = renderReplyPreviewElement(
+        { type: 'face', faceIndex: '0', text: '[表情0]' },
+        baseCtx,
+    );
+    assert.equal(html, '/微笑');
+});
+
+test('renderReplyPreviewElement: face 不在表里时回退到 getFaceName 默认串', () => {
+    const html = renderReplyPreviewElement(
+        { type: 'face', faceIndex: 9999, text: '[表情9999]' },
+        baseCtx,
+    );
+    assert.equal(html, '/表情9999');
+});
+
+test('renderReplyPreviewElement: face 完全缺 faceIndex / text，最后兜底到 [表情]', () => {
+    const html = renderReplyPreviewElement(
+        { type: 'face' },
+        baseCtx,
+    );
+    assert.equal(html, '[表情]');
+});
+
+test('renderReplyPreviewElement: video 给 fileName 时输出 🎬 + 文件名', () => {
+    const html = renderReplyPreviewElement(
+        { type: 'video', fileName: 'abc.mp4', text: '[视频]' },
+        baseCtx,
+    );
+    assert.match(html, /<span class="reply-content-attachment">🎬 abc\.mp4<\/span>/);
+});
+
+test('renderReplyPreviewElement: video 没 fileName 时退到 text 占位符', () => {
+    const html = renderReplyPreviewElement(
+        { type: 'video', text: '[视频]' },
+        baseCtx,
+    );
+    assert.match(html, /🎬 \[视频\]/);
+});
+
+test('renderReplyPreviewElement: audio 用 🎵 icon + text 占位符', () => {
+    const html = renderReplyPreviewElement(
+        { type: 'audio', text: '[语音]' },
+        baseCtx,
+    );
+    assert.match(html, /<span class="reply-content-attachment">🎵 \[语音\]<\/span>/);
+});
+
+test('renderReplyPreviewElement: file 用 📎 icon + 文件名', () => {
+    const html = renderReplyPreviewElement(
+        { type: 'file', fileName: 'report.pdf', text: '[文件]' },
+        baseCtx,
+    );
+    assert.match(html, /📎 report\.pdf/);
+});
+
+test('renderReplyPreviewElement: text 类型直接 escape 后输出', () => {
+    const html = renderReplyPreviewElement(
+        { type: 'text', text: '<script>alert(1)</script>' },
+        baseCtx,
+    );
+    assert.equal(html, '&lt;script&gt;alert(1)&lt;/script&gt;');
+});
+
+test('renderReplyPreviewElement: 未知 type 退化成 escape(text)', () => {
+    const html = renderReplyPreviewElement(
+        { type: 'unknown_xyz', text: '<b>hello</b>' },
+        baseCtx,
+    );
+    assert.equal(html, '&lt;b&gt;hello&lt;/b&gt;');
+});
+
+test('renderReplyPreviewElement: null / undefined / 非对象输入返回空串，调用方直接拼接不会爆', () => {
+    assert.equal(renderReplyPreviewElement(null, baseCtx), '');
+    assert.equal(renderReplyPreviewElement(undefined, baseCtx), '');
+    assert.equal(renderReplyPreviewElement('not an object', baseCtx), '');
+    assert.equal(renderReplyPreviewElement(42, baseCtx), '');
+});
+
+test('renderReplyPreviewElements: 把多种类型按顺序拼接', () => {
+    const html = renderReplyPreviewElements(
+        [
+            { type: 'text', text: '看这个：' },
+            { type: 'image', localPath: 'images/x.jpg' },
+            { type: 'face', faceIndex: 14, text: '[表情14]' },
+        ],
+        baseCtx,
+    );
+    assert.equal(
+        html,
+        '看这个：' +
+            '<img src="resources/images/x.jpg" class="reply-content-thumb" alt="引用图片" loading="lazy">' +
+            '/惊讶',
+    );
+});
+
+test('renderReplyPreviewElements: 空数组 / 非数组 / 全是脏数据，结果是空串', () => {
+    assert.equal(renderReplyPreviewElements([], baseCtx), '');
+    assert.equal(
+        renderReplyPreviewElements(null as unknown as unknown[], baseCtx),
+        '',
+    );
+    assert.equal(
+        renderReplyPreviewElements([null, undefined, 'x', 0, false] as unknown[], baseCtx),
+        '',
+    );
+});

--- a/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
@@ -9,6 +9,7 @@ import {
     chooseReplyJumpTarget,
     formatReplyTimestamp,
 } from './replyRender.js';
+import { renderReplyPreviewElements } from './replyPreviewRenderer.js';
 import {
     renderTemplate,
     MODERN_CSS,
@@ -1614,40 +1615,21 @@ export class ModernHtmlExporter {
         const jumpTarget = chooseReplyJumpTarget(data);
         const timeStr = formatReplyTimestamp(data?.timestamp ?? data?.time ?? null);
 
-        // Issue #128 子项：被引用消息里如果带图片 / 表情，HTML 里把它们当
-        // 缩略图渲染出来，纯文字部分用 escape 后的 text 拼接。previewElements
-        // 是 SimpleMessageParser 在 referencedMessage 命中后写进来的结构化
-        // 数组（updateResourcePaths 里又跑了一遍 backfillReplyPreviewLocalPaths
-        // 把 image 的 localPath 拉齐）。命中时整段 reply-content-text 都换成
-        // 缩略图 + 文本混排，免去再跟 `[图片]` 占位符贴一次。
-        const previewElements: any[] = Array.isArray(data?.previewElements) ? data.previewElements : [];
+        // Issue #128 子项：被引用消息里如果带图片 / 表情 / 音视频 / 文件，
+        // HTML 里把它们渲染成对应的缩略图、表情图、icon + 文件名，纯文字部分
+        // 用 escape 后的 text 拼接。previewElements 是 SimpleMessageParser 在
+        // referencedMessage 命中后写进来的结构化数组（updateResourcePaths 里
+        // 又跑了一遍 backfillReplyPreviewLocalPaths 把 image 的 localPath 拉齐）。
+        // 渲染细节统一交给 replyPreviewRenderer，这里只负责注入上下文。
+        const previewElements: unknown[] = Array.isArray(data?.previewElements) ? data.previewElements : [];
         let bodyHtml: string;
         if (previewElements.length > 0) {
-            const parts: string[] = [];
-            for (const pe of previewElements) {
-                if (!pe || typeof pe !== 'object') continue;
-                if (pe.type === 'image') {
-                    const localPath: string = pe.localPath || '';
-                    if (localPath) {
-                        const baseName = path.basename(localPath);
-                        const dataUri = this.lookupDataUri('images', baseName);
-                        const imgSrc = dataUri || `${this.resourceBaseHref}/${localPath}`;
-                        parts.push(`<img src="${imgSrc}" class="reply-content-thumb" alt="引用图片" loading="lazy">`);
-                    } else if (pe.originUrl) {
-                        // 兜底：原消息没在导出范围内，但 NT 给了带签名的 originImageUrl。
-                        // QQ 的 URL 会过期、可能跨域；标 onerror 让浏览器在加载失败时退回到 [图片] 文本。
-                        const url = String(pe.originUrl);
-                        parts.push(`<img src="${this.escapeHtml(url)}" class="reply-content-thumb" alt="引用图片" loading="lazy" onerror="this.replaceWith(document.createTextNode('[图片]'))">`);
-                    } else {
-                        parts.push(this.escapeHtml(pe.text || '[图片]'));
-                    }
-                } else if (pe.type === 'marketFace' && pe.url) {
-                    parts.push(`<img src="${this.escapeHtml(String(pe.url))}" class="reply-content-emoji" alt="${this.escapeHtml(pe.faceName || '表情')}" loading="lazy">`);
-                } else {
-                    parts.push(this.escapeHtml(pe.text || ''));
-                }
-            }
-            bodyHtml = parts.join('');
+            bodyHtml = renderReplyPreviewElements(previewElements, {
+                resourceBaseHref: this.resourceBaseHref,
+                escapeHtml: (s) => this.escapeHtml(s),
+                lookupDataUri: (kind, baseName) => this.lookupDataUri(kind, baseName),
+                getFaceName: (id) => this.getFaceNameById(id),
+            });
         } else {
             // 兼容老路径：data.imageUrl / data.elements 上有人手动塞过的图片
             let imageHtml = '';

--- a/plugins/qq-chat-exporter/lib/core/exporter/replyPreviewRenderer.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/replyPreviewRenderer.ts
@@ -1,0 +1,107 @@
+import path from 'path';
+
+/**
+ * issue #128 子项汇总：被引用消息（reply 卡片）里的预览元素，统一从这里渲染。
+ *
+ * 解析阶段（SimpleMessageParser.extractReplyContent）会把 referencedMessage
+ * 的每一个子元素塞进 `previewElements`，类型可能是 text / image / face /
+ * marketFace / video / audio / file。后续 backfillReplyPreviewLocalPaths 又
+ * 跑一遍，把图片片段的 `localPath` 拉齐。导出阶段需要把这套结构化数据
+ * 渲染成 reply 卡片正文 HTML。
+ *
+ * 该模块只负责字符串拼接，不持有 IO 状态，行为靠注入的 ctx 控制：
+ *   - escapeHtml：HTML escape，必须由调用方提供，不在这里再造一份。
+ *   - lookupDataUri：自包含模式下把资源拉成 data URI；返回 null 则走相对路径。
+ *   - getFaceName：QQ 标准小表情 ID -> 友好名（"/微笑"、"/奋斗" 等）。
+ *   - resourceBaseHref：相对资源根（一般是 'resources'）。
+ */
+export interface ReplyPreviewRenderContext {
+    resourceBaseHref: string;
+    escapeHtml: (s: string) => string;
+    lookupDataUri: (kind: 'images' | 'videos' | 'audios' | 'files', baseName: string) => string | null | undefined;
+    getFaceName: (id: string | number) => string;
+}
+
+/**
+ * 渲染单个 previewElement。返回 HTML 片段（已 escape）；类型未知或字段缺失
+ * 时回退到原始 text 文案，至少不会让正文变空白。
+ */
+export function renderReplyPreviewElement(pe: unknown, ctx: ReplyPreviewRenderContext): string {
+    if (!pe || typeof pe !== 'object') return '';
+    const e = pe as {
+        type?: string;
+        text?: string;
+        localPath?: string;
+        originUrl?: string;
+        url?: string;
+        md5?: string;
+        fileName?: string;
+        faceIndex?: number | string;
+        faceName?: string;
+    };
+    const text = typeof e.text === 'string' ? e.text : '';
+
+    switch (e.type) {
+        case 'image': {
+            const localPath = typeof e.localPath === 'string' ? e.localPath : '';
+            if (localPath) {
+                const baseName = path.basename(localPath);
+                const dataUri = ctx.lookupDataUri('images', baseName);
+                const imgSrc = dataUri || `${ctx.resourceBaseHref}/${localPath}`;
+                return `<img src="${imgSrc}" class="reply-content-thumb" alt="引用图片" loading="lazy">`;
+            }
+            if (typeof e.originUrl === 'string' && e.originUrl) {
+                // 兜底：被引用消息不在导出范围内，但 NT 给了带签名的 originImageUrl。
+                // QQ 的 URL 会过期、可能跨域；用 onerror 让浏览器在加载失败时退回到「[图片]」文本。
+                return `<img src="${ctx.escapeHtml(e.originUrl)}" class="reply-content-thumb" alt="引用图片" loading="lazy" onerror="this.replaceWith(document.createTextNode('[图片]'))">`;
+            }
+            return ctx.escapeHtml(text || '[图片]');
+        }
+        case 'marketFace': {
+            const url = typeof e.url === 'string' ? e.url : '';
+            if (url) {
+                const alt = ctx.escapeHtml(e.faceName || '表情');
+                return `<img src="${ctx.escapeHtml(url)}" class="reply-content-emoji" alt="${alt}" loading="lazy">`;
+            }
+            return ctx.escapeHtml(text || '[表情]');
+        }
+        case 'face': {
+            // 标准小表情：parser 给到 faceIndex，这里翻译成"/微笑"这种友好名，
+            // 跟主消息流里的 renderFaceElement 行为一致，免得 reply 卡片里挂着
+            // 没人看得懂的「[表情341]」。
+            const id = e.faceIndex !== undefined && e.faceIndex !== null ? String(e.faceIndex) : '';
+            const friendly = id ? ctx.getFaceName(id) : '';
+            return ctx.escapeHtml(friendly || text || '[表情]');
+        }
+        case 'video': {
+            // 短卡片里塞不下播放器，给个 🎬 + 文件名 / 占位。
+            const label = e.fileName || text || '[视频]';
+            return `<span class="reply-content-attachment">🎬 ${ctx.escapeHtml(String(label))}</span>`;
+        }
+        case 'audio': {
+            const label = text || '[语音]';
+            return `<span class="reply-content-attachment">🎵 ${ctx.escapeHtml(String(label))}</span>`;
+        }
+        case 'file': {
+            const label = e.fileName || text || '[文件]';
+            return `<span class="reply-content-attachment">📎 ${ctx.escapeHtml(String(label))}</span>`;
+        }
+        case 'text':
+        default:
+            return ctx.escapeHtml(text);
+    }
+}
+
+/**
+ * 把整组 previewElements 串接成 reply 卡片的正文 HTML。空数组返回空串，
+ * 调用方据此决定是否走老路径（用 data.content 文本拼接）。
+ */
+export function renderReplyPreviewElements(elements: unknown[], ctx: ReplyPreviewRenderContext): string {
+    if (!Array.isArray(elements) || elements.length === 0) return '';
+    const parts: string[] = [];
+    for (const pe of elements) {
+        const piece = renderReplyPreviewElement(pe, ctx);
+        if (piece) parts.push(piece);
+    }
+    return parts.join('');
+}


### PR DESCRIPTION
把 `ModernHtmlExporter.renderReplyElement` 里 `previewElements` 的渲染从内联循环拆出来，搬进新的 `lib/core/exporter/replyPreviewRenderer.ts`，按类型分支处理。

## 行为变化

被引用消息（reply 卡片）的预览正文：

- **face**：QQ 标准小表情。原来直接 escape `pe.text`，渲染成「[表情341]」这种没人看得懂的占位串。现在按 `faceIndex` 走 `getFaceNameById`（跟主消息流的 `renderFaceElement` 用同一张表），渲染成「/奋斗」。
- **video**：原来 escape `pe.text` 显示成「[视频]」。现在改成 `🎬 文件名`（没文件名时退到「🎬 [视频]」），跟资源画廊里的 video tile 视觉对得上。
- **audio**：原来「[语音]」，现在「🎵 [语音]」。
- **file**：原来「[文件]」，现在「📎 文件名」。
- **image / marketFace / text**：行为没动，只是搬到新 helper 里。

## 拆分动机

新 helper 是纯函数 + 注入式上下文（`escapeHtml` / `lookupDataUri` / `getFaceName` / `resourceBaseHref`），不持有 IO 状态，可以脱离 `ModernHtmlExporter` 实例直接 `node:test` 测，原来的内联逻辑分支多但完全没单测。

## 测试

`__tests__/unit/replyPreviewRenderer.test.ts`，19 个用例，覆盖：

- image 三种来源（localPath / dataUri 命中 / originUrl 兜底 / text 占位）
- image 的 originUrl 里塞 `"` 也能被 escape 掉，避免 HTML 截断
- marketFace 有无 url 两条路径
- face 已知 ID（0 → /微笑、341 → /奋斗）/ 未知 ID 落到 getFaceName 默认串 / 完全缺 faceIndex 兜底「[表情]」
- video / audio / file 三种新分支
- text + 未知 type 走 escape 兜底
- null / undefined / 非对象输入返回空串，调用方拼接不会爆
- `renderReplyPreviewElements` 多元素按顺序拼接 + 空数组 / 全脏数据返回空串

`npm run test:unit` 本地全绿（240/240）。

## 关联 issue

issue #128 的 follow-up，跟在画廊文件名搜索（v5.5.58）之后。