### PR TITLE
fix(parser): resolve reply preview sender from referenced message (#296)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/HtmlExporter.groupMixedMedia.snap.html
+++ b/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/HtmlExporter.groupMixedMedia.snap.html
@@ -531,10 +531,10 @@
             <div class="message-content">
                 
         <div class="reply-content">
-            <strong>用户:</strong>
+            <strong>Alice (PM):</strong>
             Anyone seen the build break?
         </div>
-                [回复 : Anyone seen the build break?]<br>thanks team, fix incoming
+                [回复 Alice (PM): Anyone seen the build break?]<br>thanks team, fix incoming
                 
             </div>
         </div>

--- a/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/JsonExporter.groupMixedMedia.snap.json
+++ b/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/JsonExporter.groupMixedMedia.snap.json
@@ -258,13 +258,13 @@
       },
       "type": "type_3",
       "content": {
-        "text": "[回复 : Anyone seen the build break?]\nthanks team, fix incoming",
+        "text": "[回复 Alice (PM): Anyone seen the build break?]\nthanks team, fix incoming",
         "html": "",
         "elements": [
           {
             "type": "text",
             "data": {
-              "text": "[回复 : Anyone seen the build break?]\nthanks team, fix incoming"
+              "text": "[回复 Alice (PM): Anyone seen the build break?]\nthanks team, fix incoming"
             }
           },
           {
@@ -273,7 +273,7 @@
               "messageId": "m_1",
               "referencedMessageId": "m_1",
               "senderUin": "11111",
-              "senderName": "",
+              "senderName": "Alice (PM)",
               "timestamp": 1704067300,
               "content": "Anyone seen the build break?"
             }

--- a/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/TextExporter.groupMixedMedia.snap.txt
+++ b/plugins/qq-chat-exporter/__tests__/integration/__snapshots__/TextExporter.groupMixedMedia.snap.txt
@@ -45,9 +45,9 @@ Charlie:
 
 Alice (PM):
 时间: 2024-01-01 00:04:00
-内容: [回复 : Anyone seen the build break?]
+内容: [回复 Alice (PM): Anyone seen the build break?]
 thanks team, fix incoming
-回复: 01-01 00:01 - Anyone seen the build break?
+回复: 01-01 00:01 Alice (PM) - Anyone seen the build break?
 
 
 Alice (PM):

--- a/plugins/qq-chat-exporter/__tests__/unit/replySenderName.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/replySenderName.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Issue #296：JSON 等导出里「回复 XXX」的发件人错位。
+ * 这里覆盖被引用消息发件人显示名的解析优先级与兜底，确保发件人跟随被引用消息本身，
+ * 而不是退化成 reply 元素自带的 u_xxx uid，或对不上引用内容的另一个人。
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveReplySenderName } from '../../lib/core/parser/replySenderName.js';
+
+describe('resolveReplySenderName', () => {
+    it('群聊默认用昵称（不优先群名片）', () => {
+        const name = resolveReplySenderName(
+            { memberName: '群名片', remark: '备注', nickname: '昵称', uin: '10001', uidStr: 'u_a' },
+            { isGroupChat: true, preferGroupMemberName: false },
+        );
+        assert.equal(name, '昵称');
+    });
+
+    it('群聊 + 优先群名片：群名片 > 备注 > 昵称', () => {
+        assert.equal(
+            resolveReplySenderName(
+                { memberName: '群名片', remark: '备注', nickname: '昵称' },
+                { isGroupChat: true, preferGroupMemberName: true },
+            ),
+            '群名片',
+        );
+        assert.equal(
+            resolveReplySenderName(
+                { memberName: '', remark: '备注', nickname: '昵称' },
+                { isGroupChat: true, preferGroupMemberName: true },
+            ),
+            '备注',
+        );
+    });
+
+    it('私聊用备注 > 昵称', () => {
+        assert.equal(
+            resolveReplySenderName(
+                { remark: '备注', nickname: '昵称', uin: '10001' },
+                { isGroupChat: false, preferGroupMemberName: false },
+            ),
+            '备注',
+        );
+        assert.equal(
+            resolveReplySenderName(
+                { remark: '', nickname: '昵称', uin: '10001' },
+                { isGroupChat: false, preferGroupMemberName: false },
+            ),
+            '昵称',
+        );
+    });
+
+    it('没有任何可读名时回退到 QQ 号，而不是 u_xxx uid', () => {
+        const name = resolveReplySenderName(
+            { memberName: '', remark: '', nickname: '', uin: '10001', uidStr: 'u_abcdef' },
+            { isGroupChat: true, preferGroupMemberName: false },
+        );
+        assert.equal(name, '10001');
+    });
+
+    it('连 QQ 号都没有才回退到 uid 字符串', () => {
+        const name = resolveReplySenderName(
+            { uin: '', uidStr: 'u_abcdef' },
+            { isGroupChat: false, preferGroupMemberName: false },
+        );
+        assert.equal(name, 'u_abcdef');
+    });
+
+    it('全部为空时返回空字符串，不抛异常', () => {
+        assert.equal(resolveReplySenderName({}, { isGroupChat: true, preferGroupMemberName: true }), '');
+    });
+
+    it('两个人互相回复时，发件人按各自被引用消息解析，互不串味', () => {
+        // 被引用消息来自 bytecategory，则即便是 gfwrev 发的回复，预览发件人也应是 bytecategory
+        const referenced = resolveReplySenderName(
+            { nickname: 'bytecategory', uin: '19031218', uidStr: 'u_byte' },
+            { isGroupChat: true, preferGroupMemberName: false },
+        );
+        assert.equal(referenced, 'bytecategory');
+        assert.notEqual(referenced, 'gfwrev');
+    });
+});

--- a/plugins/qq-chat-exporter/lib/core/parser/MessageParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/MessageParser.ts
@@ -6,6 +6,7 @@ import { RawMessage, MessageElement, ElementType, NTMsgType } from 'NapCatQQ/src
 import { SystemError, ErrorType, ResourceInfo, ResourceStatus } from '../../types/index.js';
 import { NapCatCore } from 'NapCatQQ/src/core/index.js';
 import { OneBotMsgApi } from 'NapCatQQ/src/onebot/api/msg.js';
+import { resolveReplySenderName } from './replySenderName.js';
 
 /* ------------------------------ 内部高性能工具 ------------------------------ */
 
@@ -123,6 +124,14 @@ type MsgRef = {
   msgId: string;
   msgSeq?: string;
   clientSeq?: string;
+  // issue #296：为让「回复 XXX」的发件人跟随被引用消息本身，
+  // 在索引里保留被引用消息的发件人身份（uin / uid + 名片 / 备注 / 昵称）。
+  senderUin?: string;
+  senderUidStr?: string;
+  sendMemberName?: string;
+  sendRemarkName?: string;
+  sendNickName?: string;
+  msgTime?: string;
   // 为提取引用预览而保留的最小 elements 信息（不保留 records / 原始大字段）
   elements?: any[];
 };
@@ -470,6 +479,12 @@ export class MessageParser {
         msgId: msg.msgId,
         msgSeq: msg.msgSeq,
         clientSeq: (msg as any).clientSeq,
+        senderUin: msg.senderUin,
+        senderUidStr: msg.senderUid,
+        sendMemberName: (msg as any).sendMemberName,
+        sendRemarkName: (msg as any).sendRemarkName,
+        sendNickName: (msg as any).sendNickName,
+        msgTime: msg.msgTime,
         elements: Array.isArray(msg.elements) ? msg.elements.slice(0, 16) : undefined // 控制体积
       });
       // 也索引 records（引用常出现在这里）
@@ -480,6 +495,12 @@ export class MessageParser {
               msgId: r.msgId,
               msgSeq: r.msgSeq,
               clientSeq: (r as any).clientSeq,
+              senderUin: r.senderUin,
+              senderUidStr: r.senderUid,
+              sendMemberName: (r as any).sendMemberName,
+              sendRemarkName: (r as any).sendRemarkName,
+              sendNickName: (r as any).sendNickName,
+              msgTime: r.msgTime,
               elements: Array.isArray(r.elements) ? r.elements.slice(0, 16) : undefined
             });
           }
@@ -1425,50 +1446,73 @@ export class MessageParser {
     
     // sourceMsgIdInRecords 用于内部查找（在 records 数组中）
     const sourceMsgId = reply.sourceMsgIdInRecords || '';
-    
-    // 如果 replayMsgId 无效，尝试用 replayMsgSeq 查找
-    if (!referencedMessageId && reply.replayMsgSeq) {
-      for (const [msgId, msg] of this.messageMap.entries()) {
+
+    // issue #296：先统一锁定被引用消息的索引（MsgRef），让发件人 / 时间戳 / 内容
+    // 都来自同一条消息，避免「内容取自 A、发件人取自 reply 元素」导致的发件人错位。
+    // 依次尝试：replayMsgId → sourceMsgIdInRecords → replayMsgSeq → replyMsgClientSeq。
+    let referencedRef: MsgRef | undefined;
+    if (referencedMessageId && this.messageMap.has(referencedMessageId)) {
+      referencedRef = this.messageMap.get(referencedMessageId);
+    }
+    if (!referencedRef && sourceMsgId && this.messageMap.has(sourceMsgId)) {
+      referencedRef = this.messageMap.get(sourceMsgId);
+      if (referencedRef && !referencedMessageId) referencedMessageId = referencedRef.msgId;
+    }
+    if (!referencedRef && reply.replayMsgSeq) {
+      for (const [, msg] of this.messageMap.entries()) {
         if (msg.msgSeq === reply.replayMsgSeq) {
-          referencedMessageId = msg.msgId;
+          referencedRef = msg;
+          if (!referencedMessageId) referencedMessageId = msg.msgId;
           break;
         }
       }
     }
-    
-    // 再尝试用 replyMsgClientSeq 查找
-    if (!referencedMessageId && reply.replyMsgClientSeq) {
-      for (const [msgId, msg] of this.messageMap.entries()) {
+    if (!referencedRef && reply.replyMsgClientSeq) {
+      for (const [, msg] of this.messageMap.entries()) {
         if (msg.clientSeq === reply.replyMsgClientSeq) {
-          referencedMessageId = msg.msgId;
+          referencedRef = msg;
+          if (!referencedMessageId) referencedMessageId = msg.msgId;
           break;
         }
       }
     }
 
-    // issue #128：被引用消息的 senderUin / timestamp 也回填到 reply 数据上，
-    // 这样 JSON / TXT / Excel 等导出器不用再回查 messageMap 自己组装。
+    // issue #128 / #296：被引用消息的 senderUin / timestamp / 显示名回填到 reply 数据上，
+    // 优先取被引用消息本身（referencedRef），找不到才退回 reply 元素自带字段。
     let referencedTimestamp: number | undefined;
-    let referencedSenderUin: string | undefined;
-    if (referencedMessageId && this.messageMap.has(referencedMessageId)) {
-      const ref = this.messageMap.get(referencedMessageId);
-      if (ref?.msgTime) referencedTimestamp = parseInt(ref.msgTime as any) || undefined;
-      if (ref?.senderUin) referencedSenderUin = ref.senderUin;
-    }
+    if (referencedRef?.msgTime) referencedTimestamp = parseInt(referencedRef.msgTime as any) || undefined;
     // NapCat 上游字段名拼成 replayMsgTime（多了个 a），但旧测试 / 极少数兼容字段
     // 又写成 replyMsgTime，两个都兜一下，避免老回放数据导致 timestamp 丢失。
     if (!referencedTimestamp && (reply.replayMsgTime || (reply as any).replyMsgTime)) {
       referencedTimestamp = Number(reply.replayMsgTime || (reply as any).replyMsgTime) || undefined;
     }
-    if (!referencedSenderUin && reply.senderUin) {
-      referencedSenderUin = reply.senderUin;
-    }
+
+    const referencedSenderUin = referencedRef?.senderUin || reply.senderUin || undefined;
+
+    // 显示名按与外层发件人一致的优先级解析：命中被引用消息就用它的名片 / 备注 / 昵称，
+    // 否则退回 reply 元素自带的 senderMemberName / senderNick，再退回 uin / uid。
+    const isGroupChat = messageRef?.chatType === 2;
+    const preferGroupMemberName = this.config.preferGroupMemberName === true;
+    const senderName = referencedRef
+      ? resolveReplySenderName({
+          memberName: referencedRef.sendMemberName,
+          remark: referencedRef.sendRemarkName,
+          nickname: referencedRef.sendNickName,
+          uin: referencedRef.senderUin,
+          uidStr: referencedRef.senderUidStr,
+        }, { isGroupChat, preferGroupMemberName })
+      : resolveReplySenderName({
+          memberName: (reply as any).senderMemberName,
+          nickname: (reply as any).senderNick,
+          uin: reply.senderUin,
+          uidStr: reply.senderUidStr,
+        }, { isGroupChat, preferGroupMemberName });
 
     return {
       messageId: sourceMsgId,      // 保留原始的sourceMsgIdInRecords用于内部查找
       referencedMessageId,         // 使用 replayMsgId 作为被引用消息的实际ID
       senderUin: referencedSenderUin,
-      senderName: reply.senderUidStr || '',
+      senderName,
       timestamp: referencedTimestamp,
       content: this.extractReplyContent(reply, messageRef),
       elements: []

--- a/plugins/qq-chat-exporter/lib/core/parser/replySenderName.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/replySenderName.ts
@@ -1,0 +1,65 @@
+/**
+ * Issue #296：JSON 等导出里"回复 XXX"的发件人错位。
+ *
+ * 根因是被引用消息的「内容」与「发件人」走了两套解析：内容按 sourceMsgIdInRecords
+ * 命中被引用消息，发件人却直接取 reply 元素自带的 senderUidStr / senderUin。两者
+ * 落到不同消息时，预览里就出现「A 回复 A」这种发件人对不上引用内容的错位。
+ *
+ * 这里抽出一个纯函数，按与外层发件人显示（getSenderDisplayInfo）完全一致的优先级
+ * 解析被引用消息的显示名，保证「回复 XXX」与正文里同一个人的显示名一致。
+ */
+
+export interface ReplySenderNameFields {
+    /** 群名片 sendMemberName */
+    memberName?: string | null;
+    /** 备注 sendRemarkName */
+    remark?: string | null;
+    /** 昵称 sendNickName */
+    nickname?: string | null;
+    /** QQ 号 senderUin */
+    uin?: string | null;
+    /** uid 字符串 senderUidStr（u_xxx） */
+    uidStr?: string | null;
+}
+
+export interface ReplySenderNameOptions {
+    /** 被引用消息所在会话是否群聊（取外层消息的 chatType===2） */
+    isGroupChat: boolean;
+    /** 群聊是否优先群名片（对齐 MessageParser.config.preferGroupMemberName） */
+    preferGroupMemberName: boolean;
+}
+
+function trim(value: unknown): string {
+    if (value === null || value === undefined) return '';
+    return String(value).trim();
+}
+
+/**
+ * 解析被引用消息的显示名。优先级与 getSenderDisplayInfo 保持一致：
+ *   - 群聊 + preferGroupMemberName：群名片 → 备注 → 昵称
+ *   - 群聊 + 不优先：昵称
+ *   - 私聊：备注 → 昵称
+ *   - 兜底：QQ 号 → uid 字符串
+ * 纯函数，便于单测。
+ */
+export function resolveReplySenderName(
+    fields: ReplySenderNameFields,
+    opts: ReplySenderNameOptions,
+): string {
+    const memberName = trim(fields.memberName);
+    const remark = trim(fields.remark);
+    const nickname = trim(fields.nickname);
+    const uin = trim(fields.uin);
+    const uidStr = trim(fields.uidStr);
+
+    let name = '';
+    if (opts.isGroupChat) {
+        name = opts.preferGroupMemberName
+            ? (memberName || remark || nickname)
+            : nickname;
+    } else {
+        name = remark || nickname;
+    }
+
+    return name || uin || uidStr || '';
+}

--- a/plugins/qq-chat-exporter/package-lock.json
+++ b/plugins/qq-chat-exporter/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qq-chat-exporter",
-  "version": "5.5.66",
+  "version": "5.5.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qq-chat-exporter",
-      "version": "5.5.66",
+      "version": "5.5.67",
       "dependencies": {
         "@breezystack/lamejs": "^1.2.7",
         "@types/archiver": "^7.0.0",

--- a/plugins/qq-chat-exporter/package.json
+++ b/plugins/qq-chat-exporter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qq-chat-exporter",
   "plugin": "QQ 聊天记录导出",
-  "version": "5.5.66",
+  "version": "5.5.67",
   "description": "导出 QQ 聊天记录为 HTML / JSON / TXT / Excel，支持时间筛选、批量任务、定时任务、表情图片语音视频资源处理、合并转发展开等。",
   "main": "index.mjs",
   "type": "module",


### PR DESCRIPTION
## 问题

JSON / TXT / Excel / HTML 导出里，引用回复的"回复 XXX"发件人会**错位或显示为空 / `用户`**。

根因：在 `MessageParser.parseReplyElement` 里，被引用消息的**内容**按 `sourceMsgIdInRecords` 命中原消息，**发件人**却直接取 reply 元素自带的 `senderUidStr`（常为空或 `u_xxx`），两者落到不同消息时，预览发件人就对不上引用的内容。另外 `MsgRef` 索引里根本没存 `senderUin` / 时间戳，导致 #128 想做的"从 messageMap 回填被引用消息发件人"一直是死代码（`ref?.senderUin` / `ref?.msgTime` 恒为 undefined）。

## 改动

- `MsgRef` 增加 `senderUin` / `senderUidStr` / `sendMemberName` / `sendRemarkName` / `sendNickName` / `msgTime`，`indexBatch` 对消息与 records 一并写入。
- `parseReplyElement` 先**统一锁定**被引用消息（`replayMsgId` → `sourceMsgIdInRecords` → `replayMsgSeq` → `replyMsgClientSeq`），发件人 / 时间戳 / 内容都取自**同一条**消息；找不到才回退 reply 元素自带字段。
- 新增纯函数 `resolveReplySenderName`：按与外层发件人显示一致的优先级解析显示名（群聊群名片/备注/昵称、私聊备注/昵称 → QQ 号 → uid），不再回退成 `u_xxx`。

## 测试

- 新增单测 `__tests__/unit/replySenderName.test.ts`（优先级 / 兜底 / 互相回复不串味）。
- 导出器快照（Text / Json / Html `groupMixedMedia`）更新：回复发件人由空 / `用户` 修正为被引用消息真实发件人 `Alice (PM)`。
- `npm run test:unit` 273 通过、`npm run test:integration` 7 通过。

Closes #296