### PR TITLE
fix(plugin): avoid NapCat sensitive-keyword rejection of QCE (#466)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/napcatSensitiveKeywords.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/napcatSensitiveKeywords.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Guards against NapCat PluginLoader sensitive-keyword false positives
+ * (issue #466).
+ *
+ * NapCat's PluginLoader scans the shipped plugin source and rejects the plugin
+ * outright when it finds a blocked keyword. The plugin ships its TypeScript
+ * sources verbatim (tsx loads lib/*.ts at runtime), so even keywords that only
+ * appear in comments get scanned. "发卡" — a substring of "转发卡片"
+ * ("forward card") used in comments — tripped this and made QCE disappear from
+ * the plugin list on Docker NapCat.
+ *
+ * This test fails if any blocked keyword reappears in the shipped source, so a
+ * future comment/string does not silently break Docker installs again.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PLUGIN_ROOT = path.resolve(__dirname, '../..');
+
+// Keywords NapCat's PluginLoader rejects (observed in #466). Extend as more are
+// reported.
+const BLOCKED_KEYWORDS = ['发卡'];
+
+// Files NapCat actually scans: the shipped entrypoint and the lib/ sources.
+const SHIPPED_ROOTS = [
+    path.join(PLUGIN_ROOT, 'index.mjs'),
+    path.join(PLUGIN_ROOT, 'lib'),
+];
+
+function collectFiles(target: string): string[] {
+    if (!fs.existsSync(target)) return [];
+    const stat = fs.statSync(target);
+    if (stat.isFile()) return [target];
+    const out: string[] = [];
+    for (const entry of fs.readdirSync(target)) {
+        out.push(...collectFiles(path.join(target, entry)));
+    }
+    return out;
+}
+
+const SCANNED_EXTENSIONS = new Set(['.ts', '.mjs', '.js', '.json']);
+
+test('shipped plugin source is free of NapCat sensitive keywords (#466)', () => {
+    const offenders: string[] = [];
+    for (const root of SHIPPED_ROOTS) {
+        for (const file of collectFiles(root)) {
+            if (!SCANNED_EXTENSIONS.has(path.extname(file))) continue;
+            const content = fs.readFileSync(file, 'utf8');
+            for (const keyword of BLOCKED_KEYWORDS) {
+                if (content.includes(keyword)) {
+                    offenders.push(`${path.relative(PLUGIN_ROOT, file)} contains "${keyword}"`);
+                }
+            }
+        }
+    }
+    assert.deepEqual(offenders, [], `NapCat-blocked keywords found:\n${offenders.join('\n')}`);
+});

--- a/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
@@ -1681,7 +1681,7 @@ export class ModernHtmlExporter {
         const summaryLooksLikeXml = rawSummary.trim().startsWith('<') && /<\/?[a-zA-Z]/.test(rawSummary);
         const summary = summaryLooksLikeXml ? '查看转发消息' : (rawSummary || '查看转发消息');
         const preview = data?.preview || [];
-        // issue #161：解析器现在会把合并转发卡片里的真实子消息塞进 data.messages，
+        // issue #161：解析器现在会把合并转发消息卡片里的真实子消息塞进 data.messages，
         // 优先用它渲染完整列表，老数据 / fallback 再退回 preview / summary。
         const innerMessages: Array<{
             sender?: { name?: string; uin?: string };
@@ -1800,7 +1800,7 @@ export class ModernHtmlExporter {
                     parts.push(`${d?.title || d?.summary || 'JSON'} ${d?.description || ''} ${d?.url || ''}`.trim());
                     break;
                 case 'forward': {
-                    // issue #161：搜索时把合并转发卡片里的子消息内容也带上，否则
+                    // issue #161：搜索时把合并转发消息卡片里的子消息内容也带上，否则
                     // 只能搜到外壳标题，搜不到真实文本。
                     // issue #128 子项 3：summary 可能是 multiForwardMsg XML 原文（老数据），
                     // 把它写进搜索索引里只会让索引被 `<msg>` / `<item>` 这种标签污染，跳掉。

--- a/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlTemplates.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlTemplates.ts
@@ -1076,7 +1076,7 @@ export const MODERN_CSS = `
             display: block;
         }
         
-        /* 合并转发卡片 */
+        /* 合并转发消息卡片 */
         .forward-card {
             background: var(--bubble-other);
             border: 1px solid rgba(0, 0, 0, 0.08);

--- a/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
@@ -228,7 +228,7 @@ export interface ReplyPreviewElement {
 }
 
 /**
- * 合并转发卡片里嵌套的子消息。
+ * 合并转发消息卡片里嵌套的子消息。
  * 字段刻意保持扁平，方便直接序列化到 JSON / JSONL，也方便 TXT 导出按行渲染。
  */
 export interface ForwardInnerMessage {
@@ -777,7 +777,7 @@ export class SimpleMessageParser {
       const resId = element.multiForwardMsgElement.resId || '';
       const xmlContent = element.multiForwardMsgElement.xmlContent || '';
 
-      // 拉合并转发卡片里的真实消息列表，导出 JSON / TXT 时把内容也带上（issue #161）。
+      // 拉合并转发消息卡片里的真实消息列表，导出 JSON / TXT 时把内容也带上（issue #161）。
       // 失败时降级为只保留 XML summary，绝不阻断主导出；嵌套过深也直接停在外壳。
       const innerMessages =
         forwardDepth >= SimpleMessageParser.MAX_FORWARD_DEPTH
@@ -1185,7 +1185,7 @@ export class SimpleMessageParser {
   }
 
   /**
-   * 拉合并转发卡片里的子消息列表，并把每条子消息扁平化成 ForwardInnerMessage（issue #161）。
+   * 拉合并转发消息卡片里的子消息列表，并把每条子消息扁平化成 ForwardInnerMessage（issue #161）。
    *
    * 数据来源优先级：
    *   1) message.records（NapCat 推消息时偶尔会顺手填上）

--- a/plugins/qq-chat-exporter/lib/core/parser/multiForwardXmlParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/multiForwardXmlParser.ts
@@ -1,7 +1,7 @@
 /**
  * 解析 NapCat 推过来的 multiForwardMsgElement.xmlContent（issue #128 子项 3）。
  *
- * 当合并转发卡片无法通过 getMultiMsg 拉到子消息时（消息已过期 / NapCat 拒绝下发 / 嵌套过深），
+ * 当合并转发消息卡片无法通过 getMultiMsg 拉到子消息时（消息已过期 / NapCat 拒绝下发 / 嵌套过深），
  * 旧版会把整段 XML 当作 summary 直接落进导出文件，导致 HTML / 搜索索引里出现 `<msg ... ><item ...>...`
  * 这种 XML 原文。
  *
@@ -18,7 +18,7 @@
  *     ...
  *   </msg>
  *
- * 抠出 header / preview 行 / 末尾 summary，调用方可直接拿来塞进转发卡片占位预览，
+ * 抠出 header / preview 行 / 末尾 summary，调用方可直接拿来塞进转发消息卡片占位预览，
  * 不再把 XML 原文塞进 data.summary。
  */
 


### PR DESCRIPTION
## Summary

Fixes #466. On Docker NapCat (v4.18.6) the WebUI one-click install dropped QCE from the plugin list with:

```
[warn] [PluginLoader] Rejected napcat-plugin-qce (napcat-plugin-qce): sensitive keyword "发卡"
```

NapCat's PluginLoader scans the shipped plugin source for blocked keywords. QCE ships its TypeScript sources verbatim (tsx loads `lib/*.ts` at runtime), so the keyword was picked up even though it only appears **in comments** — the phrase `合并转发卡片` ("merge-forward card") contains the blocked substring `发卡`.

Reword the 8 affected comments `转发卡片` → `转发消息卡片`. Comments only, zero runtime/output change:

```diff
-        /* 合并转发卡片 */
+        /* 合并转发消息卡片 */
```

## Verification

- New guard test `__tests__/unit/napcatSensitiveKeywords.test.ts` scans the shipped entrypoint + `lib/` and fails if any NapCat-blocked keyword (currently `发卡`) reappears.
- `grep -rn 发卡 lib index.mjs` → 0 matches after the change.
- `test:unit` green.