### PR TITLE
fix(api): persist outputDir in saveTaskToDatabase (#448)

### DIFF
--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -5553,7 +5553,7 @@ export class QQChatExporterApiServer {
                     includeRecalled: task.filter?.includeRecalled || false
                 },
                 // Issue #192: 保存实际使用的输出目录（可能是自定义路径）
-                outputDir: task.PathManager.sanitizePath(options?.outputDir || '') || this.pathManager.getExportsDir(),
+                outputDir: PathManager.sanitizePath(task.options?.outputDir || '') || this.pathManager.getExportsDir(),
                 includeResourceLinks: task.options?.includeResourceLinks || true,
                 batchSize: task.options?.batchSize || 5000,
                 timeout: 30000,

--- a/plugins/qq-chat-exporter/package-lock.json
+++ b/plugins/qq-chat-exporter/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qq-chat-exporter",
-  "version": "5.5.64",
+  "version": "5.5.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qq-chat-exporter",
-      "version": "5.5.64",
+      "version": "5.5.65",
       "dependencies": {
         "@breezystack/lamejs": "^1.2.7",
         "@types/archiver": "^7.0.0",

--- a/plugins/qq-chat-exporter/package.json
+++ b/plugins/qq-chat-exporter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qq-chat-exporter",
   "plugin": "QQ 聊天记录导出",
-  "version": "5.5.64",
+  "version": "5.5.65",
   "description": "导出 QQ 聊天记录为 HTML / JSON / TXT / Excel，支持时间筛选、批量任务、定时任务、表情图片语音视频资源处理、合并转发展开等。",
   "main": "index.mjs",
   "type": "module",


### PR DESCRIPTION
## Summary

Fixes #448. `saveTaskToDatabase` built the `outputDir` config field via a line that threw on every invocation, so task state was never persisted (the throw was swallowed by the surrounding `catch`, only logged).

```diff
- outputDir: task.PathManager.sanitizePath(options?.outputDir || '') || this.pathManager.getExportsDir(),
+ outputDir: PathManager.sanitizePath(task.options?.outputDir || '') || this.pathManager.getExportsDir(),
```

Two bugs on that one line:

- `sanitizePath` is a **static** method of `PathManager`. `task` has no `PathManager` property, so `task.PathManager` was `undefined` → `undefined.sanitizePath(...)`.
- `options` is not in scope; the method signature is `saveTaskToDatabase(task)`. Adjacent fields already read `task.options` (`includeResourceLinks`, `batchSize`).

The fix matches the other, correct call sites (`lib/api/ApiServer.ts:1167`, `:2178`).

Also bumps the plugin to `v5.5.65`.

## Verification

- `npm run test:unit` (262 pass) and `npm run test:integration` (7 pass) both green.
