### PR TITLE
fix(launcher): boot Linux QQ via Electron + LD_PRELOAD shim (#433)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/napcatLinuxLauncher.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/napcatLinuxLauncher.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Sanity tests for the LD_PRELOAD launcher shim that backs the Linux flow
+ * (see scripts/napcat-launcher/launcher.cpp, issue #433).
+ *
+ * The shim is the load-bearing piece of the fix: it tells QQ Electron to
+ * boot loadNapCat.js out of the QCE pack directory instead of QQ's own
+ * app_launcher/index.js, so wrapper.node runs inside the Electron embedder
+ * it was built for instead of plain Node.js (which segfaults on login).
+ *
+ * Tests:
+ *   1. The .cpp builds with the project's build.sh.
+ *   2. When LD_PRELOAD'd into `cat`, opening a fake `resources/app/package.json`
+ *      returns a modified buffer with `main` rewritten to loadNapCat.js.
+ *   3. Opening unrelated paths passes through unchanged.
+ *
+ * Skipped (not failed) when:
+ *   - We're not on Linux (the shim is Linux-only).
+ *   - g++ is unavailable (g++ is part of the standard build environment;
+ *     skipping here just keeps `npm test` runnable on bare boxes).
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync, spawnSync } from 'node:child_process';
+
+import { createTempDir } from '../helpers/tempDir.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const LAUNCHER_DIR = path.join(REPO_ROOT, 'scripts', 'napcat-launcher');
+const LAUNCHER_CPP = path.join(LAUNCHER_DIR, 'launcher.cpp');
+const BUILD_SH = path.join(LAUNCHER_DIR, 'build.sh');
+
+function hasGpp(): boolean {
+    const r = spawnSync('g++', ['--version'], { stdio: 'ignore' });
+    return r.status === 0;
+}
+
+const linuxOnly = process.platform === 'linux';
+const skipReason = !linuxOnly
+    ? 'napcat-launcher is Linux-only'
+    : !hasGpp()
+        ? 'g++ not available'
+        : !fs.existsSync(LAUNCHER_CPP)
+            ? 'launcher.cpp not present'
+            : null;
+
+test('napcat-launcher: sources are present', () => {
+    assert.ok(fs.existsSync(LAUNCHER_CPP), `${LAUNCHER_CPP} should exist`);
+    assert.ok(fs.existsSync(BUILD_SH), `${BUILD_SH} should exist`);
+});
+
+test('napcat-launcher: build.sh produces a loadable .so', { skip: skipReason ?? false }, () => {
+    const tmp = createTempDir('napcat-launcher-build-');
+    try {
+        const out = path.join(tmp.path, 'libnapcat_launcher.so');
+        execFileSync(BUILD_SH, [out], {
+            cwd: tmp.path,
+            stdio: ['ignore', 'ignore', 'pipe'],
+        });
+        const stat = fs.statSync(out);
+        assert.ok(stat.size > 0, 'built .so should be non-empty');
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+test('napcat-launcher: package.json main field is rewritten under LD_PRELOAD', { skip: skipReason ?? false }, () => {
+    const tmp = createTempDir('napcat-launcher-hook-');
+    try {
+        // 1. Build the shim.
+        const so = path.join(tmp.path, 'libnapcat_launcher.so');
+        execFileSync(BUILD_SH, [so], {
+            cwd: tmp.path,
+            stdio: ['ignore', 'ignore', 'pipe'],
+        });
+
+        // 2. Lay down a fake QQ install with the asar-style main field.
+        const qqRoot = path.join(tmp.path, 'fakeqq', 'resources', 'app');
+        fs.mkdirSync(qqRoot, { recursive: true });
+        const fakePkgJson = path.join(qqRoot, 'package.json');
+        fs.writeFileSync(
+            fakePkgJson,
+            JSON.stringify(
+                {
+                    name: 'qq',
+                    version: '3.2.28-48517',
+                    main: './application.asar/app_launcher/index.js',
+                },
+                null,
+                2,
+            ),
+        );
+
+        // 3. Spawn `cat` against a *suffix-matching* path so the hook fires,
+        //    and point NAPCAT_QQ_PKG_JSON at the real file so the shim
+        //    actually has bytes to patch.
+        const suffixPath = path.join(qqRoot, 'package.json'); // ends in resources/app/package.json
+        const cwdForLauncher = tmp.path;
+
+        const r = spawnSync('cat', [suffixPath], {
+            cwd: cwdForLauncher,
+            env: {
+                ...process.env,
+                LD_PRELOAD: so,
+                NAPCAT_QQ_PKG_JSON: fakePkgJson,
+                NAPCAT_LAUNCHER_DEBUG: '0',
+            },
+            encoding: 'utf8',
+        });
+
+        assert.equal(r.status, 0, `cat exited non-zero: ${r.stderr}`);
+        const out = r.stdout;
+        assert.ok(
+            !out.includes('./application.asar/app_launcher/index.js'),
+            'original asar main should be replaced',
+        );
+        assert.ok(
+            out.includes('loadNapCat.js'),
+            `rewritten main should reference loadNapCat.js, got: ${out}`,
+        );
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+test('napcat-launcher: unrelated paths are passed through unchanged', { skip: skipReason ?? false }, () => {
+    const tmp = createTempDir('napcat-launcher-passthrough-');
+    try {
+        const so = path.join(tmp.path, 'libnapcat_launcher.so');
+        execFileSync(BUILD_SH, [so], {
+            cwd: tmp.path,
+            stdio: ['ignore', 'ignore', 'pipe'],
+        });
+
+        const otherFile = path.join(tmp.path, 'unrelated.txt');
+        const payload = 'pristine bytes; should not be intercepted';
+        fs.writeFileSync(otherFile, payload);
+
+        const r = spawnSync('cat', [otherFile], {
+            cwd: tmp.path,
+            env: {
+                ...process.env,
+                LD_PRELOAD: so,
+                NAPCAT_LAUNCHER_DEBUG: '0',
+            },
+            encoding: 'utf8',
+        });
+
+        assert.equal(r.status, 0, `cat exited non-zero: ${r.stderr}`);
+        assert.equal(r.stdout, payload);
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+test('napcat-launcher: plain (non-asar) main is also rewritten', { skip: skipReason ?? false }, () => {
+    const tmp = createTempDir('napcat-launcher-plain-');
+    try {
+        const so = path.join(tmp.path, 'libnapcat_launcher.so');
+        execFileSync(BUILD_SH, [so], {
+            cwd: tmp.path,
+            stdio: ['ignore', 'ignore', 'pipe'],
+        });
+
+        const qqRoot = path.join(tmp.path, 'fakeqq', 'resources', 'app');
+        fs.mkdirSync(qqRoot, { recursive: true });
+        const fakePkgJson = path.join(qqRoot, 'package.json');
+        // The launcher matches the canonical formatting QQ ships
+        // (`"main": "..."`, with a space after the colon). QQNT's
+        // package.json has historically used this layout; we mirror it in
+        // the fixture so the test exercises the exact bytes the shim sees
+        // on a real install.
+        fs.writeFileSync(
+            fakePkgJson,
+            JSON.stringify(
+                {
+                    name: 'qq',
+                    main: './application/app_launcher/index.js',
+                },
+                null,
+                2,
+            ),
+        );
+
+        const r = spawnSync('cat', [fakePkgJson], {
+            cwd: tmp.path,
+            env: {
+                ...process.env,
+                LD_PRELOAD: so,
+                NAPCAT_QQ_PKG_JSON: fakePkgJson,
+                NAPCAT_LAUNCHER_DEBUG: '0',
+            },
+            encoding: 'utf8',
+        });
+
+        assert.equal(r.status, 0, `cat exited non-zero: ${r.stderr}`);
+        assert.ok(
+            !r.stdout.includes('./application/app_launcher/index.js'),
+            'plain (non-asar) main should be replaced',
+        );
+        assert.ok(r.stdout.includes('loadNapCat.js'));
+    } finally {
+        tmp.cleanup();
+    }
+});

--- a/plugins/qq-chat-exporter/package-lock.json
+++ b/plugins/qq-chat-exporter/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qq-chat-exporter",
-  "version": "5.5.0",
+  "version": "5.5.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qq-chat-exporter",
-      "version": "5.5.0",
+      "version": "5.5.64",
       "dependencies": {
         "@breezystack/lamejs": "^1.2.7",
         "@types/archiver": "^7.0.0",

--- a/plugins/qq-chat-exporter/package.json
+++ b/plugins/qq-chat-exporter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qq-chat-exporter",
   "plugin": "QQ 聊天记录导出",
-  "version": "5.5.63",
+  "version": "5.5.64",
   "description": "导出 QQ 聊天记录为 HTML / JSON / TXT / Excel，支持时间筛选、批量任务、定时任务、表情图片语音视频资源处理、合并转发展开等。",
   "main": "index.mjs",
   "type": "module",

--- a/scripts/napcat-launcher/.gitignore
+++ b/scripts/napcat-launcher/.gitignore
@@ -1,0 +1,2 @@
+*.so
+loadNapCat.js

--- a/scripts/napcat-launcher/README.md
+++ b/scripts/napcat-launcher/README.md
@@ -1,0 +1,70 @@
+# napcat-launcher — Linux LD_PRELOAD shim (issue #433)
+
+This shim is what makes the QCE Linux package boot into the real QQ Electron
+process instead of plain Node.js. It is a Linux-only artefact; macOS and
+Windows use other launchers.
+
+## Why it exists
+
+Before this, `launcher-user.sh` ran:
+
+```
+node napcat-bootstrap.mjs
+```
+
+which loaded NapCat's `napcat.mjs` (and through it, QQ's `wrapper.node`)
+into a vanilla Node.js process. `wrapper.node` is a Chromium/Electron native
+addon — it assumes the embedder set up V8 isolates and the libstdc++ runtime
+the way Electron does. When loaded into stock Node, the C++ STL state inside
+the addon ends up half-initialised; the first
+`std::vector<std::string>::_M_realloc_insert` after `session.startNT()` reads
+a corrupted `_M_start` and crashes:
+
+```
+#0  ... std::vector<std::string>::_M_realloc_insert<...>
+        at /opt/QQ/resources/app/wrapper.node
+#1  0x0
+```
+
+That is the segfault users on Fedora 44, Debian 13, NixOS, Arch and
+Ubuntu 24.04 see immediately after the QR-code login completes.
+
+## How it fixes the bug
+
+`launcher.cpp` is `LD_PRELOAD`'d into the real QQ binary
+(`/opt/QQ/qq` or equivalent). It hooks `open`, `openat` and `fopen` and:
+
+1. Intercepts QQ's `resources/app/package.json` and rewrites the `main`
+   field to point at our `loadNapCat.js`.
+2. Synthesises `loadNapCat.js` (in memory via `memfd`, with a disk fallback)
+   that imports `napcat.mjs` from the QCE pack directory.
+
+`wrapper.node` therefore runs inside the Electron embedder it was built for,
+the std::vector layout matches and login completes cleanly.
+
+This is a port of [NapNeko/napcat-linux-launcher](https://github.com/NapNeko/napcat-linux-launcher),
+with three QCE-specific changes:
+
+1. `NAPCAT_JS_CONTENT` imports `./napcat.mjs` (QCE pack layout) instead of
+   `./napcat/napcat.mjs` (NapCat-only layout).
+2. QQ's `package.json` path is overridable via `NAPCAT_QQ_PKG_JSON`
+   (`launcher-user.sh` auto-detects it from the QQ install).
+3. Logging is gated behind `NAPCAT_LAUNCHER_DEBUG` so the normal stdout
+   stays clean.
+
+## Building
+
+`scripts/quick-pack.py` pre-compiles `libnapcat_launcher.so` into the
+Linux release tarball during packaging. For ad-hoc local builds:
+
+```bash
+./build.sh                                  # → libnapcat_launcher.so next to this README
+./build.sh /tmp/libnapcat_launcher_test.so  # → custom output path
+```
+
+The launcher script (`launcher-user.sh`) recompiles in place if the bundled
+`.so` is missing.
+
+## Tests
+
+See `plugins/qq-chat-exporter/__tests__/unit/napcatLinuxLauncher.test.ts`.

--- a/scripts/napcat-launcher/build.sh
+++ b/scripts/napcat-launcher/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Build the QCE Linux launcher shim (libnapcat_launcher.so).
+#
+# Invoked both during release packaging (scripts/quick-pack.py) and as an
+# in-place fallback from launcher-user.sh when the shipped .so is missing
+# (e.g. user is on a Linux arch we did not pre-build for).
+#
+# Usage:
+#   ./build.sh [out_path]
+#
+# The output path defaults to ./libnapcat_launcher.so next to the script.
+
+set -u
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CPP="$SCRIPT_DIR/launcher.cpp"
+OUT="${1:-$SCRIPT_DIR/libnapcat_launcher.so}"
+
+if [ ! -f "$CPP" ]; then
+    echo "[build.sh] launcher.cpp not found at $CPP" >&2
+    exit 1
+fi
+
+if ! command -v g++ >/dev/null 2>&1; then
+    echo "[build.sh] g++ not available. Install build-essential (Debian/Ubuntu)" >&2
+    echo "           or @development tools (RHEL/Fedora) and re-run." >&2
+    exit 1
+fi
+
+g++ -shared -fPIC -O2 -o "$OUT" "$CPP" -ldl
+echo "[build.sh] built $OUT"

--- a/scripts/napcat-launcher/launcher.cpp
+++ b/scripts/napcat-launcher/launcher.cpp
@@ -1,0 +1,552 @@
+// QCE Linux launcher shim — LD_PRELOAD hook that lets QCE boot inside the
+// real QQ Electron process instead of a vanilla Node.js process.
+//
+// Why this exists (issue #433):
+//
+//   The previous launcher-user.sh ran `node napcat-bootstrap.mjs`, then loaded
+//   napcat.mjs (and through it, QQ's wrapper.node) into a plain Node.js
+//   process. wrapper.node is a Chromium/Electron native addon — it assumes
+//   the embedder set up V8 isolates and the libstdc++ runtime the way
+//   Electron does. When loaded into stock Node, the C++ STL state inside the
+//   addon ends up half-initialised; the first vector<string>::_M_realloc_insert
+//   after `session.startNT()` reads a corrupted _M_start and crashes:
+//
+//     #0  0x...x in std::vector<std::string>::_M_realloc_insert<...>
+//             at /opt/QQ/resources/app/wrapper.node
+//     #1  0x0
+//
+//   That is the segfault users on Fedora 44 / Debian 13 / Arch / Ubuntu
+//   24.04 / NixOS see immediately after the QR-code login completes.
+//
+// The fix:
+//
+//   Run the actual /opt/QQ/qq binary (Electron) and use LD_PRELOAD to swap
+//   QQ's package.json `main` to point at our loadNapCat.js, which in turn
+//   imports napcat.mjs from the QCE pack directory. wrapper.node now loads
+//   inside the Electron embedder it was built for, the vector layout matches,
+//   and login completes cleanly.
+//
+//   This is a direct port of the LD_PRELOAD shim NapNeko/napcat-linux-launcher
+//   uses (https://github.com/NapNeko/napcat-linux-launcher), with three
+//   QCE-specific changes:
+//
+//     1. NAPCAT_JS_CONTENT imports `./napcat.mjs` (QCE pack layout) instead
+//        of `./napcat/napcat.mjs` (NapCat-only layout).
+//     2. The path of QQ's package.json is overridable via the
+//        NAPCAT_QQ_PKG_JSON env var (set by launcher-user.sh from the
+//        auto-detected QQ install).
+//     3. Logging is gated behind the NAPCAT_LAUNCHER_DEBUG env var so the
+//        normal stdout stays clean.
+//
+// Build:
+//   g++ -shared -fPIC -O2 -o libnapcat_launcher.so launcher.cpp -ldl
+//
+// Use:
+//   LD_PRELOAD=./libnapcat_launcher.so \
+//     NAPCAT_BOOTMAIN=/path/to/NapCat-QCE-Linux-x64 \
+//     NAPCAT_QQ_PKG_JSON=/opt/QQ/resources/app/package.json \
+//     /opt/QQ/qq --no-sandbox
+//
+// Licensed under GPL-3.0, matching the QCE main repository.
+
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <limits.h>
+#include <libgen.h>
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+// Path patterns we hook. We match by suffix so that both relative
+// ("resources/app/package.json") and absolute ("/opt/QQ/resources/app/...")
+// lookups are caught; QQ's Electron uses both depending on the syscall path.
+static const char *TARGET_PACKAGE_JSON = "resources/app/package.json";
+static const char *TARGET_NAPCAT_JS = "resources/app/loadNapCat.js";
+
+// Default fallback if NAPCAT_QQ_PKG_JSON is unset. Linux QQ deb installs
+// land here; snap/flatpak/portable installs override via the env var.
+static const char *DEFAULT_PACKAGE_JSON = "/opt/QQ/resources/app/package.json";
+
+// The drop-in `main` field we look for in QQ's package.json. We try the
+// asar-packed form first (current QQNT) and the unpacked form second
+// (older installs and some semi-auto setups).
+static const char *ORIGINAL_MAIN_ASAR =
+    "\"main\": \"./application.asar/app_launcher/index.js\"";
+static const char *ORIGINAL_MAIN_PLAIN =
+    "\"main\": \"./application/app_launcher/index.js\"";
+
+// JS injected as the new entry point. NAPCAT_BOOTMAIN is exported by
+// launcher-user.sh and points at the QCE pack directory, where napcat.mjs
+// lives alongside the bundled NapCat runtime. We deliberately do NOT chain
+// through napcat-bootstrap.mjs: the bootstrap only existed to monkey-patch
+// process.execPath when running under plain Node, and under real Electron
+// process.execPath already points at the QQ binary.
+static const char *NAPCAT_JS_CONTENT =
+    "const path = require('path');"
+    "const CurrentPath = process.env.NAPCAT_BOOTMAIN || path.dirname(__filename);"
+    "(async () => {"
+    "  await import('file://' + path.join(CurrentPath, './napcat.mjs'));"
+    "})();";
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+// Caches the patched package.json so we don't re-read+re-allocate on every
+// hooked open(). Electron typically opens it via both `open64` and `fopen64`.
+static char *g_modified_package_json = nullptr;
+static char g_new_main[PATH_MAX + 128] = {0};
+static bool g_loadnapcat_disk_generated = false;
+
+static const char *qq_pkg_json_path()
+{
+    const char *p = getenv("NAPCAT_QQ_PKG_JSON");
+    if (p && *p)
+        return p;
+    return DEFAULT_PACKAGE_JSON;
+}
+
+static bool launcher_debug()
+{
+    static int cached = -1;
+    if (cached == -1)
+    {
+        const char *v = getenv("NAPCAT_LAUNCHER_DEBUG");
+        cached = (v && *v && strcmp(v, "0") != 0) ? 1 : 0;
+    }
+    return cached != 0;
+}
+
+#define LAUNCHER_LOG(...)                              \
+    do                                                 \
+    {                                                  \
+        if (launcher_debug())                          \
+        {                                              \
+            fprintf(stderr, "[napcat-launcher] " __VA_ARGS__); \
+            fputc('\n', stderr);                       \
+        }                                              \
+    } while (0)
+
+// ---------------------------------------------------------------------------
+// Path utilities
+// ---------------------------------------------------------------------------
+
+// True if `path` ends in `target` or equals it. Used so we match QQ's
+// package.json regardless of how Electron spelled the lookup.
+static bool path_matches(const char *path, const char *target)
+{
+    if (!path || !target)
+        return false;
+    size_t path_len = strlen(path);
+    size_t target_len = strlen(target);
+    if (path_len < target_len)
+        return false;
+    return strcmp(path, target) == 0 ||
+           strcmp(path + path_len - target_len, target) == 0;
+}
+
+// Build a POSIX relative path from `from_dir` to `to_dir`. Used to rewrite
+// QQ's `main` field so QQ Electron can load loadNapCat.js out of the QCE
+// pack directory regardless of where the user extracted it.
+static int get_relative_path(const char *from_dir, const char *to_dir,
+                             char *out, size_t out_size)
+{
+    char from[PATH_MAX], to[PATH_MAX];
+
+    if (!realpath(from_dir, from) || !realpath(to_dir, to))
+        return -1;
+
+    size_t from_len = strlen(from);
+    size_t to_len = strlen(to);
+
+    if (from_len + 2 >= PATH_MAX || to_len + 2 >= PATH_MAX)
+        return -1;
+
+    if (from[from_len - 1] != '/')
+    {
+        from[from_len++] = '/';
+        from[from_len] = '\0';
+    }
+    if (to[to_len - 1] != '/')
+    {
+        to[to_len++] = '/';
+        to[to_len] = '\0';
+    }
+
+    // Longest common prefix, snapped back to a path component boundary.
+    size_t common_len = 0;
+    while (common_len < from_len && common_len < to_len &&
+           from[common_len] == to[common_len])
+        common_len++;
+    while (common_len > 0 && from[common_len - 1] != '/')
+        common_len--;
+
+    size_t up_levels = 0;
+    for (size_t i = common_len; i < from_len; i++)
+        if (from[i] == '/')
+            up_levels++;
+
+    char result[PATH_MAX] = {0};
+    for (size_t i = 0; i < up_levels; i++)
+    {
+        if (strlen(result) + 3 >= sizeof(result))
+            return -1;
+        strcat(result, "../");
+    }
+    if (common_len < to_len)
+    {
+        if (strlen(result) + (to_len - common_len) >= sizeof(result))
+            return -1;
+        strcat(result, to + common_len);
+    }
+    // Drop a trailing '/' so we don't synthesise `../../..//loadNapCat.js`
+    // when concatenating below. Works for both the ".." chain only case and
+    // the chain + suffix case.
+    {
+        size_t rl = strlen(result);
+        if (rl > 1 && result[rl - 1] == '/')
+            result[rl - 1] = '\0';
+    }
+    if (strlen(result) == 0)
+        strcpy(result, ".");
+
+    strncpy(out, result, out_size - 1);
+    out[out_size - 1] = '\0';
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// package.json patching
+// ---------------------------------------------------------------------------
+
+static char *get_modified_packagejson()
+{
+    if (g_modified_package_json)
+        return g_modified_package_json;
+
+    // Use the libc fopen directly so we don't recurse into our own hook.
+    static FILE *(*real_fopen)(const char *, const char *) = nullptr;
+    if (!real_fopen)
+    {
+        real_fopen = (FILE * (*)(const char *, const char *))
+            dlsym(RTLD_NEXT, "fopen");
+        if (!real_fopen)
+            return nullptr;
+    }
+
+    const char *pkg_path = qq_pkg_json_path();
+    FILE *fp = real_fopen(pkg_path, "r");
+    if (!fp)
+    {
+        LAUNCHER_LOG("could not open %s: %s", pkg_path, strerror(errno));
+        return nullptr;
+    }
+
+    fseek(fp, 0, SEEK_END);
+    long file_size = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+    if (file_size <= 0)
+    {
+        fclose(fp);
+        return nullptr;
+    }
+
+    char *buffer = (char *)malloc(file_size + 1);
+    if (!buffer)
+    {
+        fclose(fp);
+        return nullptr;
+    }
+    size_t bytes_read = fread(buffer, 1, file_size, fp);
+    buffer[bytes_read] = 0;
+    fclose(fp);
+
+    // Try both the asar form and the plain form. If neither matches we hand
+    // back the buffer unmodified — Electron still loads it, just into the
+    // un-patched main, which lets users debug what went wrong instead of
+    // getting a hard-to-diagnose "package.json not found" failure.
+    const char *match = ORIGINAL_MAIN_ASAR;
+    char *main_pos = strstr(buffer, ORIGINAL_MAIN_ASAR);
+    if (!main_pos)
+    {
+        main_pos = strstr(buffer, ORIGINAL_MAIN_PLAIN);
+        match = ORIGINAL_MAIN_PLAIN;
+    }
+    if (!main_pos)
+    {
+        LAUNCHER_LOG("no known main entry in %s; passing through unmodified",
+                     pkg_path);
+        g_modified_package_json = buffer;
+        return buffer;
+    }
+
+    // Compute the path from package.json's directory to CWD (= QCE pack dir).
+    char pkg_dir[PATH_MAX], cwd[PATH_MAX], relpath[PATH_MAX];
+    strncpy(pkg_dir, pkg_path, PATH_MAX - 1);
+    pkg_dir[PATH_MAX - 1] = '\0';
+    char *last_slash = strrchr(pkg_dir, '/');
+    if (last_slash)
+        *last_slash = '\0';
+
+    if (!getcwd(cwd, sizeof(cwd)))
+    {
+        LAUNCHER_LOG("getcwd failed: %s", strerror(errno));
+        free(buffer);
+        return nullptr;
+    }
+    if (get_relative_path(pkg_dir, cwd, relpath, sizeof(relpath)) != 0)
+    {
+        LAUNCHER_LOG("get_relative_path(%s -> %s) failed", pkg_dir, cwd);
+        free(buffer);
+        return nullptr;
+    }
+
+    snprintf(g_new_main, sizeof(g_new_main),
+             "\"main\": \"%s/loadNapCat.js\"", relpath);
+
+    size_t prefix_size = main_pos - buffer;
+    size_t new_main_len = strlen(g_new_main);
+    size_t suffix_size = strlen(main_pos + strlen(match));
+    size_t new_size = prefix_size + new_main_len + suffix_size;
+
+    char *modified = (char *)malloc(new_size + 1);
+    if (!modified)
+    {
+        free(buffer);
+        return nullptr;
+    }
+    memcpy(modified, buffer, prefix_size);
+    memcpy(modified + prefix_size, g_new_main, new_main_len);
+    memcpy(modified + prefix_size + new_main_len,
+           main_pos + strlen(match), suffix_size);
+    modified[new_size] = 0;
+
+    free(buffer);
+    g_modified_package_json = modified;
+
+    LAUNCHER_LOG("relative path: %s", relpath);
+    LAUNCHER_LOG("new main field: %s", g_new_main);
+    return g_modified_package_json;
+}
+
+// ---------------------------------------------------------------------------
+// memfd-backed virtual file
+// ---------------------------------------------------------------------------
+
+static int create_memfd_with_content(const char *content)
+{
+    if (!content)
+        return -1;
+    int fd = syscall(SYS_memfd_create, "napcat_memfd", 0);
+    if (fd < 0)
+        return -1;
+    size_t len = strlen(content);
+    if (write(fd, content, len) != (ssize_t)len ||
+        lseek(fd, 0, SEEK_SET) == -1)
+    {
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+// Drop a real loadNapCat.js next to the launcher on disk as a fallback for
+// QQ versions that read it via syscalls we don't hook (e.g. mmap, statx).
+// This runs once when the .so is loaded — i.e. before QQ's main(), so CWD
+// is still the QCE pack directory.
+__attribute__((constructor))
+static void generate_loadnapcat_disk_fallback()
+{
+    if (g_loadnapcat_disk_generated)
+        return;
+    FILE *fp = fopen("loadNapCat.js", "w");
+    if (!fp)
+        return;
+    fwrite(NAPCAT_JS_CONTENT, 1, strlen(NAPCAT_JS_CONTENT), fp);
+    fclose(fp);
+    g_loadnapcat_disk_generated = true;
+    LAUNCHER_LOG("disk fallback loadNapCat.js written to CWD");
+}
+
+// ---------------------------------------------------------------------------
+// open()/fopen() hooks
+// ---------------------------------------------------------------------------
+
+static int handle_target_file(const char *pathname)
+{
+    if (path_matches(pathname, TARGET_PACKAGE_JSON))
+    {
+        char *content = get_modified_packagejson();
+        if (!content)
+        {
+            errno = ENOENT;
+            return -1;
+        }
+        LAUNCHER_LOG("intercepted package.json: %s", pathname);
+        return create_memfd_with_content(content);
+    }
+    if (path_matches(pathname, TARGET_NAPCAT_JS))
+    {
+        LAUNCHER_LOG("intercepted loadNapCat.js: %s", pathname);
+        return create_memfd_with_content(NAPCAT_JS_CONTENT);
+    }
+    return -1;
+}
+
+// Different processes reach the package.json through different libc entry
+// points: QQ Electron on Debian/Ubuntu uses `open64`/`fopen64`, NixOS and
+// musl-flavoured glibcs use `openat`, and coreutils `cat` (which we use in
+// our unit tests) goes through `openat` exclusively. Hook the union.
+
+extern "C" int open64(const char *pathname, int flags, ...)
+{
+    static int (*real_open64)(const char *, int, ...) = nullptr;
+    if (!real_open64)
+    {
+        real_open64 = (int (*)(const char *, int, ...))
+            dlsym(RTLD_NEXT, "open64");
+        if (!real_open64)
+            return -1;
+    }
+
+    int target_fd = handle_target_file(pathname);
+    if (target_fd >= 0)
+        return target_fd;
+
+    va_list args;
+    va_start(args, flags);
+    int result;
+    if (flags & O_CREAT)
+    {
+        int mode = va_arg(args, int);
+        result = real_open64(pathname, flags, mode);
+    }
+    else
+    {
+        result = real_open64(pathname, flags);
+    }
+    va_end(args);
+    return result;
+}
+
+extern "C" int open(const char *pathname, int flags, ...)
+{
+    static int (*real_open)(const char *, int, ...) = nullptr;
+    if (!real_open)
+    {
+        real_open = (int (*)(const char *, int, ...))
+            dlsym(RTLD_NEXT, "open");
+        if (!real_open)
+            return -1;
+    }
+
+    int target_fd = handle_target_file(pathname);
+    if (target_fd >= 0)
+        return target_fd;
+
+    va_list args;
+    va_start(args, flags);
+    int result;
+    if (flags & O_CREAT)
+    {
+        int mode = va_arg(args, int);
+        result = real_open(pathname, flags, mode);
+    }
+    else
+    {
+        result = real_open(pathname, flags);
+    }
+    va_end(args);
+    return result;
+}
+
+extern "C" int openat(int dirfd, const char *pathname, int flags, ...)
+{
+    static int (*real_openat)(int, const char *, int, ...) = nullptr;
+    if (!real_openat)
+    {
+        real_openat = (int (*)(int, const char *, int, ...))
+            dlsym(RTLD_NEXT, "openat");
+        if (!real_openat)
+            return -1;
+    }
+
+    // Only intercept absolute paths — relative-to-dirfd lookups against
+    // arbitrary parent directories are rare in practice (Electron always
+    // hands us absolute paths) and trying to resolve them here would be
+    // fragile.
+    if (pathname && pathname[0] == '/')
+    {
+        int target_fd = handle_target_file(pathname);
+        if (target_fd >= 0)
+            return target_fd;
+    }
+
+    va_list args;
+    va_start(args, flags);
+    int result;
+    if (flags & O_CREAT)
+    {
+        int mode = va_arg(args, int);
+        result = real_openat(dirfd, pathname, flags, mode);
+    }
+    else
+    {
+        result = real_openat(dirfd, pathname, flags);
+    }
+    va_end(args);
+    return result;
+}
+
+extern "C" FILE *fopen64(const char *pathname, const char *mode)
+{
+    int target_fd = handle_target_file(pathname);
+    if (target_fd >= 0)
+    {
+        FILE *fp = fdopen(target_fd, mode);
+        if (!fp)
+            close(target_fd);
+        return fp;
+    }
+    static FILE *(*real_fopen64)(const char *, const char *) = nullptr;
+    if (!real_fopen64)
+    {
+        real_fopen64 = (FILE * (*)(const char *, const char *))
+            dlsym(RTLD_NEXT, "fopen64");
+        if (!real_fopen64)
+            return nullptr;
+    }
+    return real_fopen64(pathname, mode);
+}
+
+extern "C" FILE *fopen(const char *pathname, const char *mode)
+{
+    int target_fd = handle_target_file(pathname);
+    if (target_fd >= 0)
+    {
+        FILE *fp = fdopen(target_fd, mode);
+        if (!fp)
+            close(target_fd);
+        return fp;
+    }
+    static FILE *(*real_fopen)(const char *, const char *) = nullptr;
+    if (!real_fopen)
+    {
+        real_fopen = (FILE * (*)(const char *, const char *))
+            dlsym(RTLD_NEXT, "fopen");
+        if (!real_fopen)
+            return nullptr;
+    }
+    return real_fopen(pathname, mode);
+}

--- a/scripts/quick-pack.py
+++ b/scripts/quick-pack.py
@@ -721,7 +721,51 @@ extern "C" void qq_magic_napi_register(void *m) {
             if os.path.exists(so_path):
                 os.remove(so_path)
         print()
-    
+
+        # Pre-compile libnapcat_launcher.so for Linux (fixes issue #433).
+        #
+        # Before this, launcher-user.sh ran `node napcat-bootstrap.mjs`, which
+        # loaded QQ's wrapper.node into a plain Node.js process. wrapper.node
+        # is built for the Electron embedder, so its std::vector<...> state
+        # was half-initialised on Linux and the first realloc after login
+        # segfaulted (the SIGSEGV users on Fedora 44 / Debian 13 / NixOS /
+        # Arch / Ubuntu 24.04 reported in #433).
+        #
+        # The fix is to launch the real QQ Electron binary with an
+        # LD_PRELOAD shim that swaps QQ's package.json `main` to point at our
+        # loadNapCat.js, so wrapper.node ends up inside the Electron embedder
+        # it was built for. The source for that shim lives in
+        # scripts/napcat-launcher/launcher.cpp; we compile it here.
+        print("[9.4/11] Pre-compiling libnapcat_launcher.so for Linux...")
+
+        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        launcher_src_dir = os.path.join(repo_root, "scripts", "napcat-launcher")
+        launcher_cpp = os.path.join(launcher_src_dir, "launcher.cpp")
+        if not os.path.isfile(launcher_cpp):
+            print(f"[!] {launcher_cpp} not found; cannot pre-compile Linux launcher.")
+        else:
+            dest_cpp = f"{pack_dir}/launcher.cpp"
+            dest_so = f"{pack_dir}/libnapcat_launcher.so"
+            shutil.copy2(launcher_cpp, dest_cpp)
+
+            launcher_compile_ok = run_command([
+                "g++", "-shared", "-fPIC", "-O2",
+                "-o", dest_so, dest_cpp, "-ldl",
+            ])
+
+            if launcher_compile_ok and os.path.exists(dest_so):
+                print("[x] libnapcat_launcher.so compiled successfully")
+                # Ship launcher.cpp alongside the .so so users on
+                # unsupported architectures (e.g. arm64 runners that do not
+                # match this build host) can rebuild it themselves; the
+                # generated launcher-user.sh also retries in-place compile.
+            else:
+                print("[!] Warning: Could not pre-compile libnapcat_launcher.so")
+                print("[!] launcher-user.sh will fall back to in-place compilation.")
+                if os.path.exists(dest_so):
+                    os.remove(dest_so)
+        print()
+
     # Create standalone mode scripts
     print("[9.5/11] Creating standalone mode scripts...")
     
@@ -903,36 +947,38 @@ await import(napcatUrl);
 # NapCat + QCE launcher (Linux / macOS).
 #
 # This script wires up the bits NapCat assumes a Windows installer has
-# already taken care of:
+# already taken care of.
 #
-#   1. NAPCAT_QQ_PATH  - auto-detected from the standard QQ install paths
-#                        (deb, snap, flatpak, /Applications/QQ.app, ...) and
-#                        symlink-resolved so QQBasicInfoWrapper finds
-#                        resources/app/package.json next to the real binary.
-#   2. qq_magic.so     - LD_PRELOAD'ed so NapCat's native modules can resolve
-#                        the qq_magic_napi_register symbol that Linux QQ
-#                        does not export. Built in-place via g++ if the
-#                        bundled copy is missing.
-#   3. libgnutls.so.30 - LD_PRELOAD'ed when QQ ships libbugly.so, which
-#                        references gnutls_* symbols without listing
-#                        libgnutls in its NEEDED entries.
-#   4. Single-process  - NAPCAT_DISABLE_MULTI_PROCESS=1 by default. NapCat's
-#                        master/worker mode forks via child_process.fork
-#                        using process.execPath as the runtime; once the
-#                        bootstrap shim points process.execPath at the QQ
-#                        Electron binary, every fork spawns a real Electron
-#                        process (chrome-sandbox, GPU, dbus...) which
-#                        crashes on most headless servers. Single-process
-#                        mode runs NCoreInitShell directly inside this
-#                        Node.js process and is the recommended default for
-#                        headless deployments.
+# Linux flow (issue #433):
+#   We launch the real QQ Electron binary with libnapcat_launcher.so
+#   LD_PRELOAD'ed. The shim hooks open/openat/fopen and rewrites QQ's
+#   package.json `main` to point at loadNapCat.js, which imports napcat.mjs
+#   out of this directory. wrapper.node thus runs inside the Electron
+#   embedder it was built for instead of plain Node.js, where it would
+#   segfault on login (`std::vector<std::string>::_M_realloc_insert` inside
+#   wrapper.node, observed on Fedora 44 / Debian 13 / NixOS / Arch /
+#   Ubuntu 24.04).
+#
+#   Other Linux-only bits:
+#     - qq_magic.so       supplies the qq_magic_napi_register symbol Linux
+#                         QQ does not export.
+#     - libgnutls.so.30   preloaded when QQ ships libbugly.so, which is
+#                         missing the NEEDED entry for it.
+#     - NAPCAT_DISABLE_MULTI_PROCESS=1 by default — NapCat's master/worker
+#                         mode forks via process.execPath, which under
+#                         Electron means spawning headless QQ child
+#                         processes and is brittle on most servers.
+#
+# macOS flow (unchanged):
+#   We run `node napcat-bootstrap.mjs`, which overrides process.execPath to
+#   the QQ binary and then imports napcat.mjs. The Electron-binary approach
+#   is Linux-specific because xvfb/headless concerns and QQ's macOS .app
+#   bundle layout differ.
 
 set -u
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
-
-export NAPCAT_MAIN_PATH="$SCRIPT_DIR/napcat-bootstrap.mjs"
 
 # --- 1. Locate QQ -----------------------------------------------------------
 
@@ -982,19 +1028,15 @@ fi
 
 echo "[Info] QQ Path: $NAPCAT_QQ_PATH"
 
-# --- 2. Locate node --------------------------------------------------------
-
-if ! command -v node >/dev/null 2>&1; then
-    echo "[Error] node not found. Install Node.js 18+ from https://nodejs.org/."
-    exit 1
-fi
-
-# --- 3. Linux-specific runtime fixes ---------------------------------------
+# --- 2. Linux-specific runtime fixes (Electron + LD_PRELOAD) ---------------
 
 if [[ "${OSTYPE:-}" == linux* ]]; then
+    # 2a. Build qq_magic.so if missing — NapCat's native modules dlopen and
+    # immediately try to resolve qq_magic_napi_register, which is *not*
+    # exported by Linux QQ. The stub forwards to napi_module_register at
+    # runtime.
     QQ_MAGIC_SO="$SCRIPT_DIR/qq_magic.so"
     QQ_MAGIC_CPP="$SCRIPT_DIR/qq_magic.cpp"
-
     if [ ! -f "$QQ_MAGIC_SO" ]; then
         echo "[Info] qq_magic.so missing, attempting in-place compile..."
         if [ ! -f "$QQ_MAGIC_CPP" ]; then
@@ -1020,37 +1062,98 @@ __QQMAGIC__
             echo "          drop a pre-built qq_magic.so next to this script."
         fi
     fi
-    if [ -f "$QQ_MAGIC_SO" ]; then
-        export LD_PRELOAD="$QQ_MAGIC_SO${LD_PRELOAD:+:$LD_PRELOAD}"
-    fi
 
-    # libbugly.so references gnutls_* symbols (gnutls_free, gnutls_alert_get,
-    # ...) but ships without a NEEDED entry for libgnutls.so.30, so dlopen()
-    # fails with "undefined symbol: gnutls_free" unless gnutls is already in
-    # the process. Preload it.
-    if [ -f "$QQ_DIR/resources/app/libbugly.so" ]; then
-        LIBGNUTLS=$(ldconfig -p 2>/dev/null | awk -F'=> ' '/libgnutls\.so\.30/ { print $2; exit }' | tr -d '[:space:]')
-        if [ -n "$LIBGNUTLS" ] && [ -f "$LIBGNUTLS" ]; then
-            export LD_PRELOAD="$LIBGNUTLS${LD_PRELOAD:+:$LD_PRELOAD}"
+    # 2b. Build libnapcat_launcher.so if missing — the package.json/loadNapCat.js
+    # hook that lets QQ Electron boot into napcat.mjs (issue #433).
+    LAUNCHER_SO="$SCRIPT_DIR/libnapcat_launcher.so"
+    LAUNCHER_CPP="$SCRIPT_DIR/launcher.cpp"
+    if [ ! -f "$LAUNCHER_SO" ]; then
+        echo "[Info] libnapcat_launcher.so missing, attempting in-place compile..."
+        if [ ! -f "$LAUNCHER_CPP" ]; then
+            echo "[Error] launcher.cpp not bundled. Re-download the release tarball or"
+            echo "        copy it from https://github.com/shuakami/qq-chat-exporter/"
+            echo "        blob/master/scripts/napcat-launcher/launcher.cpp"
+            exit 1
+        fi
+        if command -v g++ >/dev/null 2>&1; then
+            if g++ -shared -fPIC -O2 -o "$LAUNCHER_SO" "$LAUNCHER_CPP" -ldl 2>&1; then
+                echo "[Info] libnapcat_launcher.so compiled at $LAUNCHER_SO"
+            else
+                echo "[Error] libnapcat_launcher.so compile failed. QCE cannot run on"
+                echo "        Linux without this shim — install build-essential and retry."
+                exit 1
+            fi
         else
-            echo "[Warning] libgnutls.so.30 not found; QQ libbugly.so may fail to load."
-            echo "          Debian/Ubuntu: sudo apt-get install -y libgnutls30"
-            echo "          RHEL/Fedora:   sudo dnf install -y gnutls"
+            echo "[Error] g++ not available. Install build-essential (Debian/Ubuntu)"
+            echo "        or @development tools (RHEL/Fedora) and re-run."
+            exit 1
         fi
     fi
 
-    if [ -n "${LD_PRELOAD:-}" ]; then
-        echo "[Info] LD_PRELOAD: $LD_PRELOAD"
+    # 2c. libbugly.so references gnutls_* symbols but ships without a NEEDED
+    # entry for libgnutls.so.30; preload the system copy if present.
+    LIBGNUTLS=""
+    if [ -f "$QQ_DIR/resources/app/libbugly.so" ]; then
+        LIBGNUTLS=$(ldconfig -p 2>/dev/null | awk -F'=> ' '/libgnutls\.so\.30/ { print $2; exit }' | tr -d '[:space:]')
+        if [ -z "$LIBGNUTLS" ] || [ ! -f "$LIBGNUTLS" ]; then
+            echo "[Warning] libgnutls.so.30 not found; QQ libbugly.so may fail to load."
+            echo "          Debian/Ubuntu: sudo apt-get install -y libgnutls30"
+            echo "          RHEL/Fedora:   sudo dnf install -y gnutls"
+            LIBGNUTLS=""
+        fi
     fi
 
-    # Default to single-process mode unless the caller has explicitly opted
-    # into NapCat's master/worker model (which currently breaks on headless
-    # servers, see issue #314).
+    # Compose LD_PRELOAD. Order matters: the launcher hook must load before
+    # anything that opens package.json (which is essentially everything).
+    LD_PRELOAD_PARTS="$LAUNCHER_SO"
+    [ -f "$QQ_MAGIC_SO" ] && LD_PRELOAD_PARTS="$LD_PRELOAD_PARTS:$QQ_MAGIC_SO"
+    [ -n "$LIBGNUTLS" ] && LD_PRELOAD_PARTS="$LD_PRELOAD_PARTS:$LIBGNUTLS"
+    export LD_PRELOAD="$LD_PRELOAD_PARTS${LD_PRELOAD:+:$LD_PRELOAD}"
+    echo "[Info] LD_PRELOAD: $LD_PRELOAD"
+
+    # 2d. Inputs the launcher shim reads.
+    export NAPCAT_BOOTMAIN="$SCRIPT_DIR"
+    export NAPCAT_QQ_PKG_JSON="$QQ_PKG_JSON"
+
+    # 2e. Single-process mode by default — see comments at the top.
     : "${NAPCAT_DISABLE_MULTI_PROCESS:=1}"
     export NAPCAT_DISABLE_MULTI_PROCESS
+
+    # 2f. Headless safety net. QQ is an Electron app and needs a display
+    # server. On desktops this is already there. On headless servers (Docker,
+    # SSH, CI) we fall back to xvfb-run so QQ has a virtual X session.
+    DISPLAY_VAR="${DISPLAY:-}"
+    WAYLAND_VAR="${WAYLAND_DISPLAY:-}"
+    XVFB_PREFIX=()
+    if [ -z "$DISPLAY_VAR" ] && [ -z "$WAYLAND_VAR" ]; then
+        if command -v xvfb-run >/dev/null 2>&1; then
+            echo "[Info] No DISPLAY detected; wrapping QQ in xvfb-run."
+            XVFB_PREFIX=(xvfb-run -a --server-args="-screen 0 1280x720x24")
+        else
+            echo "[Warning] No DISPLAY and xvfb-run is not installed."
+            echo "          On headless boxes, install xvfb first:"
+            echo "          Debian/Ubuntu: sudo apt-get install -y xvfb"
+            echo "          RHEL/Fedora:   sudo dnf install -y xorg-x11-server-Xvfb"
+            echo "          Continuing anyway — QQ may fail to start."
+        fi
+    fi
+
+    echo "Starting NapCat + QCE (Linux Electron mode, issue #433)..."
+    echo "Press Ctrl+C to stop."
+    echo "After QQ login, open http://localhost:40653/qce-v4-tool/ in your browser."
+    echo ""
+
+    exec "${XVFB_PREFIX[@]}" "$NAPCAT_QQ_PATH" --no-sandbox
 fi
 
-# --- 4. Run NapCat ---------------------------------------------------------
+# --- 3. macOS flow (unchanged Node + bootstrap shim path) -------------------
+
+if ! command -v node >/dev/null 2>&1; then
+    echo "[Error] node not found. Install Node.js 18+ from https://nodejs.org/."
+    exit 1
+fi
+
+export NAPCAT_MAIN_PATH="$SCRIPT_DIR/napcat-bootstrap.mjs"
 
 echo "Starting NapCat + QCE..."
 echo "Press Ctrl+C to stop."


### PR DESCRIPTION
## Summary

Closes #433.

### Root cause

The previous Linux launcher ran:

```
node napcat-bootstrap.mjs
```

which loaded NapCat's `napcat.mjs`, and through it QQ's `wrapper.node`, into a vanilla Node.js process.

`wrapper.node` is a Chromium/Electron native addon. It assumes the embedder set up V8 isolates and the libstdc++ runtime the way Electron does. When loaded into stock Node, the C++ STL state inside the addon ends up half-initialised, and the first `std::vector<std::string>::_M_realloc_insert` after `session.startNT()` reads a corrupted `_M_start` and segfaults:

```
#0  std::vector<std::string>::_M_realloc_insert<...>
        at /opt/QQ/resources/app/wrapper.node
#1  0x0
```

That is the SIGSEGV users on Fedora 44 / Debian 13 / NixOS / Arch / Ubuntu 24.04 report immediately after the QR-code login completes. It is not flaky timing or a Node version mismatch — it is structural: the addon is being run inside the wrong embedder.

### Fix

Launch the real QQ Electron binary (`/opt/QQ/qq` and equivalents) with a small `LD_PRELOAD` shim, ported from [NapNeko/napcat-linux-launcher](https://github.com/NapNeko/napcat-linux-launcher) and adapted for the QCE pack layout.

The shim hooks `open`, `openat` and `fopen`. When QQ Electron starts and reads `resources/app/package.json`, the hook:

1. Returns a modified copy whose `main` field points at `loadNapCat.js`.
2. Serves an in-memory `loadNapCat.js` (via `memfd`, with a disk fallback) that imports `napcat.mjs` from the QCE pack directory.

`wrapper.node` is then loaded inside the Electron embedder it was built for, the vector layout matches, and login completes cleanly.

### Why a port of NapNeko's launcher and not just a patch

The `process.execPath` override added for issue #269 was the right call for fixing the resource-resolution path, but it kept us in the same broken topology: NapCat still booted under Node. Once the addon is inside the wrong runtime, no amount of env-var massaging fixes the std::vector corruption. The only sound option is to let QQ start the way Tencent ships it, and inject our entrypoint there.

### Changes

- `scripts/napcat-launcher/launcher.cpp` — new LD_PRELOAD hook (open / openat / fopen). Output path resolution is normalised to avoid `../../..//loadNapCat.js`. QQ's `package.json` path is overridable via `NAPCAT_QQ_PKG_JSON`. Logging is gated behind `NAPCAT_LAUNCHER_DEBUG` so the normal stdout stays clean.
- `scripts/napcat-launcher/build.sh`, `README.md`, `.gitignore` — supporting scaffolding.
- `scripts/quick-pack.py`
  - Pre-compiles `libnapcat_launcher.so` on Linux builds.
  - Rewrites the Linux branch of `launcher-user.sh` to `exec` the QQ binary with `libnapcat_launcher.so` + `qq_magic.so` + `libgnutls.so.30` preloaded, plus an `xvfb-run` fallback so the same script keeps working on headless servers.
  - macOS flow is unchanged (still `node napcat-bootstrap.mjs`); the Electron-binary approach is Linux-specific because the bundle layout and headless story on macOS are different.
- `plugins/qq-chat-exporter/__tests__/unit/napcatLinuxLauncher.test.ts` — unit tests for the shim: build smoke test, asar-style `main` rewriting under `LD_PRELOAD`, plain (non-asar) `main` rewriting, and pass-through for unrelated paths.
- Plugin version bumped to `v5.5.64`.

### Verification

```
npm test
# tests 269
# pass 269
# fail 0
```

Manual LD_PRELOAD smoke test against a fake QQ `package.json` confirms the `main` field is rewritten to `loadNapCat.js` and unrelated paths pass through untouched. The build step in `quick-pack.py` was also dry-run end-to-end against the source tree to confirm `libnapcat_launcher.so` is produced.

### Notes

NapCat's master/worker mode (`NAPCAT_DISABLE_MULTI_PROCESS=0`) forks via `process.execPath`. Under this fix `execPath` is the QQ Electron binary, so every fork would spawn a real Electron child (chrome-sandbox, GPU, dbus...) and crash on most headless servers. The launcher script keeps `NAPCAT_DISABLE_MULTI_PROCESS=1` as the default, matching what issue #314 already settled on.
