### PR TITLE
修复 JSON/JSONL 导出合并转发子消息丢失

### DIFF
--- a/plugins/qq-chat-exporter/lib/core/exporter/JsonExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/JsonExporter.ts
@@ -1082,6 +1082,19 @@ export class JsonExporter extends BaseExporter {
             });
         }
 
+        if (content.multiForward) {
+            elements.push({
+                type: 'forward',
+                data: {
+                    title: content.multiForward.title,
+                    summary: content.multiForward.summary,
+                    messageCount: content.multiForward.messageCount,
+                    senderNames: content.multiForward.senderNames,
+                    messages: content.multiForward.messages || []
+                }
+            });
+        }
+
         return elements;
     }
 

--- a/plugins/qq-chat-exporter/lib/core/parser/MessageParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/MessageParser.ts
@@ -291,6 +291,7 @@ export interface ParsedMessageContent {
     summary: string;
     messageCount: number;
     senderNames: string[];
+    messages?: any[];
   };
   calendar?: {
     title: string;
@@ -1234,11 +1235,40 @@ export class MessageParser {
                         senderNames: []
                       };
                       multiForward.messageCount = result.data.messages.length;
+                      multiForward.messages = result.data.messages;
                     }
                   }
                 }
               } catch (error) {
                 // 获取合并转发详情失败，忽略错误
+              }
+
+              const fallbackResId = element.multiForwardMsgElement.resId
+                || (element.multiForwardMsgElement.xmlContent || '').match(/m_resid="([^"]+)"/)?.[1]
+                || '';
+              if ((!Array.isArray(multiForward?.messages) || multiForward.messages.length === 0) && fallbackResId) {
+                try {
+                  const bridge = (globalThis as any).__NAPCAT_BRIDGE__;
+                  const getForwardAction = bridge?.actions?.get?.('get_forward_msg');
+                  if (getForwardAction) {
+                    const result = await getForwardAction.handle({
+                      message_id: fallbackResId
+                    }, 'plugin', {});
+
+                    if (result?.data?.messages) {
+                      multiForward = multiForward || {
+                        title: '聊天记录',
+                        summary: '合并转发的聊天记录',
+                        messageCount: result.data.messages.length,
+                        senderNames: []
+                      };
+                      multiForward.messageCount = result.data.messages.length;
+                      multiForward.messages = result.data.messages;
+                    }
+                  }
+                } catch {
+                  // resId 兜底失败时保持外层合并转发占位。
+                }
               }
               
               const count = multiForward?.messageCount || 0;

--- a/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
@@ -1233,6 +1233,13 @@ export class SimpleMessageParser {
       }
     }
 
+    if (raws.length === 0) {
+      const fromAction = await this.fetchForwardInnerMessagesByAction(message, resId);
+      if (fromAction.length > 0) {
+        return fromAction;
+      }
+    }
+
     if (raws.length === 0) return [];
 
     const out: ForwardInnerMessage[] = [];
@@ -1272,6 +1279,66 @@ export class SimpleMessageParser {
       } catch {
         // 单条子消息解析失败时跳过，避免拖死整批。
       }
+    }
+    return out;
+  }
+
+  private async fetchForwardInnerMessagesByAction(
+    message: RawMessage,
+    resId: string
+  ): Promise<ForwardInnerMessage[]> {
+    const bridge = (globalThis as any).__NAPCAT_BRIDGE__;
+    const getForwardAction = bridge?.actions?.get?.('get_forward_msg');
+    if (!getForwardAction) return [];
+
+    for (const messageId of [message.msgId, resId].filter(Boolean)) {
+      try {
+        const result = await getForwardAction.handle({ message_id: messageId }, 'plugin', {});
+        const messages = result?.data?.messages;
+        if (Array.isArray(messages) && messages.length > 0) {
+          return this.normalizeForwardActionMessages(messages);
+        }
+      } catch {
+        // 继续尝试下一个 messageId / resId。
+      }
+    }
+    return [];
+  }
+
+  private normalizeForwardActionMessages(messages: any[]): ForwardInnerMessage[] {
+    const out: ForwardInnerMessage[] = [];
+    for (const item of messages) {
+      if (!item) continue;
+      const sender = item.sender || {};
+      const elements = Array.isArray(item.message)
+        ? item.message.map((element: any) => ({
+            type: String(element?.type || 'unknown'),
+            data: element?.data || {}
+          }))
+        : [];
+      const textFromElements = elements
+        .map((element) => this.elementToText(element, false).text)
+        .filter(Boolean)
+        .join('');
+      const rawText = typeof item.raw_message === 'string' ? item.raw_message : '';
+      const text = textFromElements || rawText;
+      const tsMs = millisFromUnixSeconds(item.time || 0);
+      const senderName = sender.card || sender.nickname || sender.name || String(item.user_id || sender.user_id || '');
+
+      out.push({
+        id: String(item.message_id || item.real_id || item.message_seq || item.real_seq || ''),
+        timestamp: tsMs,
+        time: rfc3339FromMillis(tsMs),
+        sender: {
+          uid: item.user_id != null ? String(item.user_id) : undefined,
+          uin: sender.user_id != null ? String(sender.user_id) : undefined,
+          name: senderName
+        },
+        content: {
+          text,
+          elements
+        }
+      });
     }
     return out;
   }


### PR DESCRIPTION
## 概要

修复 #451。

这个 PR 修复合并转发子消息在导出结果中丢失的问题，覆盖两条路径：

- 普通 JSON 导出：`MessageParser + JsonExporter`
- `STREAMING_JSONL` / `chunked_jsonl` 导出：`SimpleMessageParser`

此前导出结果可能只包含 `[合并转发: <?xml ...>]`、`preview` 或 `messageCount`，但没有写出内部 `messages`。

> 说明：本 PR 的初步定位由 AI 辅助完成，使用模型为 **gpt-5.5 high**。代码改动和导出行为已通过本地验证。

## 修改内容

JSON 导出路径：

- `ParsedMessageContent.multiForward` 增加可选 `messages` 字段。
- `MessageParser` 调用 `get_forward_msg` 成功时保存 `result.data.messages`。
- `JsonExporter.convertContentToElements()` 将 `content.multiForward` 输出为 `forward` element，并带上 `messages`。

JSONL 导出路径：

- `SimpleMessageParser.fetchForwardInnerMessages` 保留原来的 `MsgApi.getMultiMsg` 逻辑。
- 如果结果为空，再通过 `bridge.actions.get('get_forward_msg')` 兜底。
- 兜底时依次尝试外层 `msgId` 和 `resId`。
- 将 OB11 返回的子消息转换成 JSONL 使用的 `ForwardInnerMessage` 结构。

两条路径都会在数字 `message_id` 获取失败或为空时，尝试使用 `multiForwardMsgElement.resId` 或 XML 中的 `m_resid` 兜底。

## 原因分析

普通 JSON 路径中，`get_forward_msg` 返回值此前主要用于更新 `messageCount`：

```ts
multiForward.messageCount = result.data.messages.length;
```

实际的 `result.data.messages` 没有保存到 `multiForward`，因此后续 `JsonExporter` 无法写出子消息。

JSONL 路径独立使用 `SimpleMessageParser`。如果只修复 `MessageParser + JsonExporter`，`chunked_jsonl` 仍可能只导出 `preview` / `messageCount`，而 `messages` 为空。

## 验证

本地验证方式：fork 仓库后修改 `plugins/qq-chat-exporter` 下的运行时代码，将插件目录复制覆盖到本地 NapCat Framework 运行目录，然后导出同一测试群聊。

普通 JSON 修复后，合并转发从外层 XML 占位变为结构化 `forward` element：

```ts
{
  type: 'forward',
  data: {
    title,
    summary,
    messageCount,
    senderNames,
    messages
  }
}
```

JSONL 修复效果可以看同一条合并转发的脱敏 diff：

```diff
 "messageCount": 5,
-"messages": []
+"messages": [
+  {
+    "id": "...",
+    "timestamp": "...",
+    "time": "...",
+    "sender": { "uid": "...", "uin": "...", "name": "..." },
+    "content": {
+      "text": "...",
+      "elements": [{ "type": "text", "data": "..." }]
+    }
+  },
+  {
+    "id": "...",
+    "timestamp": "...",
+    "time": "...",
+    "sender": { "uid": "...", "uin": "...", "name": "..." },
+    "content": {
+      "text": "...",
+      "elements": [{ "type": "text", "data": "..." }]
+    }
+  },
+  {
+    "id": "...",
+    "timestamp": "...",
+    "time": "...",
+    "sender": { "uid": "...", "uin": "...", "name": "..." },
+    "content": {
+      "text": "...",
+      "elements": [{ "type": "text", "data": "..." }]
+    }
+  },
+  {
+    "id": "...",
+    "timestamp": "...",
+    "time": "...",
+    "sender": { "uid": "...", "uin": "...", "name": "..." },
+    "content": {
+      "text": "...",
+      "elements": [{ "type": "image", "data": "..." }]
+    }
+  },
+  {
+    "id": "...",
+    "timestamp": "...",
+    "time": "...",
+    "sender": { "uid": "...", "uin": "...", "name": "..." },
+    "content": {
+      "text": "...",
+      "elements": [{ "type": "image", "data": "..." }]
+    }
+  }
+]
```
## 备注

`resId` fallback 在部分 NapCat 版本中可能返回不完全准确的 sender/group 元数据，但它可以保留合并转发正文内容，避免导出结果完全丢失子消息。