### PR TITLE
fix(html-export): 合并转发卡片不再把 NapCat XML 原文塞进导出 (#128)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/SimpleMessageParser.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/SimpleMessageParser.test.ts
@@ -408,11 +408,41 @@ test('forward element falls back gracefully when bridge cannot resolve content (
     const [parsed] = await parser.parseMessages([m]);
     const fw = parsed.content.elements[0];
     assert.equal(fw.type, 'forward');
-    assert.equal(fw.data.summary, '<msg>没有内容</msg>');
+    // issue #128 子项 3：summary 不再保留 NapCat 推下来的 XML 原文，
+    // 改用解析失败时的占位文本"查看转发消息"。
+    assert.equal(fw.data.summary, '查看转发消息');
     assert.equal(fw.data.messageCount, 0);
     assert.deepEqual(fw.data.messages, []);
+    assert.deepEqual(fw.data.preview, []);
     // 文本仍然有 [转发消息] 占位，不会丢空。
     assert.match(parsed.content.text, /\[转发消息\]/);
+});
+
+test('forward element extracts preview lines from multiForwardMsg XML when getMultiMsg fails (#128)', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const xml = `<msg multiMsgFlag="0" m_resid="fwd_xml"><item layout="1">
+        <title size="34">群聊的聊天记录</title>
+        <title size="26">小明: 你好</title>
+        <title size="26">小红: 在吗</title>
+        <title size="26">小明: 出去玩吧</title>
+        <summary size="26">查看7条转发消息</summary>
+    </item></msg>`;
+    const m = msg({ chatType: 2, peerUid: 'group://9' })
+        .forward({ resId: 'fw_xml_only', xmlContent: xml })
+        .at_time(T)
+        .build();
+    const [parsed] = await parser.parseMessages([m]);
+    const fw = parsed.content.elements[0];
+    assert.equal(fw.type, 'forward');
+    assert.equal(fw.data.title, '群聊的聊天记录');
+    assert.equal(fw.data.summary, '查看7条转发消息');
+    assert.equal(fw.data.messageCount, 7);
+    assert.deepEqual(fw.data.messages, []);
+    assert.deepEqual(fw.data.preview, ['小明: 你好', '小红: 在吗', '小明: 出去玩吧']);
+    // text 应该带上从 XML 抠到的预览行
+    assert.match(parsed.content.text, /小明: 你好/);
+    assert.match(parsed.content.text, /\[转发消息: 7条\]/);
 });
 
 test('forward element renders preview lines in content.text (#161)', async () => {

--- a/plugins/qq-chat-exporter/__tests__/unit/multiForwardXmlParser.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/multiForwardXmlParser.test.ts
@@ -1,0 +1,132 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    parseMultiForwardXml,
+    looksLikeMultiForwardXml,
+} from '../../lib/core/parser/multiForwardXmlParser.js';
+
+/**
+ * QQ 客户端典型的 multiForwardMsg 卡片 XML（issue #128 子项 3）。
+ * 真机抓回来的字段会比这更花哨（多了 m_resid / m_fileName / brief / sourceMsgId），
+ * 但 <title> / <summary> 这一层结构是固定的。
+ */
+const sampleXml = `<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<msg serviceID="35" templateID="1" action="viewMultiMsg" actionData="" brief="[聊天记录]" m_resid="abc==" m_fileName="123" sourceMsgId="0" url="" flag="3" adverSign="0" multiMsgFlag="0">
+    <item layout="1" advertiser_id="0" aid="0">
+        <title size="34" maxLines="2" lineSpace="12">群聊的聊天记录</title>
+        <title size="26" color="#777777" maxLines="2" lineSpace="12">小明: 你好</title>
+        <title size="26" color="#777777" maxLines="2" lineSpace="12">小红: 在吗</title>
+        <title size="26" color="#777777" maxLines="2" lineSpace="12">小明: 我们出去玩吧</title>
+        <hr hidden="false" style="0" />
+        <summary size="26" color="#777777">查看7条转发消息</summary>
+    </item>
+    <source name="聊天记录" icon="" action="" appid="-1" />
+</msg>`;
+
+test('looksLikeMultiForwardXml: 识别真实卡片 XML', () => {
+    assert.equal(looksLikeMultiForwardXml(sampleXml), true);
+    assert.equal(
+        looksLikeMultiForwardXml(`<msg viewMultiMsg="1"><item><title>x</title></item></msg>`),
+        true,
+    );
+});
+
+test('looksLikeMultiForwardXml: 不把普通带尖括号文本当成卡片 XML', () => {
+    assert.equal(looksLikeMultiForwardXml('hello <b>world</b>'), false);
+    assert.equal(looksLikeMultiForwardXml('<msg>plain</msg>'), false); // 没 multiMsg 特征
+    assert.equal(looksLikeMultiForwardXml(''), false);
+    assert.equal(looksLikeMultiForwardXml(null), false);
+    assert.equal(looksLikeMultiForwardXml(undefined), false);
+});
+
+test('parseMultiForwardXml: 抠出 header / 预览行 / summary / messageCount', () => {
+    const info = parseMultiForwardXml(sampleXml);
+    assert.equal(info.header, '群聊的聊天记录');
+    assert.deepEqual(info.previewLines, [
+        '小明: 你好',
+        '小红: 在吗',
+        '小明: 我们出去玩吧',
+    ]);
+    assert.equal(info.summary, '查看7条转发消息');
+    assert.equal(info.messageCount, 7);
+});
+
+test('parseMultiForwardXml: 空 / 非 XML 输入返回空 info', () => {
+    const empty = parseMultiForwardXml('');
+    assert.equal(empty.header, '');
+    assert.deepEqual(empty.previewLines, []);
+    assert.equal(empty.summary, '');
+    assert.equal(empty.messageCount, 0);
+
+    const notXml = parseMultiForwardXml('随便一段普通文本');
+    assert.equal(notXml.header, '');
+    assert.deepEqual(notXml.previewLines, []);
+
+    assert.deepEqual(parseMultiForwardXml(null).previewLines, []);
+    assert.deepEqual(parseMultiForwardXml(undefined).previewLines, []);
+});
+
+test('parseMultiForwardXml: 反转义 XML 实体', () => {
+    const xml = `<msg multiMsgFlag="0"><item>
+        <title size="34">A &amp; B 的聊天</title>
+        <title size="26">A: 你 &lt; 我 &gt; 他</title>
+        <title size="26">B: &quot;hello&quot; &apos;world&apos;</title>
+        <title size="26">C: &#x4E2D;&#20013;</title>
+        <summary size="26">查看3条转发消息</summary>
+    </item></msg>`;
+    const info = parseMultiForwardXml(xml);
+    assert.equal(info.header, 'A & B 的聊天');
+    assert.deepEqual(info.previewLines, [
+        'A: 你 < 我 > 他',
+        `B: "hello" 'world'`,
+        'C: 中中',
+    ]);
+    assert.equal(info.summary, '查看3条转发消息');
+    assert.equal(info.messageCount, 3);
+});
+
+test('parseMultiForwardXml: 没 size 标记时退化为 第一条=header / 其余=preview', () => {
+    const xml = `<msg multiMsgFlag="0"><item>
+        <title>聊天记录</title>
+        <title>张三: 嗨</title>
+        <title>李四: 嗨嗨</title>
+    </item></msg>`;
+    const info = parseMultiForwardXml(xml);
+    assert.equal(info.header, '聊天记录');
+    assert.deepEqual(info.previewLines, ['张三: 嗨', '李四: 嗨嗨']);
+});
+
+test('parseMultiForwardXml: <title> 数量上限保护，最多解析 16 条预览', () => {
+    const titles = ['<title size="34">头部</title>'];
+    for (let i = 0; i < 50; i++) {
+        titles.push(`<title size="26">行${i}</title>`);
+    }
+    const xml = `<msg multiMsgFlag="0"><item>${titles.join('')}<summary size="26">查看51条转发消息</summary></item></msg>`;
+    const info = parseMultiForwardXml(xml);
+    assert.equal(info.header, '头部');
+    // 最多 16 条预览
+    assert.equal(info.previewLines.length, 16);
+    assert.equal(info.messageCount, 51);
+});
+
+test('parseMultiForwardXml: summary 没数字时 messageCount 保持 0', () => {
+    const xml = `<msg multiMsgFlag="0"><item>
+        <title size="34">聊天记录</title>
+        <summary size="26">查看转发消息</summary>
+    </item></msg>`;
+    const info = parseMultiForwardXml(xml);
+    assert.equal(info.summary, '查看转发消息');
+    assert.equal(info.messageCount, 0);
+});
+
+test('parseMultiForwardXml: 没 summary 标签时，messageCount=0、summary=空字符串', () => {
+    const xml = `<msg multiMsgFlag="0"><item>
+        <title size="34">A 的聊天</title>
+        <title size="26">A: 你好</title>
+    </item></msg>`;
+    const info = parseMultiForwardXml(xml);
+    assert.equal(info.header, 'A 的聊天');
+    assert.deepEqual(info.previewLines, ['A: 你好']);
+    assert.equal(info.summary, '');
+    assert.equal(info.messageCount, 0);
+});

--- a/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
@@ -1675,7 +1675,11 @@ export class ModernHtmlExporter {
 
     private renderForwardElement(data: any): string {
         const title = data?.title || '聊天记录';
-        const summary = data?.summary || data?.content || '查看转发消息';
+        const rawSummary = typeof data?.summary === 'string' ? data.summary : (typeof data?.content === 'string' ? data.content : '');
+        // issue #128 子项 3：老数据里 summary 可能是 NapCat 推下来的 multiForwardMsg XML 原文，
+        // 不能直接当预览渲染（否则前台会出现 <msg ... ><item ...> 这种 XML 卡片代码）。
+        const summaryLooksLikeXml = rawSummary.trim().startsWith('<') && /<\/?[a-zA-Z]/.test(rawSummary);
+        const summary = summaryLooksLikeXml ? '查看转发消息' : (rawSummary || '查看转发消息');
         const preview = data?.preview || [];
         // issue #161：解析器现在会把合并转发卡片里的真实子消息塞进 data.messages，
         // 优先用它渲染完整列表，老数据 / fallback 再退回 preview / summary。
@@ -1694,14 +1698,14 @@ export class ModernHtmlExporter {
                 return `<div class="forward-card-line"><span class="forward-card-sender">${name}:</span> <span class="forward-card-body">${this.escapeHtml(trimmed)}</span></div>`;
             }).join('');
         } else if (Array.isArray(preview) && preview.length > 0) {
-            previewHtml = preview.slice(0, 3).map((line: any) => {
+            previewHtml = preview.slice(0, 5).map((line: any) => {
                 const text = typeof line === 'string' ? line : (line?.text || '');
-                return this.escapeHtml(text);
-            }).join('<br>');
-        } else if (typeof summary === 'string') {
-            // 尝试从summary中提取预览内容
-            const lines = summary.split('\n').slice(0, 3);
-            previewHtml = lines.map(l => this.escapeHtml(l)).join('<br>');
+                const trimmed = text.length > 80 ? text.slice(0, 80) + '…' : text;
+                return `<div class="forward-card-line"><span class="forward-card-body">${this.escapeHtml(trimmed)}</span></div>`;
+            }).join('');
+        } else if (!summaryLooksLikeXml && summary) {
+            // 解析器没解析出预览行时，用 summary（"查看N条转发消息"）当占位文本。
+            previewHtml = `<div class="forward-card-line"><span class="forward-card-body">${this.escapeHtml(summary)}</span></div>`;
         }
 
         const footerLabel = messageCount > 0 ? `转发消息 · ${messageCount}条` : '转发消息';
@@ -1798,7 +1802,17 @@ export class ModernHtmlExporter {
                 case 'forward': {
                     // issue #161：搜索时把合并转发卡片里的子消息内容也带上，否则
                     // 只能搜到外壳标题，搜不到真实文本。
-                    parts.push(`${d?.title || '转发'} ${d?.summary || d?.content || ''}`.trim());
+                    // issue #128 子项 3：summary 可能是 multiForwardMsg XML 原文（老数据），
+                    // 把它写进搜索索引里只会让索引被 `<msg>` / `<item>` 这种标签污染，跳掉。
+                    const fwdSummary = typeof d?.summary === 'string' ? d.summary : '';
+                    const fwdSummaryLooksLikeXml = fwdSummary.trim().startsWith('<') && /<\/?[a-zA-Z]/.test(fwdSummary);
+                    const fwdSummaryClean = fwdSummaryLooksLikeXml ? '' : fwdSummary;
+                    parts.push(`${d?.title || '转发'} ${fwdSummaryClean || d?.content || ''}`.trim());
+                    if (Array.isArray(d?.preview)) {
+                        for (const line of d.preview) {
+                            if (typeof line === 'string' && line.trim()) parts.push(line);
+                        }
+                    }
                     if (Array.isArray(d?.messages)) {
                         for (const m of d.messages) {
                             const name = m?.sender?.name || (m?.sender?.uin ? String(m.sender.uin) : '');

--- a/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { RawMessage, MessageElement, NTMsgType } from 'NapCatQQ/src/core/types.js';
+import { parseMultiForwardXml, looksLikeMultiForwardXml } from './multiForwardXmlParser.js';
 
 /* ------------------------------ 内部高性能工具 ------------------------------ */
 
@@ -783,13 +784,25 @@ export class SimpleMessageParser {
           ? []
           : await this.fetchForwardInnerMessages(message, resId, forwardDepth + 1);
 
+      // issue #128 子项 3：拉子消息失败时不再把 XML 原文塞进 summary，
+      // 改解析 QQ 客户端的卡片 XML（带 <title>/<summary> 标记）抠出可读预览。
+      // 拉成功的情况下也留一份 xmlPreview，方便 fallback 到 fallback 时还能用。
+      const xmlInfo = parseMultiForwardXml(xmlContent);
+      const cardTitle = xmlInfo.header || '聊天记录';
+      const cardSummary = xmlInfo.summary
+        || (innerMessages.length > 0 ? `查看${innerMessages.length}条转发消息` : '查看转发消息');
+      const messageCount = innerMessages.length > 0
+        ? innerMessages.length
+        : xmlInfo.messageCount;
+
       return {
         type: 'forward',
         data: {
-          title: '转发消息',
+          title: cardTitle,
           resId,
-          summary: xmlContent,
-          messageCount: innerMessages.length,
+          summary: cardSummary,
+          preview: xmlInfo.previewLines,
+          messageCount,
           messages: innerMessages
         }
       };
@@ -1053,9 +1066,13 @@ export class SimpleMessageParser {
       case 'forward': {
         const inner: ForwardInnerMessage[] = Array.isArray(element.data?.messages) ? element.data.messages : [];
         const count = element.data?.messageCount ?? inner.length;
+        // issue #128：拉子消息失败时退回到 multiForwardMsg XML 抠出来的卡片预览行（已 unescape，无 XML）。
+        const xmlPreview: string[] = Array.isArray(element.data?.preview)
+          ? element.data.preview.filter((s: unknown): s is string => typeof s === 'string' && s.trim().length > 0)
+          : [];
 
         // 预览前几条作者+文本，方便扫一眼能看到合并转发里到底是什么内容。
-        const previewLines = inner.slice(0, 3).map((m) => {
+        const innerPreviewLines = inner.slice(0, 3).map((m) => {
           const name = m?.sender?.name || (m?.sender?.uin ? String(m.sender.uin) : '');
           const body = (m?.content?.text || '').replace(/\s+/g, ' ').trim();
           const trimmedBody = body.length > 40 ? body.slice(0, 40) + '…' : body;
@@ -1063,6 +1080,9 @@ export class SimpleMessageParser {
           if (name) return name;
           return trimmedBody;
         }).filter(Boolean);
+        const previewLines = innerPreviewLines.length > 0
+          ? innerPreviewLines
+          : xmlPreview.slice(0, 3).map((l) => l.length > 60 ? l.slice(0, 60) + '…' : l);
 
         const header = count > 0 ? `[转发消息: ${count}条]` : `[转发消息]`;
         const text = previewLines.length > 0 ? `${header}\n${previewLines.map((l) => `  ${l}`).join('\n')}` : header;
@@ -1077,6 +1097,10 @@ export class SimpleMessageParser {
             const name = escapeHtmlFast(m?.sender?.name || (m?.sender?.uin ? String(m.sender.uin) : '未知'));
             const body = escapeHtmlFast((m?.content?.text || '').replace(/\s+/g, ' ').trim());
             return `<li><span class="forward-inner-sender">${name}</span><span class="forward-inner-text">${body}</span></li>`;
+          }).join('')}</ul>`;
+        } else if (xmlPreview.length > 0) {
+          innerHtml = `<ul class="forward-inner">${xmlPreview.slice(0, 5).map((line) => {
+            return `<li><span class="forward-inner-text">${escapeHtmlFast(line)}</span></li>`;
           }).join('')}</ul>`;
         }
         return {

--- a/plugins/qq-chat-exporter/lib/core/parser/multiForwardXmlParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/multiForwardXmlParser.ts
@@ -1,0 +1,130 @@
+/**
+ * 解析 NapCat 推过来的 multiForwardMsgElement.xmlContent（issue #128 子项 3）。
+ *
+ * 当合并转发卡片无法通过 getMultiMsg 拉到子消息时（消息已过期 / NapCat 拒绝下发 / 嵌套过深），
+ * 旧版会把整段 XML 当作 summary 直接落进导出文件，导致 HTML / 搜索索引里出现 `<msg ... ><item ...>...`
+ * 这种 XML 原文。
+ *
+ * 这里用纯 regex 抠 QQ 客户端协议规定的固定结构（不引入 xml 依赖）：
+ *   <msg ...>
+ *     <item layout="1" ...>
+ *       <title size="34" ...>聊天记录头部（"群聊的聊天记录" / "好友的聊天记录"）</title>
+ *       <title size="26" ...>张三: 早</title>
+ *       <title size="26" ...>李四: 在吗</title>
+ *       ...
+ *       <hr .../>
+ *       <summary size="26" ...>查看N条转发消息</summary>
+ *     </item>
+ *     ...
+ *   </msg>
+ *
+ * 抠出 header / preview 行 / 末尾 summary，调用方可直接拿来塞进转发卡片占位预览，
+ * 不再把 XML 原文塞进 data.summary。
+ */
+
+export interface MultiForwardXmlInfo {
+    /** 卡片头部文本，如 "群聊的聊天记录" */
+    header: string;
+    /** 卡片中部可见的若干预览行（已 unescape，去除前后空白） */
+    previewLines: string[];
+    /** 卡片底部统计行，如 "查看7条转发消息"；解析不到时为空字符串 */
+    summary: string;
+    /** 若解析过程中能从 summary 中抠到数字则填上，否则为 0 */
+    messageCount: number;
+}
+
+const TITLE_RE = /<title\b([^>]*)>([\s\S]*?)<\/title>/g;
+const SUMMARY_RE = /<summary\b[^>]*>([\s\S]*?)<\/summary>/;
+
+/** size 属性是 QQ 客户端区分卡片层级用的：34 = header，26 = body（preview 行）。 */
+const HEADER_SIZE = '34';
+
+/**
+ * unescape XML 实体；QQ 这边只会用到 5 个标准 entity，外加 numeric character reference。
+ */
+function unescapeXmlEntities(input: string): string {
+    if (!input) return '';
+    return input
+        .replace(/&#x([0-9A-Fa-f]+);/g, (_, hex) => {
+            const code = parseInt(hex, 16);
+            return Number.isFinite(code) ? String.fromCodePoint(code) : '';
+        })
+        .replace(/&#(\d+);/g, (_, dec) => {
+            const code = parseInt(dec, 10);
+            return Number.isFinite(code) ? String.fromCodePoint(code) : '';
+        })
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&apos;/g, "'")
+        .replace(/&amp;/g, '&');
+}
+
+function extractAttribute(rawAttrs: string, name: string): string {
+    const re = new RegExp(`\\b${name}\\s*=\\s*"([^"]*)"`);
+    const match = rawAttrs.match(re);
+    return match ? match[1]! : '';
+}
+
+/**
+ * 判断给定字符串是否疑似 multiForwardMsg 的 XML 卡片。
+ *
+ * 用最严格的特征：必须出现 `<msg` 头 + `multiMsgFlag` 或 `viewMultiMsg`。
+ * 这样能排掉只是普通带尖括号的文本。
+ */
+export function looksLikeMultiForwardXml(s: string | null | undefined): boolean {
+    if (!s || typeof s !== 'string') return false;
+    const trimmed = s.trim();
+    if (!trimmed.startsWith('<')) return false;
+    if (!/<msg\b/i.test(trimmed)) return false;
+    return /multiMsgFlag\s*=|viewMultiMsg/i.test(trimmed);
+}
+
+/**
+ * 抠 QQ multiForwardMsg 卡片 XML 的可视部分。
+ * 解析失败时返回空 info（header / previewLines / summary 全空），调用方应当回退到 generic placeholder。
+ */
+export function parseMultiForwardXml(xml: string | null | undefined): MultiForwardXmlInfo {
+    const info: MultiForwardXmlInfo = {
+        header: '',
+        previewLines: [],
+        summary: '',
+        messageCount: 0
+    };
+    if (!xml || typeof xml !== 'string') return info;
+
+    const rawTitles: Array<{ attrs: string; text: string }> = [];
+    let m: RegExpExecArray | null;
+    TITLE_RE.lastIndex = 0;
+    while ((m = TITLE_RE.exec(xml)) !== null) {
+        rawTitles.push({ attrs: m[1] ?? '', text: unescapeXmlEntities(m[2] ?? '').trim() });
+        if (rawTitles.length > 32) break; // 防止恶意 XML 撑爆解析
+    }
+
+    if (rawTitles.length > 0) {
+        // 按 size 区分：先尝试取第一条 size="34" 当 header，其余 size!=34 当预览。
+        // 没有 size 标注时退化为「第一条 = header，其余 = preview」。
+        const headerEntry = rawTitles.find(t => extractAttribute(t.attrs, 'size') === HEADER_SIZE) ?? rawTitles[0];
+        if (headerEntry) {
+            info.header = headerEntry.text;
+        }
+        for (const t of rawTitles) {
+            if (t === headerEntry) continue;
+            if (!t.text) continue;
+            info.previewLines.push(t.text);
+            if (info.previewLines.length >= 16) break;
+        }
+    }
+
+    const summaryMatch = xml.match(SUMMARY_RE);
+    if (summaryMatch) {
+        info.summary = unescapeXmlEntities(summaryMatch[1] ?? '').trim();
+        const numMatch = info.summary.match(/(\d+)/);
+        if (numMatch) {
+            const n = parseInt(numMatch[1]!, 10);
+            if (Number.isFinite(n)) info.messageCount = n;
+        }
+    }
+
+    return info;
+}

--- a/plugins/qq-chat-exporter/package.json
+++ b/plugins/qq-chat-exporter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qq-chat-exporter",
   "plugin": "QQ 聊天记录导出",
-  "version": "5.5.60",
+  "version": "5.5.61",
   "description": "导出 QQ 聊天记录为 HTML / JSON / TXT / Excel，支持时间筛选、批量任务、定时任务、表情图片语音视频资源处理、合并转发展开等。",
   "main": "index.mjs",
   "type": "module",


### PR DESCRIPTION
## 修复合并转发卡片 XML 泄漏到导出（issue #128 子项 3）

### 问题
拉合并转发卡片里的子消息（`getMultiMsg`）失败时，老逻辑会直接把 NapCat 推下来的 `multiForwardMsgElement.xmlContent` 原样塞进 `data.summary`。前端导出 HTML 后会把这串

```xml
<msg multiMsgFlag="0" m_resid="..."><item layout="1"><title size="34">群聊的聊天记录</title><title size="26">小明: 你好</title>...<summary size="26">查看N条转发消息</summary></item></msg>
```

按 HTML 渲染，结果就是页面上出现一坨 `<msg>` `<item>` 标签的视觉残留；JSON / TXT 里也是 XML 原文，搜索索引被 `<msg>` `<item>` 这种垃圾词污染。

### 改法

| 位置 | 改动 |
|------|-----|
| `lib/core/parser/multiForwardXmlParser.ts`（新增） | 纯 regex 解析 `multiForwardMsg` 卡片 XML，抠出 `header` / `previewLines[]` / `summary` / `messageCount`，反转义 `&#x...;` `&lt;` `&amp;` 等实体 |
| `lib/core/parser/SimpleMessageParser.ts` | `parseElement` 里对 `multiForwardMsgElement` 调一次 `parseMultiForwardXml`；拉子消息失败 / 空时改用 XML 抠出来的预览行做 fallback；都没拿到就退回到占位文本 `查看转发消息`，绝不再塞 XML |
| `lib/core/exporter/ModernHtmlExporter.ts` | `renderForwardElement` 检测到 `summary` 长得像 XML（首字符 `<` 且带成对标签）时直接当 fallback 占位处理；改成优先用 `data.preview`，最多 5 行；搜索索引同步跳过 XML、加上 preview 行 |
| `__tests__/unit/multiForwardXmlParser.test.ts`（新增） | 9 项：识别真实卡片 XML / 普通 `<msg>` 不误命中 / 抠 header 预览 summary / 反转义 / 没 size 标记降级 / 上限保护 / messageCount 0 兜底 等 |
| `__tests__/unit/SimpleMessageParser.test.ts` | 更新原 `forward fallback` 期望（不再期望 XML 原文）+ 新增「getMultiMsg 失败但有 XML 预览行」回归 |

### 兼容性
- 新逻辑对 `summary` 字段做了 `looksLikeXml` 检测，老数据库里残留的 XML summary 在重新导出时会被自动跳过（不会渲染、不会进搜索索引）
- 内层消息（`messages[]`）能拉成功的场景，行为与之前完全一致
- 版本号一并 bump 到 5.5.61

### 测试
- 250 / 250 unit test 全绿（含新增 9 + 1 测试）

issue #128 子项 1 / 2 / 4 / 5 已分别在 v5.5.53 / v5.5.57 / v5.5.59 落地，本 PR 闭环子项 3。