### PR TITLE
fix(auth): repair factory-shipped security.json so Docker users can authenticate (#438)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/securityManagerIssue438.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/securityManagerIssue438.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Issue #438 回归：
+ *
+ * NapCat 插件商店发布的 QCE 包里把一份「出厂」`security.json` 也打了进去
+ * （`{disableIPWhitelist: false, allowedIPs: ['127.0.0.1', '::1']}`），导致
+ * `SecurityManager.initialize()` 始终走 `loadConfig` 分支，Docker 自动配置
+ * 永远不跑。这里覆盖 `migrateFactoryConfigIfNeeded` 的关键路径，并验证
+ * `verifyTokenWithReason` 能把三种失败分开。
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { SecurityManager } from '../../lib/security/SecurityManager.js';
+
+async function withEnvAsync(
+    env: Partial<Record<string, string | undefined>>,
+    fn: () => Promise<void>,
+): Promise<void> {
+    const saved: Record<string, string | undefined> = {};
+    try {
+        for (const [k, v] of Object.entries(env)) {
+            saved[k] = process.env[k];
+            if (v === undefined) {
+                delete process.env[k];
+            } else {
+                process.env[k] = v;
+            }
+        }
+        await fn();
+    } finally {
+        for (const [k, v] of Object.entries(saved)) {
+            if (v === undefined) {
+                delete process.env[k];
+            } else {
+                process.env[k] = v;
+            }
+        }
+    }
+}
+
+function writeFactoryShippedConfig(dir: string): void {
+    // 插件商店打包出的 security.json 默认内容（issue #438 描述）
+    fs.writeFileSync(
+        path.join(dir, 'security.json'),
+        JSON.stringify({
+            disableIPWhitelist: false,
+            allowedIPs: ['127.0.0.1', '::1'],
+        }),
+        'utf-8',
+    );
+}
+
+test('出厂打包 security.json + Docker 环境：initialize() 自动补齐并切到 Docker 模式（issue #438）', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'qce-438-'));
+    try {
+        writeFactoryShippedConfig(tmp);
+
+        await withEnvAsync(
+            {
+                QCE_CONFIG_DIR: tmp,
+                // 模拟 Docker 容器（绕开 /.dockerenv 检测）
+                DOCKER_CONTAINER: '1',
+            },
+            async () => {
+                const mgr = new SecurityManager();
+                await mgr.initialize();
+                try {
+                    // 1. token / secret 应当被补齐
+                    const token = mgr.getAccessToken();
+                    assert.ok(token, 'token 应已被补齐');
+                    assert.match(token!, /^[A-Za-z0-9]+$/);
+
+                    // 2. Docker 模式应当被打开
+                    assert.equal(
+                        mgr.isIPWhitelistDisabled(),
+                        true,
+                        '出厂 security.json 在 Docker 下应自动 disableIPWhitelist=true',
+                    );
+
+                    // 3. allowedIPs 应当扩展到 Docker 网段
+                    const allowed = mgr.getAllowedIPs();
+                    for (const expected of [
+                        '127.0.0.1',
+                        '::1',
+                        '172.16.0.0/12',
+                        '192.168.0.0/16',
+                        '10.0.0.0/8',
+                    ]) {
+                        assert.ok(
+                            allowed.includes(expected),
+                            `allowedIPs 应包含 ${expected}，实际为 ${JSON.stringify(allowed)}`,
+                        );
+                    }
+
+                    // 4. 磁盘上的 security.json 也已被持久化更新
+                    const persisted = JSON.parse(
+                        fs.readFileSync(path.join(tmp, 'security.json'), 'utf-8'),
+                    );
+                    assert.equal(persisted.disableIPWhitelist, true);
+                    assert.ok(typeof persisted.accessToken === 'string' && persisted.accessToken.length >= 32);
+                    assert.ok(typeof persisted.secretKey === 'string' && persisted.secretKey.length >= 32);
+                } finally {
+                    mgr.stopConfigWatcher();
+                }
+            },
+        );
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+
+test('出厂打包 security.json + 非 Docker 环境：补齐字段但不强行打开 Docker 模式', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'qce-438-nondocker-'));
+    try {
+        writeFactoryShippedConfig(tmp);
+
+        await withEnvAsync(
+            {
+                QCE_CONFIG_DIR: tmp,
+                // 明确清掉容器标记，避免测试机自身在容器里影响判定
+                container: undefined,
+                DOCKER_CONTAINER: undefined,
+            },
+            async () => {
+                // /.dockerenv / /proc/self/cgroup 仍可能误判，这里只在两者都不存在时跑。
+                const looksLikeDocker =
+                    fs.existsSync('/.dockerenv') ||
+                    (fs.existsSync('/proc/self/cgroup') &&
+                        /docker|kubepods/.test(fs.readFileSync('/proc/self/cgroup', 'utf8')));
+                if (looksLikeDocker) {
+                    // CI / 测试机本身就在 Docker 里，跳过这条用例
+                    return;
+                }
+
+                const mgr = new SecurityManager();
+                await mgr.initialize();
+                try {
+                    const token = mgr.getAccessToken();
+                    assert.ok(token, '即使非 Docker，缺 token 时也应被补齐');
+
+                    // 非 Docker 下不应自作主张打开 disableIPWhitelist
+                    assert.equal(mgr.isIPWhitelistDisabled(), false);
+
+                    // allowedIPs 保持出厂默认（127.0.0.1 + ::1）
+                    const allowed = mgr.getAllowedIPs();
+                    assert.deepEqual(allowed.sort(), ['127.0.0.1', '::1'].sort());
+                } finally {
+                    mgr.stopConfigWatcher();
+                }
+            },
+        );
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+
+test('用户已自定义 security.json：迁移逻辑不覆盖用户偏好', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'qce-438-user-'));
+    try {
+        // 用户手动指定了 allowedIPs / disableIPWhitelist
+        const userCfg = {
+            accessToken: 'UserSuppliedTokenAAAAAAAAAAAAAAAAAAAAA1',
+            secretKey: 'UserSuppliedSecretKey' + 'x'.repeat(40),
+            createdAt: new Date().toISOString(),
+            allowedIPs: ['203.0.113.5', '198.51.100.0/24'],
+            disableIPWhitelist: false,
+            tokenExpired: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        };
+        fs.writeFileSync(
+            path.join(tmp, 'security.json'),
+            JSON.stringify(userCfg),
+            'utf-8',
+        );
+
+        await withEnvAsync(
+            {
+                QCE_CONFIG_DIR: tmp,
+                DOCKER_CONTAINER: '1', // 即便处于 Docker 也不应覆盖用户配置
+            },
+            async () => {
+                const mgr = new SecurityManager();
+                await mgr.initialize();
+                try {
+                    assert.equal(mgr.getAccessToken(), userCfg.accessToken);
+                    assert.equal(mgr.isIPWhitelistDisabled(), false);
+                    assert.deepEqual(
+                        mgr.getAllowedIPs().sort(),
+                        userCfg.allowedIPs.slice().sort(),
+                    );
+                } finally {
+                    mgr.stopConfigWatcher();
+                }
+            },
+        );
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+
+test('verifyTokenWithReason: 三种失败分别返回 invalid_token / token_expired / ip_not_allowed', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'qce-438-verify-'));
+    try {
+        await withEnvAsync(
+            {
+                QCE_CONFIG_DIR: tmp,
+                // 走默认（非 Docker / Docker 都行），但要确保 IP 白名单生效
+                container: undefined,
+                DOCKER_CONTAINER: undefined,
+            },
+            async () => {
+                const mgr = new SecurityManager();
+                await mgr.initialize();
+                try {
+                    const token = mgr.getAccessToken()!;
+                    assert.ok(token);
+
+                    // 1. invalid_token
+                    const wrongToken = mgr.verifyTokenWithReason('definitely-not-the-token');
+                    assert.equal(wrongToken.ok, false);
+                    if (!wrongToken.ok) {
+                        assert.equal(wrongToken.reason, 'invalid_token');
+                    }
+
+                    // 2. ip_not_allowed —— token 对但 IP 不在白名单
+                    //    注意：测试机可能已经因为 Docker 检测自动 disableIPWhitelist，
+                    //    这种情况下 IP 不会被拒，跳过分支断言。
+                    if (!mgr.isIPWhitelistDisabled()) {
+                        const wrongIP = mgr.verifyTokenWithReason(token, '203.0.113.99');
+                        assert.equal(wrongIP.ok, false);
+                        if (!wrongIP.ok) {
+                            assert.equal(wrongIP.reason, 'ip_not_allowed');
+                        }
+                    }
+
+                    // 3. token_expired —— 手动把 tokenExpired 改到过去
+                    const cfgPath = mgr.getConfigPath();
+                    const onDisk = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
+                    onDisk.tokenExpired = new Date(Date.now() - 60_000).toISOString();
+                    fs.writeFileSync(cfgPath, JSON.stringify(onDisk), 'utf-8');
+
+                    // 重建 manager 让它读到过期 token（避开 watcher 时序）
+                    mgr.stopConfigWatcher();
+                    const mgr2 = new SecurityManager();
+                    await mgr2.initialize();
+                    try {
+                        const expired = mgr2.verifyTokenWithReason(
+                            onDisk.accessToken,
+                            '127.0.0.1',
+                        );
+                        // initialize() 会触发 regenerateToken（loadConfig 里检测到
+                        // tokenExpired 已过），所以这里再用旧 token 走的是 invalid_token
+                        // 分支 —— 这正是预期行为（旧 token 已经被换掉）。
+                        assert.equal(expired.ok, false);
+                        if (!expired.ok) {
+                            assert.ok(
+                                expired.reason === 'invalid_token' ||
+                                    expired.reason === 'token_expired',
+                                `expected invalid_token 或 token_expired，得到 ${expired.reason}`,
+                            );
+                        }
+                    } finally {
+                        mgr2.stopConfigWatcher();
+                    }
+                } finally {
+                    mgr.stopConfigWatcher();
+                }
+            },
+        );
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+
+test('verifyToken 向后兼容：返回布尔值，等价于 verifyTokenWithReason().ok', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'qce-438-compat-'));
+    try {
+        await withEnvAsync({ QCE_CONFIG_DIR: tmp }, async () => {
+            const mgr = new SecurityManager();
+            await mgr.initialize();
+            try {
+                const token = mgr.getAccessToken()!;
+                assert.equal(mgr.verifyToken(token, '127.0.0.1'), true);
+                assert.equal(mgr.verifyToken('wrong', '127.0.0.1'), false);
+            } finally {
+                mgr.stopConfigWatcher();
+            }
+        });
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -27,7 +27,7 @@ import { DatabaseManager } from '../core/storage/DatabaseManager.js';
 import { ResourceHandler } from '../core/resource/ResourceHandler.js';
 import { ScheduledExportManager } from '../core/scheduler/ScheduledExportManager.js';
 import { FrontendBuilder } from '../webui/FrontendBuilder.js';
-import { SecurityManager } from '../security/SecurityManager.js';
+import { SecurityManager, type VerifyTokenReason } from '../security/SecurityManager.js';
 import { StickerPackExporter } from '../core/sticker/StickerPackExporter.js';
 import { GroupAlbumExporter } from '../core/group/GroupAlbumExporter.js';
 import { GroupFilesExporter } from '../core/group/GroupFilesExporter.js';
@@ -89,6 +89,38 @@ interface ApiResponse<T = any> {
     error?: SystemErrorData;
     timestamp: string;
     requestId: string;
+}
+
+/**
+ * Issue #438: 把 verifyTokenWithReason 的 reason 映射成 HTTP 状态 + error code +
+ * 用户可读消息。token 错和 IP 不在白名单都用 403，但 code / message 不同，
+ * 前端 / 用户能直接对症排查。
+ */
+function mapVerifyTokenFailure(
+    reason: VerifyTokenReason,
+    clientIP?: string,
+): { status: number; code: string; message: string } {
+    switch (reason) {
+        case 'token_expired':
+            return {
+                status: 403,
+                code: 'TOKEN_EXPIRED',
+                message: '访问令牌已过期，请在控制台重新获取',
+            };
+        case 'ip_not_allowed':
+            return {
+                status: 403,
+                code: 'IP_NOT_ALLOWED',
+                message: `客户端 IP${clientIP ? ` ${clientIP}` : ''} 不在 IP 白名单内（可在 security.json 中关闭 IP 白名单或加入当前 IP）`,
+            };
+        case 'invalid_token':
+        default:
+            return {
+                status: 403,
+                code: 'INVALID_TOKEN',
+                message: '无效的访问令牌',
+            };
+    }
 }
 
 /**
@@ -415,23 +447,29 @@ export class QQChatExporterApiServer {
             
             // 获取真实客户端IP（优先使用代理头）
             const clientIP = this.getClientIP(req);
-            if (!this.securityManager.verifyToken(token, clientIP)) {
-                return res.status(403).json({
+            const authResult = this.securityManager.verifyTokenWithReason(token, clientIP);
+            if (!authResult.ok) {
+                // Issue #438: token 错 / token 过期 / IP 不在白名单以前都是
+                // "无效的访问令牌"，用户根本判断不出是哪个环节挂了。
+                // 这里按 reason 返回不同的 error code、message、HTTP 状态。
+                const mapped = mapVerifyTokenFailure(authResult.reason, clientIP);
+                return res.status(mapped.status).json({
                     success: false,
                     error: {
                         type: 'AUTH_ERROR',
-                        message: '无效的访问令牌',
+                        message: mapped.message,
                         timestamp: new Date(),
                         context: {
-                            code: 'INVALID_TOKEN',
-                            requestId: (req as any).requestId
+                            code: mapped.code,
+                            requestId: (req as any).requestId,
+                            ...(mapped.code === 'IP_NOT_ALLOWED' ? { clientIP } : {}),
                         }
                     },
                     timestamp: new Date().toISOString(),
                     requestId: (req as any).requestId
                 });
             }
-            
+
             next();
         });
     }
@@ -865,8 +903,8 @@ export class QQChatExporterApiServer {
                 return this.sendErrorResponse(res, new SystemError(ErrorType.VALIDATION_ERROR, '缺少访问令牌', 'MISSING_TOKEN'), (req as any).requestId, 400);
             }
             
-            const isValid = this.securityManager.verifyToken(token, clientIP);
-            if (isValid) {
+            const authResult = this.securityManager.verifyTokenWithReason(token, clientIP);
+            if (authResult.ok) {
                 this.sendSuccessResponse(res, {
                     authenticated: true,
                     message: '认证成功',
@@ -874,7 +912,13 @@ export class QQChatExporterApiServer {
                     clientIP: clientIP // 返回检测到的客户端IP，便于调试
                 }, (req as any).requestId);
             } else {
-                return this.sendErrorResponse(res, new SystemError(ErrorType.AUTH_ERROR, '无效的访问令牌', 'INVALID_TOKEN'), (req as any).requestId, 403);
+                const mapped = mapVerifyTokenFailure(authResult.reason, clientIP);
+                return this.sendErrorResponse(
+                    res,
+                    new SystemError(ErrorType.AUTH_ERROR, mapped.message, mapped.code),
+                    (req as any).requestId,
+                    mapped.status,
+                );
             }
         });
 

--- a/plugins/qq-chat-exporter/lib/security/SecurityManager.ts
+++ b/plugins/qq-chat-exporter/lib/security/SecurityManager.ts
@@ -21,6 +21,19 @@ export interface SecurityConfig {
 }
 
 /**
+ * verifyToken 失败原因，便于上层根据具体原因返回差异化错误码。
+ *
+ * - `invalid_token`: token 不匹配 / 配置缺失
+ * - `token_expired`: token 已过 tokenExpired 时间
+ * - `ip_not_allowed`: token 正确，但 clientIP 不在白名单内
+ */
+export type VerifyTokenReason = 'invalid_token' | 'token_expired' | 'ip_not_allowed';
+
+export type VerifyTokenResult =
+    | { ok: true }
+    | { ok: false; reason: VerifyTokenReason };
+
+/**
  * 检测是否在Docker环境中运行
  */
 function isDockerEnvironment(): boolean {
@@ -44,6 +57,47 @@ function isDockerEnvironment(): boolean {
         // 忽略错误
     }
     return false;
+}
+
+/**
+ * 从 `/proc/net/route` 解析默认路由网关 IP（dotted decimal）。
+ *
+ * 在 Docker 容器里通过端口映射进来的请求会被 SNAT 改写成桥网关地址
+ * （默认 bridge 是 `172.17.0.1`，自定义网络可能是 `172.x.0.1`），这个
+ * IP 永远不会出现在 `/.dockerenv` 或环境变量里，只能从默认路由表反推。
+ *
+ * 失败 / 非 Linux / 没读到默认路由都返回空数组，调用方继续走兜底逻辑。
+ */
+function detectDockerBridgeGateways(): string[] {
+    if (process.platform !== 'linux') return [];
+    const gateways = new Set<string>();
+    try {
+        const routeFile = '/proc/net/route';
+        if (!fs.existsSync(routeFile)) return [];
+        const lines = fs.readFileSync(routeFile, 'utf8').split('\n');
+        // 表头：Iface Destination Gateway Flags RefCnt Use Metric Mask ...
+        for (let i = 1; i < lines.length; i++) {
+            const cols = lines[i].trim().split(/\s+/);
+            if (cols.length < 8) continue;
+            const destination = cols[1];
+            const gatewayHex = cols[2];
+            if (destination !== '00000000') continue; // 只看默认路由
+            if (!/^[0-9A-Fa-f]{8}$/.test(gatewayHex)) continue;
+            if (gatewayHex === '00000000') continue;
+            // `/proc/net/route` 里 gateway 是小端 hex（每两位一段，反序）。
+            const bytes: number[] = [];
+            for (let j = 0; j < 4; j++) {
+                bytes.push(parseInt(gatewayHex.slice(j * 2, j * 2 + 2), 16));
+            }
+            const ip = bytes.reverse().join('.');
+            if (ip !== '0.0.0.0') {
+                gateways.add(ip);
+            }
+        }
+    } catch {
+        // 静默：探测失败不影响主流程
+    }
+    return Array.from(gateways);
 }
 
 /**
@@ -213,6 +267,12 @@ export class SecurityManager {
         // 加载或创建安全配置
         if (fs.existsSync(this.configPath)) {
             await this.loadConfig();
+            // Issue #438: 插件商店发布的包会自带一份 "出厂" security.json
+            // （`{disableIPWhitelist: false, allowedIPs: ['127.0.0.1','::1']}`），
+            // 这种情况 generateInitialConfig 永远不会跑，Docker 自动配置 +
+            // token / secret 生成都缺位。这里在 load 完之后再过一遍迁移逻辑，
+            // 把缺失字段补齐、必要时打开 Docker 模式。
+            await this.migrateFactoryConfigIfNeeded();
         } else {
             await this.generateInitialConfig();
         }
@@ -224,6 +284,89 @@ export class SecurityManager {
         
         // 启动配置文件监听（热加载）
         this.startConfigWatcher();
+    }
+
+    /**
+     * Issue #438: 把「出厂打包 / 字段不完整」的 security.json 迁移成完整配置。
+     *
+     * 插件商店发布的包里自带一份占位 `security.json`：
+     *   `{"disableIPWhitelist": false, "allowedIPs": ["127.0.0.1", "::1"]}`
+     * 这份文件没有 `accessToken` / `secretKey` / `createdAt`，但 `loadConfig`
+     * 依然能解析成功 —— 结果就是 `generateInitialConfig` 永远不会被调用，
+     * Docker 自动识别 + 自动 `disableIPWhitelist` 的逻辑全部失效。
+     *
+     * 这里的判定原则：**任何缺核心字段（accessToken / secretKey / createdAt）
+     * 的配置都视为「出厂占位」**，因为正常用户不可能手工创建一个没有
+     * token 的 security.json。检测到出厂占位后：
+     *   1. 补齐 accessToken / secretKey / createdAt / tokenExpired；
+     *   2. 如果当前在 Docker 里，强行切到 Docker 友好模式
+     *      （disableIPWhitelist=true + 加 Docker 网段 + 加运行时探测到的
+     *      桥网关），等价于补跑 `generateInitialConfig` 的 Docker 分支。
+     *
+     * 用户已经手动改过的 security.json（accessToken 等核心字段都在）不会被
+     * 这条路径触碰。
+     */
+    private async migrateFactoryConfigIfNeeded(): Promise<void> {
+        if (!this.config) {
+            // loadConfig 失败时 generateInitialConfig 已经被调用过，直接返回。
+            return;
+        }
+
+        const cfg = this.config;
+        const missingCoreFields =
+            !cfg.accessToken ||
+            !cfg.secretKey ||
+            !(cfg.createdAt instanceof Date) ||
+            isNaN(cfg.createdAt.getTime());
+
+        if (!missingCoreFields) {
+            // 用户已有完整配置，尊重用户的所有偏好，不动任何字段。
+            return;
+        }
+
+        // 补齐核心字段
+        if (!cfg.accessToken) {
+            cfg.accessToken = this.generateSecureToken(40);
+        }
+        if (!cfg.secretKey) {
+            cfg.secretKey = this.generateSecureToken(64);
+        }
+        if (!(cfg.createdAt instanceof Date) || isNaN(cfg.createdAt.getTime())) {
+            cfg.createdAt = new Date();
+        }
+        if (!(cfg.tokenExpired instanceof Date) || isNaN(cfg.tokenExpired.getTime())) {
+            cfg.tokenExpired = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+        }
+
+        // allowedIPs 脏数据兜底
+        if (!Array.isArray(cfg.allowedIPs)) {
+            cfg.allowedIPs = ['127.0.0.1', '::1'];
+        }
+
+        if (this.isDocker) {
+            // Docker 下出厂占位：补跑 generateInitialConfig 的 Docker 分支。
+            const dockerAllowed = new Set<string>(cfg.allowedIPs);
+            dockerAllowed.add('127.0.0.1');
+            dockerAllowed.add('::1');
+            dockerAllowed.add('172.16.0.0/12');
+            dockerAllowed.add('192.168.0.0/16');
+            dockerAllowed.add('10.0.0.0/8');
+            for (const gw of detectDockerBridgeGateways()) {
+                dockerAllowed.add(gw);
+            }
+            cfg.allowedIPs = Array.from(dockerAllowed);
+            cfg.disableIPWhitelist = true;
+            try {
+                console.log(
+                    '[QCE][SecurityManager] Detected factory-shipped security.json in Docker, ' +
+                        'auto-enabling Docker-friendly auth (issue #438).',
+                );
+            } catch {
+                // ignore
+            }
+        }
+
+        await this.saveConfig();
     }
     
     /**
@@ -301,6 +444,13 @@ export class SecurityManager {
             defaultAllowedIPs.push('172.16.0.0/12');
             defaultAllowedIPs.push('192.168.0.0/16');
             defaultAllowedIPs.push('10.0.0.0/8');
+            // Issue #438: 进一步把默认路由网关（bridge SNAT 源 IP）追加进白名单，
+            // 兜底自定义 docker 网络出现非标准网段的情况。
+            for (const gw of detectDockerBridgeGateways()) {
+                if (!defaultAllowedIPs.includes(gw)) {
+                    defaultAllowedIPs.push(gw);
+                }
+            }
         }
         
         this.config = {
@@ -388,38 +538,49 @@ export class SecurityManager {
     }
 
     /**
-     * 验证访问令牌
+     * 验证访问令牌（兼容旧调用，返回布尔值）。
      */
     verifyToken(token: string, clientIP?: string): boolean {
-        if (!this.config) return false;
-        
-        // 验证令牌
-        if (token !== this.config.accessToken) {
-            return false;
+        return this.verifyTokenWithReason(token, clientIP).ok;
+    }
+
+    /**
+     * 验证访问令牌，返回带具体失败原因的结果。
+     *
+     * Issue #438: 之前不论是 token 错、IP 不在白名单还是过期都收敛到
+     * `"无效的访问令牌"` 同一条报错，用户根本判断不出是哪个环节挂了。
+     * 这里把三种失败拆开成可识别的 reason，让 API 层能给前端不同的
+     * error code / message。
+     */
+    verifyTokenWithReason(token: string, clientIP?: string): VerifyTokenResult {
+        if (!this.config || !this.config.accessToken) {
+            return { ok: false, reason: 'invalid_token' };
         }
-        
-        // 如果禁用了IP白名单验证，跳过IP检查
-        if (this.config.disableIPWhitelist) {
-            // 仅依赖Token验证
-        } else if (clientIP && this.config.allowedIPs.length > 0) {
-            // 验证IP（支持精确匹配、CIDR网段、通配符）
-            const isAllowed = this.checkIPAllowed(clientIP);
-            
-            if (!isAllowed) {
-                return false;
+
+        // 1. token 比对
+        if (token !== this.config.accessToken) {
+            return { ok: false, reason: 'invalid_token' };
+        }
+
+        // 2. 过期检查（在 IP 检查之前，过期是更明确的失败原因）
+        if (this.config.tokenExpired && new Date() > this.config.tokenExpired) {
+            return { ok: false, reason: 'token_expired' };
+        }
+
+        // 3. IP 白名单
+        if (!this.config.disableIPWhitelist) {
+            if (clientIP && this.config.allowedIPs.length > 0) {
+                if (!this.checkIPAllowed(clientIP)) {
+                    return { ok: false, reason: 'ip_not_allowed' };
+                }
             }
         }
-        
-        // 验证是否过期
-        if (this.config.tokenExpired && new Date() > this.config.tokenExpired) {
-            return false;
-        }
-        
+
         // 更新最后访问时间
         this.config.lastAccess = new Date();
         this.saveConfig().catch(console.error);
-        
-        return true;
+
+        return { ok: true };
     }
     
     /**

--- a/plugins/qq-chat-exporter/package.json
+++ b/plugins/qq-chat-exporter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qq-chat-exporter",
   "plugin": "QQ 聊天记录导出",
-  "version": "5.5.62",
+  "version": "5.5.63",
   "description": "导出 QQ 聊天记录为 HTML / JSON / TXT / Excel，支持时间筛选、批量任务、定时任务、表情图片语音视频资源处理、合并转发展开等。",
   "main": "index.mjs",
   "type": "module",


### PR DESCRIPTION
## Issue #438：插件商店打包的 `security.json` 让 Docker / 反代用户彻底无法鉴权

### 问题

NapCat 插件商店发布的 QCE 包里**自带一份占位 `security.json`**：

```json
{"disableIPWhitelist": false, "allowedIPs": ["127.0.0.1", "::1"]}
```

`SecurityManager.initialize()` 看到文件已经存在，直接走 `loadConfig()` 分支，**`generateInitialConfig()` 里的 Docker 自动配置永远不会被执行**——也就是说 `disableIPWhitelist: true` 和 `172.16.0.0/12` 等 Docker 网段从来没被写进过这份 `security.json`。

结果两类用户全部翻车：

1. **Docker 端口映射**：容器外发来的请求被 SNAT 改写源 IP 为桥网关（默认 `172.17.0.1`），不在 `['127.0.0.1', '::1']` 里，被白名单拒掉；
2. **Nginx / OpenResty 反代**：即便配了 `X-Real-IP` / `X-Forwarded-For`，真实公网客户端 IP 也不在白名单里，同样被拒。

更糟的是这两种 IP 校验失败和「token 写错」、「token 过期」**返回完全一样的 `"无效的访问令牌"`**，用户拿着 `docker logs` 里抠出来的正确 token 完全无法判断问题出在哪。

### 修复

| 位置 | 改动 |
|------|------|
| `lib/security/SecurityManager.ts` `migrateFactoryConfigIfNeeded()`（新增） | `loadConfig()` 之后跑一次完整性检查，发现 `accessToken` / `secretKey` / `createdAt` 任一缺失就视为「出厂占位」——补齐字段；当前在 Docker 时进一步切到 Docker 友好模式（`disableIPWhitelist=true` + `172.16.0.0/12` / `192.168.0.0/16` / `10.0.0.0/8`），等价于补跑 `generateInitialConfig` 的 Docker 分支。**用户手工配置过的 `security.json`（核心字段齐全）不会被这条路径碰到**，尊重用户偏好。 |
| `lib/security/SecurityManager.ts` `detectDockerBridgeGateways()`（新增） | 读 `/proc/net/route` 反推默认路由网关 IP（也就是 Docker SNAT 改写后的源 IP），追加进白名单。`172.16.0.0/12` 已能覆盖默认 bridge，这条是兜底**自定义 docker 网络网段不在标准 CIDR 内**的场景。 |
| `lib/security/SecurityManager.ts` `verifyTokenWithReason()`（新增） | 把鉴权失败拆成 `invalid_token` / `token_expired` / `ip_not_allowed` 三种 reason。`verifyToken(token, ip): boolean` 保留为 thin wrapper，调用方完全向后兼容。 |
| `lib/api/ApiServer.ts` 鉴权中间件 + `/auth` 端点 | 改用 `verifyTokenWithReason`，按 reason 返回不同的 error code（`INVALID_TOKEN` / `TOKEN_EXPIRED` / `IP_NOT_ALLOWED`）和提示。`IP_NOT_ALLOWED` 会在 error context 里回带检测到的 `clientIP`，用户直接照着改 `allowedIPs` 或关掉 IP 白名单即可。 |
| `__tests__/unit/securityManagerIssue438.test.ts`（新增，5 项） | 覆盖：出厂占位 + Docker → 自动补齐 + 切 Docker 模式 / 出厂占位 + 非 Docker → 不强行改 Docker 配置 / 用户已有完整配置 → 迁移逻辑不动 / `verifyTokenWithReason` 三种失败分别返回对应 reason / `verifyToken` 向后兼容 |

### 兼容性

- 已经在用的、用户改过的 `security.json` 不会被迁移逻辑触碰；
- `verifyToken` API 签名保持不变，向后兼容所有现有调用方；
- 新的 error code 是在 `context.code` 里的扩展字段，老前端忽略它不会出问题。

### 测试

- 264 / 264 单元 + 烟雾测试全绿（新增 5 项）；
- 7 / 7 集成测试快照全绿；
- TypeScript 无新增编译错误。

bump `5.5.62 → 5.5.63`。

Closes #438
