### PR TITLE
feat(api): actionable error when port 40653 is occupied or reserved (#450)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/serverStartupError.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/serverStartupError.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Issue #450：端口被占用 / 被 Windows 保留时，应给出明确可操作的启动失败提示，
+ * 而不是把原始 error 直接抛出、非 debug 模式下静默挂掉。
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { describeServerStartupError } from '../../lib/utils/serverStartupError.js';
+
+describe('describeServerStartupError', () => {
+    it('EADDRINUSE 时给出端口占用 / WinNAT 保留的可操作提示，并带上端口号', () => {
+        const msg = describeServerStartupError({ code: 'EADDRINUSE', message: 'listen EADDRINUSE: address already in use 0.0.0.0:40653' }, 40653);
+        assert.match(msg, /端口 40653/);
+        assert.match(msg, /占用|保留/);
+        // 必须包含可直接执行的修复命令
+        assert.match(msg, /net stop winnat/);
+        assert.match(msg, /netsh interface ipv4 add excludedportrange protocol=tcp startport=40653/);
+        assert.match(msg, /net start winnat/);
+    });
+
+    it('EACCES 时提示权限不足', () => {
+        const msg = describeServerStartupError({ code: 'EACCES', message: 'listen EACCES' }, 40653);
+        assert.match(msg, /端口 40653/);
+        assert.match(msg, /权限/);
+    });
+
+    it('其它错误回退到原始 message', () => {
+        const msg = describeServerStartupError({ code: 'EOTHER', message: 'boom' }, 40653);
+        assert.match(msg, /服务器启动失败/);
+        assert.match(msg, /boom/);
+    });
+
+    it('error 为空时不抛异常', () => {
+        const msg = describeServerStartupError(undefined, 40653);
+        assert.match(msg, /服务器启动失败/);
+    });
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -58,6 +58,7 @@ import {
 import { resolveSessionName } from './sessionNameResolver.js';
 import { normalizeGroupSystemNotify } from './groupSystemNotify.js';
 import { buildResourceSummaryMessage } from '../utils/resourceSummary.js';
+import { describeServerStartupError } from '../utils/serverStartupError.js';
 import {
     reconcileOrphanedTask,
     buildTaskResyncPayload,
@@ -5681,7 +5682,7 @@ export class QQChatExporterApiServer {
             });
 
             this.server.on('error', (error) => {
-                console.error('[QCE] 服务器启动失败:', error);
+                console.error(describeServerStartupError(error as NodeJS.ErrnoException, 40653));
                 reject(error);
             });
         });

--- a/plugins/qq-chat-exporter/lib/utils/serverStartupError.ts
+++ b/plugins/qq-chat-exporter/lib/utils/serverStartupError.ts
@@ -1,0 +1,43 @@
+/**
+ * 服务器启动失败时的可读诊断信息。
+ *
+ * Issue #450：当 API 端口（默认 40653）被占用、或被 Windows 系统保留（WinNAT）时，
+ * server.listen 会抛出 EADDRINUSE / EACCES。原本只把原始 error 打到控制台，
+ * 非 debug 模式下用户基本看不到有效提示，表现为“什么都不报错直接挂掉”。
+ * 这里根据错误码给出明确、可操作的中文提示。
+ */
+
+interface ErrnoLike {
+    code?: string;
+    message?: string;
+}
+
+/**
+ * 根据启动错误与端口，生成面向用户的可操作提示。
+ * 纯函数，便于单测。
+ */
+export function describeServerStartupError(error: ErrnoLike | undefined, port: number): string {
+    const code = error?.code;
+
+    if (code === 'EADDRINUSE') {
+        return [
+            `[QCE] 启动失败：端口 ${port} 已被占用，或被系统保留，无法启动 Web 服务。`,
+            `[QCE] 可能原因：已有一个 QCE / 其它程序正在使用该端口，或该端口被 Windows 保留（WinNAT 动态端口段）。`,
+            `[QCE] 解决方法：`,
+            `[QCE]   1. 关闭占用该端口的程序后重试；`,
+            `[QCE]   2. 若为 Windows 端口保留导致，请以管理员身份执行：`,
+            `[QCE]        net stop winnat`,
+            `[QCE]        netsh interface ipv4 add excludedportrange protocol=tcp startport=${port} numberofports=1 store=persistent`,
+            `[QCE]        net start winnat`,
+        ].join('\n');
+    }
+
+    if (code === 'EACCES') {
+        return [
+            `[QCE] 启动失败：没有权限绑定端口 ${port}。`,
+            `[QCE] 解决方法：请以管理员 / 更高权限运行，或释放该端口后重试。`,
+        ].join('\n');
+    }
+
+    return `[QCE] 服务器启动失败: ${error?.message ?? String(error)}`;
+}

--- a/plugins/qq-chat-exporter/package-lock.json
+++ b/plugins/qq-chat-exporter/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qq-chat-exporter",
-  "version": "5.5.65",
+  "version": "5.5.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qq-chat-exporter",
-      "version": "5.5.65",
+      "version": "5.5.66",
       "dependencies": {
         "@breezystack/lamejs": "^1.2.7",
         "@types/archiver": "^7.0.0",

--- a/plugins/qq-chat-exporter/package.json
+++ b/plugins/qq-chat-exporter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qq-chat-exporter",
   "plugin": "QQ 聊天记录导出",
-  "version": "5.5.65",
+  "version": "5.5.66",
   "description": "导出 QQ 聊天记录为 HTML / JSON / TXT / Excel，支持时间筛选、批量任务、定时任务、表情图片语音视频资源处理、合并转发展开等。",
   "main": "index.mjs",
   "type": "module",


### PR DESCRIPTION
## Summary

Fixes #450. When the API port (40653) is occupied or **reserved by Windows** (WinNAT dynamic port range), `this.server.listen(40653, ...)` emits `EADDRINUSE`/`EACCES`. The old handler logged only the raw error object, so in non-debug mode the launcher appeared to die with no actionable message.

```diff
- this.server.on('error', (error) => {
-   console.error('[QCE] 服务器启动失败:', error);
-   reject(error);
- });
+ this.server.on('error', (error) => {
+   console.error(describeServerStartupError(error as NodeJS.ErrnoException, 40653));
+   reject(error);
+ });
```

New pure helper `describeServerStartupError(error, port)` (in `lib/utils/serverStartupError.ts`):
- `EADDRINUSE` → likely cause + the exact fix the reporter used:
  `net stop winnat` / `netsh interface ipv4 add excludedportrange protocol=tcp startport=40653 numberofports=1 store=persistent` / `net start winnat`
- `EACCES` → permission hint
- otherwise → falls back to the original `error.message`

## Verification

- New unit test `__tests__/unit/serverStartupError.test.ts` (4 cases) covers EADDRINUSE/EACCES/fallback/undefined.
- Full suite green: `test:unit` 266 pass, `test:integration` 7 pass.

> Note: this release (`v5.5.66`) also ships #452 (merge-forward inner messages in JSON/JSONL), which was merged to master separately.
