### PR TITLE
fix(reply): 把 senderUin / timestamp / 可读文件名补到 reply 数据里 (#128)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/JsonExporter.groupMixedMedia.snap.json
+++ b/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/JsonExporter.groupMixedMedia.snap.json
@@ -272,7 +272,9 @@
             "data": {
               "messageId": "m_1",
               "referencedMessageId": "m_1",
+              "senderUin": "11111",
               "senderName": "",
+              "timestamp": 1704067300,
               "content": "Anyone seen the build break?"
             }
           }

--- a/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/TextExporter.groupMixedMedia.snap.txt
+++ b/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/TextExporter.groupMixedMedia.snap.txt
@@ -47,7 +47,7 @@ Alice (PM):
 时间: 2024-01-01 00:04:00
 内容: [回复 : Anyone seen the build break?]
 thanks team, fix incoming
-回复:  - Anyone seen the build break?
+回复: 01-01 00:01 - Anyone seen the build break?
 
 
 Alice (PM):

--- a/plugins/qq-chat-exporter/__tests__/unit/SimpleMessageParser.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/SimpleMessageParser.test.ts
@@ -322,6 +322,65 @@ test('reply uses group card from referenced message even when replyElement carri
     assert.equal(replyEl!.data.senderName, 'Bob (PM)');
 });
 
+test('reply preview uses readable face / video / file names instead of placeholder indices (#128)', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    // 被引用消息：一段文本 + 一个视频 + 一个文件 + 一个表情 ID
+    const original = msg()
+        .sender({ uid: 'u_bob', uin: '22222', nick: 'Bob' })
+        .text('看看这个：')
+        .video({ filename: '会议录像.mp4' })
+        .file({ filename: '议程.pdf' })
+        .face(0)  // /微 在 faceMap 里映射过的
+        .at_time(T + 0)
+        .build();
+    const reply = msg()
+        .sender({ uid: 'u_alice', uin: '11111', nick: 'Alice' })
+        .reply({ sourceMsgId: original.msgId, msgSeq: original.msgSeq, msgTime: Number(original.msgTime) })
+        .text('收到')
+        .at_time(T + 60)
+        .build();
+    const parsed = await parser.parseMessages([original, reply]);
+    const replyEl = parsed[1].content.elements.find((e) => e.type === 'reply');
+    assert.ok(replyEl, 'expected a reply element');
+    // content 字符串里看得到带文件名的占位符
+    assert.match(replyEl!.data.content, /\[视频:会议录像\.mp4\]/);
+    assert.match(replyEl!.data.content, /\[文件:议程\.pdf\]/);
+    // /微 是 faceMap 里 faceId=0 的预定义读音，不该再是 [表情0]
+    assert.doesNotMatch(replyEl!.data.content, /\[表情0\]/);
+    // previewElements 里也要带可读 fileName / faceIndex
+    const previews: any[] = replyEl!.data.previewElements || [];
+    const videoPreview = previews.find((p: any) => p.type === 'video');
+    const filePreview = previews.find((p: any) => p.type === 'file');
+    const facePreview = previews.find((p: any) => p.type === 'face');
+    assert.equal(videoPreview?.fileName, '会议录像.mp4');
+    assert.equal(filePreview?.fileName, '议程.pdf');
+    assert.equal(facePreview?.faceIndex, 0);
+});
+
+test('reply data exposes referenced sender uin + epoch timestamp (#128)', async () => {
+    const { SimpleMessageParser } = await loadParser();
+    const parser = new SimpleMessageParser({ html: 'none' });
+    const original = msg()
+        .sender({ uid: 'u_bob', uin: '22222', nick: 'Bob' })
+        .text('the question')
+        .at_time(T + 0)
+        .build();
+    const reply = msg()
+        .sender({ uid: 'u_alice', uin: '11111', nick: 'Alice' })
+        .reply({ sourceMsgId: original.msgId, msgSeq: original.msgSeq, msgTime: Number(original.msgTime) })
+        .text('the answer')
+        .at_time(T + 60)
+        .build();
+    const parsed = await parser.parseMessages([original, reply]);
+    const replyEl = parsed[1].content.elements.find((e) => e.type === 'reply');
+    assert.ok(replyEl, 'expected a reply element');
+    assert.equal(replyEl!.data.senderUin, '22222');
+    // SimpleMessageParser 的 reply 走的是被引用消息的 msgTime（秒级 epoch）
+    assert.equal(typeof replyEl!.data.timestamp, 'number');
+    assert.equal(replyEl!.data.timestamp, Number(original.msgTime));
+});
+
 test('forward element preserves resId and surfaces records via map', async () => {
     const { SimpleMessageParser } = await loadParser();
     const parser = new SimpleMessageParser({ html: 'none' });

--- a/plugins/qq-chat-exporter/lib/core/exporter/ExcelExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ExcelExporter.ts
@@ -506,11 +506,16 @@ export class ExcelExporter extends BaseExporter {
         }
         
         if (content.reply) {
+            // issue #128：Excel 行里的 reply 元素同步带上 referencedMessageId / senderUin / timestamp，
+            // 跟 JSON 字段保持一致，方便用户在 Excel 里直接拉时间列做透视。
             elements.push({
                 type: 'reply',
                 data: {
                     messageId: content.reply.messageId,
+                    referencedMessageId: content.reply.referencedMessageId,
+                    senderUin: content.reply.senderUin,
                     senderName: content.reply.senderName,
+                    timestamp: content.reply.timestamp,
                     content: content.reply.content
                 }
             });

--- a/plugins/qq-chat-exporter/lib/core/exporter/JsonExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/JsonExporter.ts
@@ -1067,12 +1067,16 @@ export class JsonExporter extends BaseExporter {
 
         // 添加回复元素
         if (content.reply) {
+            // issue #128：被引用消息的时间戳直接挂出来（秒级 epoch），
+            // 调用方就不用再回查 messageMap 自己组装"几月几日 几点几分"了。
             elements.push({
                 type: 'reply',
                 data: {
                     messageId: content.reply.messageId,
                     referencedMessageId: content.reply.referencedMessageId, // 被引用消息的实际messageId
+                    senderUin: content.reply.senderUin,
                     senderName: content.reply.senderName,
+                    timestamp: content.reply.timestamp,
                     content: content.reply.content
                 }
             });

--- a/plugins/qq-chat-exporter/lib/core/exporter/TextExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/TextExporter.ts
@@ -12,6 +12,23 @@ import { ParsedMessage } from '../parser/MessageParser.js';
 import { SimpleMessageParser, CleanMessage } from '../parser/SimpleMessageParser.js';
 
 /**
+ * issue #128：把被引用消息时间戳渲染成 "MM-DD HH:MM" 标签。
+ * 接受秒级 epoch / 毫秒级 epoch / 数字字符串，全都归一到毫秒后再 toLocaleString。
+ * 老数据里 timestamp 字段缺失或为 0 时直接返回空串，调用方看到空串就跳过。
+ */
+function formatReplyTimeLabel(ts: number): string {
+    if (!Number.isFinite(ts) || ts <= 0) return '';
+    const ms = ts < 1e12 ? ts * 1000 : ts;
+    const d = new Date(ms);
+    if (Number.isNaN(d.getTime())) return '';
+    const mm = String(d.getMonth() + 1).padStart(2, '0');
+    const dd = String(d.getDate()).padStart(2, '0');
+    const hh = String(d.getHours()).padStart(2, '0');
+    const min = String(d.getMinutes()).padStart(2, '0');
+    return `${mm}-${dd} ${hh}:${min}`;
+}
+
+/**
  * 文本格式选项接口
  */
 interface TextFormatOptions {
@@ -141,7 +158,21 @@ export class TextExporter extends BaseExporter {
         const cleanMessages = await simpleParser.parseMessages(messages);
         
         // 将CleanMessage转换为ParsedMessage格式
-        return cleanMessages.map((cleanMsg: CleanMessage): ParsedMessage => ({
+        return cleanMessages.map((cleanMsg: CleanMessage): ParsedMessage => {
+            // issue #128：从 cleanMsg.content.elements 里把 type=reply 的数据回挂到
+            // content.reply，这样 formatMessage 能直接走"回复: 时间 名字 - 内容"那条路径。
+            const replyEl = (cleanMsg.content.elements || []).find((el: any) => el?.type === 'reply');
+            const reply = replyEl?.data && typeof replyEl.data === 'object' ? {
+                messageId: String(replyEl.data.messageId ?? ''),
+                referencedMessageId: replyEl.data.referencedMessageId,
+                senderUin: replyEl.data.senderUin,
+                senderName: replyEl.data.senderName,
+                timestamp: typeof replyEl.data.timestamp === 'number' ? replyEl.data.timestamp : undefined,
+                content: typeof replyEl.data.content === 'string' ? replyEl.data.content : '',
+                elements: []
+            } : undefined;
+
+            return {
             messageId: cleanMsg.id,
             messageSeq: cleanMsg.seq,
             timestamp: new Date(cleanMsg.timestamp),
@@ -181,6 +212,7 @@ export class TextExporter extends BaseExporter {
                     checkedAt: new Date()
                 })),
                 emojis: [],
+                reply,
                 special: []
             },
             stats: {
@@ -190,7 +222,8 @@ export class TextExporter extends BaseExporter {
                 processingTime: 0
             },
             rawMessage: {} as any // 没有原始消息数据
-        }));
+            };
+        });
     }
 
     /**
@@ -316,7 +349,14 @@ export class TextExporter extends BaseExporter {
         }
         
         if (message.content.reply) {
-            lines.push(`回复: ${message.content.reply.senderName} - ${message.content.reply.content}`);
+            // issue #128：被引用消息的时间戳如果拿到，就在前面加一个"MM-DD HH:MM"，
+            // 让纯文本导出也能看出引用的是几点几分的消息。
+            const reply = message.content.reply;
+            const ts = typeof reply.timestamp === 'number' && reply.timestamp > 0 ? reply.timestamp : 0;
+            const tsLabel = ts ? formatReplyTimeLabel(ts) : '';
+            const sender = reply.senderName || '';
+            const head = tsLabel ? `${tsLabel} ${sender}`.trim() : sender;
+            lines.push(`回复: ${head} - ${reply.content}`);
         }
         
         return lines.map(line => this.wrapLine(line));

--- a/plugins/qq-chat-exporter/lib/core/parser/MessageParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/MessageParser.ts
@@ -258,7 +258,11 @@ export interface ParsedMessageContent {
   reply?: {
     messageId: string;
     referencedMessageId?: string;  // 被引用消息的实际messageId，用于链接跳转
+    // issue #128：senderUin / timestamp 直接挂在 content.reply 上，导出器
+    // (JSON / TXT / Excel) 不用再回查 messageMap 自己组装。
+    senderUin?: string;
     senderName?: string;
+    timestamp?: number;
     content: string;
     elements?: any[];
   };
@@ -1412,10 +1416,30 @@ export class MessageParser {
       }
     }
 
+    // issue #128：被引用消息的 senderUin / timestamp 也回填到 reply 数据上，
+    // 这样 JSON / TXT / Excel 等导出器不用再回查 messageMap 自己组装。
+    let referencedTimestamp: number | undefined;
+    let referencedSenderUin: string | undefined;
+    if (referencedMessageId && this.messageMap.has(referencedMessageId)) {
+      const ref = this.messageMap.get(referencedMessageId);
+      if (ref?.msgTime) referencedTimestamp = parseInt(ref.msgTime as any) || undefined;
+      if (ref?.senderUin) referencedSenderUin = ref.senderUin;
+    }
+    // NapCat 上游字段名拼成 replayMsgTime（多了个 a），但旧测试 / 极少数兼容字段
+    // 又写成 replyMsgTime，两个都兜一下，避免老回放数据导致 timestamp 丢失。
+    if (!referencedTimestamp && (reply.replayMsgTime || (reply as any).replyMsgTime)) {
+      referencedTimestamp = Number(reply.replayMsgTime || (reply as any).replyMsgTime) || undefined;
+    }
+    if (!referencedSenderUin && reply.senderUin) {
+      referencedSenderUin = reply.senderUin;
+    }
+
     return {
       messageId: sourceMsgId,      // 保留原始的sourceMsgIdInRecords用于内部查找
       referencedMessageId,         // 使用 replayMsgId 作为被引用消息的实际ID
+      senderUin: referencedSenderUin,
       senderName: reply.senderUidStr || '',
+      timestamp: referencedTimestamp,
       content: this.extractReplyContent(reply, messageRef),
       elements: []
     };
@@ -1639,10 +1663,23 @@ export class MessageParser {
         for (const element of referencedMessage.elements) {
           if (element.textElement) b.push(element.textElement.content || '');
           else if (element.picElement) b.push('[图片]');
-          else if (element.videoElement) b.push('[视频]');
+          else if (element.videoElement) {
+            // issue #128：视频 / 文件元素带文件名时直接挂在占位符里，
+            // JSON / TXT / Excel 这些纯文本导出能看出原消息引用的是哪个视频。
+            const name = element.videoElement.fileName || '';
+            b.push(name ? `[视频:${name}]` : '[视频]');
+          }
           else if (element.pttElement) b.push('[语音]');
-          else if (element.fileElement) b.push(`[文件: ${element.fileElement.fileName || ''}]`);
-          else if (element.faceElement) b.push(`[表情${element.faceElement.faceIndex}]`);
+          else if (element.fileElement) {
+            const name = element.fileElement.fileName || '';
+            b.push(name ? `[文件:${name}]` : '[文件]');
+          }
+          else if (element.faceElement) {
+            // issue #128：表情元素优先用 faceText / faceMap 给出的可读名（如 /微 /奋）。
+            const faceId = element.faceElement.faceIndex?.toString() || '';
+            const faceText = element.faceElement.faceText || this.faceMap.get(faceId) || `表情${faceId}`;
+            b.push(faceText.startsWith('[') ? faceText : `[${faceText}]`);
+          }
           else if (element.marketFaceElement) {
             const faceName = element.marketFaceElement.faceName || '超级表情';
             b.push(`[${faceName}]`);

--- a/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
@@ -1723,27 +1723,38 @@ export class SimpleMessageParser {
               fileName: element.picElement.fileName || ''
             });
           } else if (element.videoElement) {
-            parts.push('[视频]');
+            // issue #128：视频 / 文件元素带文件名时直接挂在占位符里，
+            // JSON / TXT / Excel 这些纯文本导出能看出原消息引用的是哪个视频。
+            const videoName = element.videoElement.fileName || '';
+            const videoText = videoName ? `[视频:${videoName}]` : '[视频]';
+            parts.push(videoText);
             result.previewElements.push({
               type: 'video',
-              text: '[视频]',
-              fileName: element.videoElement.fileName || ''
+              text: videoText,
+              fileName: videoName
             });
           } else if (element.pttElement) {
             parts.push('[语音]');
             result.previewElements.push({ type: 'audio', text: '[语音]' });
           } else if (element.fileElement) {
-            parts.push('[文件]');
+            const fileName = element.fileElement.fileName || '';
+            const fileText = fileName ? `[文件:${fileName}]` : '[文件]';
+            parts.push(fileText);
             result.previewElements.push({
               type: 'file',
-              text: '[文件]',
-              fileName: element.fileElement.fileName || ''
+              text: fileText,
+              fileName
             });
           } else if (element.faceElement) {
-            parts.push(`[表情${element.faceElement.faceIndex}]`);
+            // issue #128：表情元素优先用 faceText / faceMap 给出的可读名（如 /微 /奋），
+            // 而不是抛"[表情341]"这种调用方还得自己查表的占位文本。
+            const faceId = element.faceElement.faceIndex?.toString() || '';
+            const faceText = element.faceElement.faceText || this.faceMap.get(faceId) || `表情${faceId}`;
+            const facePart = faceText.startsWith('[') ? faceText : `[${faceText}]`;
+            parts.push(facePart);
             result.previewElements.push({
               type: 'face',
-              text: `[表情${element.faceElement.faceIndex}]`,
+              text: facePart,
               faceIndex: element.faceElement.faceIndex
             });
           } else if (element.marketFaceElement) {

--- a/plugins/qq-chat-exporter/package.json
+++ b/plugins/qq-chat-exporter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qq-chat-exporter",
   "plugin": "QQ 聊天记录导出",
-  "version": "5.5.61",
+  "version": "5.5.62",
   "description": "导出 QQ 聊天记录为 HTML / JSON / TXT / Excel，支持时间筛选、批量任务、定时任务、表情图片语音视频资源处理、合并转发展开等。",
   "main": "index.mjs",
   "type": "module",


### PR DESCRIPTION
## Summary

reply 数据原来在导出器（JSON / TXT / Excel）里只露 `messageId / senderName / content` 三个字段，调用方还得自己回查 messageMap 才能拿到被引用消息的 QQ 号 / 发送时间，且 content 里把视频 / 文件 / 表情都吞成了「[视频]」「[文件]」「[表情341]」这种没意义的占位符。这版把数据补齐：

| 文件 | 改动 |
|---|---|
| `SimpleMessageParser.extractReplyContent` | 视频 / 文件占位符带文件名（`[视频:foo.mp4]`）；表情走 `faceMap`，给出 `[/微]` 这种可读名而不是 `[表情341]`；`previewElements` 同步带可读字段 |
| `MessageParser.parseReplyElement` | 从 `messageMap` 回填被引用消息的 `senderUin` / `timestamp`（秒级 epoch），缺失时退到 `reply.replayMsgTime` / `replyMsgTime` 兼容老回放数据 |
| `MessageParser.extractReplyContent` | 同步使用可读占位符 |
| `ParsedMessageContent.reply` 接口 | 加 `senderUin?` / `timestamp?` 字段 |
| `JsonExporter.convertContentToElements` | reply 元素带上 `senderUin` / `timestamp` |
| `ExcelExporter.convertContentToElements` | 同步加 `referencedMessageId` / `senderUin` / `timestamp` |
| `TextExporter` | CleanMessage 转 ParsedMessage 时把 `type=reply` 元素回挂到 `content.reply`；渲染 reply 行时给 senderName 前面加 `"MM-DD HH:MM"` 时间标签，老数据无 timestamp 直接跳过 |
| 测试 | 新增 2 项单元测试（可读 face / video / file 名 + `senderUin` / `timestamp` 暴露）；刷新 JSON / TXT 集成快照 |

向后兼容：reply 接口的 `senderUin` / `timestamp` 都是可选字段，缺失时导出器走原行为，不会让历史导出数据缺字段崩掉。

bump `5.5.61 → 5.5.62`。259 / 259 测试全绿（含集成快照）。