### PR TITLE
fix: 递归渲染嵌套合并转发（嵌套的[聊天记录]）

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/ModernHtmlExporter.nestedForward.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/ModernHtmlExporter.nestedForward.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Issue #434: 嵌套合并转发（[聊天记录]里又套了一层[聊天记录]）应递归渲染成内层卡片，
+ * 而不是只显示一行"[转发消息]"占位。
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { ModernHtmlExporter } from '../../lib/core/exporter/ModernHtmlExporter.js';
+import { createTempDir } from '../helpers/tempDir.js';
+import { silenceConsole } from '../helpers/silenceConsole.js';
+
+let console_!: ReturnType<typeof silenceConsole>;
+let tmp!: ReturnType<typeof createTempDir>;
+
+test.beforeEach(() => {
+    console_ = silenceConsole();
+    tmp = createTempDir();
+});
+
+test.afterEach(() => {
+    tmp.cleanup();
+    console_.restore();
+});
+
+async function renderMessage(message: any): Promise<string> {
+    const outputDir = path.join(tmp.path, 'out');
+    fs.mkdirSync(outputDir, { recursive: true });
+    const outputPath = path.join(outputDir, 'chat.html');
+    const exporter = new ModernHtmlExporter({
+        outputPath,
+        includeResourceLinks: true,
+        includeSystemMessages: true
+    });
+    async function* iter() {
+        yield message;
+    }
+    await exporter.exportFromIterable(iter(), { name: 'Alice', type: 'private' });
+    return fs.readFileSync(outputPath, 'utf8');
+}
+
+test('nested merged-forward is rendered recursively as inner cards (#434)', async () => {
+    // 外层转发里有一条子消息，这条子消息本身又是一层转发，里面装着两条最里层消息。
+    const innerForward = {
+        type: 'forward',
+        data: {
+            title: '聊天记录',
+            messageCount: 2,
+            messages: [
+                { sender: { name: '深层用户甲' }, content: { text: '最里层消息一', elements: [{ type: 'text', data: { text: '最里层消息一' } }] } },
+                { sender: { name: '深层用户乙' }, content: { text: '最里层消息二', elements: [{ type: 'text', data: { text: '最里层消息二' } }] } }
+            ]
+        }
+    };
+
+    const message: any = {
+        id: 'm_1',
+        timestamp: Date.now(),
+        sender: { id: 'u_alice', uin: '11111', name: 'Alice' },
+        chatType: 1,
+        peer: { peerUid: 'u_alice' },
+        content: {
+            elements: [
+                {
+                    type: 'forward',
+                    data: {
+                        title: '聊天记录',
+                        messageCount: 1,
+                        messages: [
+                            {
+                                sender: { name: '中层用户' },
+                                content: { text: '[转发消息: 2条]', elements: [innerForward] }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    };
+
+    const html = await renderMessage(message);
+
+    // 最里层的发送者与消息内容必须出现，说明递归展开成功，而不是停在占位文本。
+    assert.ok(html.includes('深层用户甲'), 'innermost sender 深层用户甲 should be rendered');
+    assert.ok(html.includes('最里层消息一'), 'innermost message body should be rendered');
+    assert.ok(html.includes('深层用户乙'), 'second innermost sender should be rendered');
+    // 内层卡片应带 forward-card-nested 标记。
+    assert.ok(html.includes('forward-card-nested'), 'nested forward card class should be present');
+    // 占位文本"[转发消息: 2条]"被内层卡片替代，不应再作为正文出现。
+    assert.ok(!html.includes('[转发消息: 2条]'), 'placeholder text should be replaced by the nested card');
+});
+
+test('forward render depth is capped to avoid runaway nesting (#434)', async () => {
+    // 构造超过上限的深层嵌套，确保不抛错且能正常导出。
+    const makeForward = (depth: number): any => {
+        if (depth === 0) {
+            return { sender: { name: '叶子' }, content: { text: '叶子消息', elements: [{ type: 'text', data: { text: '叶子消息' } }] } };
+        }
+        const child = makeForward(depth - 1);
+        return {
+            sender: { name: `第${depth}层` },
+            content: {
+                text: '[转发消息: 1条]',
+                elements: [{ type: 'forward', data: { title: '聊天记录', messageCount: 1, messages: [child] } }]
+            }
+        };
+    };
+
+    const message: any = {
+        id: 'm_deep',
+        timestamp: Date.now(),
+        sender: { id: 'u_alice', uin: '11111', name: 'Alice' },
+        chatType: 1,
+        peer: { peerUid: 'u_alice' },
+        content: {
+            elements: [
+                { type: 'forward', data: { title: '聊天记录', messageCount: 1, messages: [makeForward(6)] } }
+            ]
+        }
+    };
+
+    const html = await renderMessage(message);
+    // 不抛错即视为通过；浅层应渲染出来。
+    assert.ok(html.includes('第6层') || html.includes('第5层'), 'shallow nesting levels should render');
+});

--- a/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
@@ -1673,7 +1673,7 @@ export class ModernHtmlExporter {
         </div>`;
     }
 
-    private renderForwardElement(data: any): string {
+    private renderForwardElement(data: any, depth: number = 0): string {
         const title = data?.title || '聊天记录';
         const rawSummary = typeof data?.summary === 'string' ? data.summary : (typeof data?.content === 'string' ? data.content : '');
         // issue #128 子项 3：老数据里 summary 可能是 NapCat 推下来的 multiForwardMsg XML 原文，
@@ -1685,9 +1685,12 @@ export class ModernHtmlExporter {
         // 优先用它渲染完整列表，老数据 / fallback 再退回 preview / summary。
         const innerMessages: Array<{
             sender?: { name?: string; uin?: string };
-            content?: { text?: string };
+            content?: { text?: string; elements?: Array<{ type?: string; data?: any }> };
         }> = Array.isArray(data?.messages) ? data.messages : [];
         const messageCount: number = typeof data?.messageCount === 'number' ? data.messageCount : innerMessages.length;
+        // issue #434：子消息本身可能又是一条合并转发（嵌套[聊天记录]），递归展开成内层卡片。
+        // 解析器侧 MAX_FORWARD_DEPTH=3，这里用同样的上限兜底异常数据。
+        const MAX_RENDER_DEPTH = 3;
 
         let previewHtml = '';
         if (innerMessages.length > 0) {
@@ -1695,7 +1698,14 @@ export class ModernHtmlExporter {
                 const name = this.escapeHtml(m?.sender?.name || (m?.sender?.uin ? String(m.sender.uin) : '未知'));
                 const text = (m?.content?.text || '').replace(/\s+/g, ' ').trim();
                 const trimmed = text.length > 60 ? text.slice(0, 60) + '…' : text;
-                return `<div class="forward-card-line"><span class="forward-card-sender">${name}:</span> <span class="forward-card-body">${this.escapeHtml(trimmed)}</span></div>`;
+                const nestedForwards = depth < MAX_RENDER_DEPTH && Array.isArray(m?.content?.elements)
+                    ? m.content!.elements.filter((el) => el?.type === 'forward' && el?.data)
+                    : [];
+                const nestedHtml = nestedForwards.map((el) => this.renderForwardElement(el.data, depth + 1)).join('');
+                // 子消息只是一条嵌套转发时，正文就是"[转发消息: N条]"这类占位，已由内层卡片表达，去掉避免重复。
+                const bodyText = nestedHtml && /^\[转发消息/.test(text) ? '' : trimmed;
+                const bodyHtml = bodyText ? `<span class="forward-card-body">${this.escapeHtml(bodyText)}</span>` : '';
+                return `<div class="forward-card-line"><span class="forward-card-sender">${name}:</span> ${bodyHtml}${nestedHtml}</div>`;
             }).join('');
         } else if (Array.isArray(preview) && preview.length > 0) {
             previewHtml = preview.slice(0, 5).map((line: any) => {
@@ -1710,7 +1720,7 @@ export class ModernHtmlExporter {
 
         const footerLabel = messageCount > 0 ? `转发消息 · ${messageCount}条` : '转发消息';
 
-        return `<div class="forward-card">
+        return `<div class="forward-card${depth > 0 ? ' forward-card-nested' : ''}">
             <div class="forward-card-header">
                 <svg class="forward-card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
                     <path d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlTemplates.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlTemplates.ts
@@ -1114,23 +1114,18 @@ export const MODERN_CSS = `
             font-size: 13px;
             color: var(--text-secondary);
             line-height: 1.6;
-            max-height: 120px;
-            overflow: hidden;
             position: relative;
         }
-        
-        .forward-card-content::after {
-            content: '';
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            height: 30px;
-            background: linear-gradient(to bottom, transparent, var(--bubble-other));
+
+        /* issue #434：嵌套的合并转发消息卡片，缩进 + 左侧分隔线，区分层级。 */
+        .forward-card-nested {
+            margin-left: 8px;
+            margin-top: 4px;
+            border-left: 2px solid rgba(0, 0, 0, 0.08);
         }
-        
-        .message.self .forward-card-content::after {
-            background: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.05));
+
+        [data-theme="dark"] .forward-card-nested {
+            border-left-color: rgba(255, 255, 255, 0.12);
         }
         
         .forward-card-footer {


### PR DESCRIPTION
## 问题

#434：合并转发里如果有子消息本身又是一条合并转发（嵌套的 [聊天记录]），HTML 导出只显示一行 `[转发消息: N条]` 占位，没法看到里层聊天记录。

## 改动

- `ModernHtmlExporter.renderForwardElement` 增加 `depth` 参数，遇到子消息里的 `forward` 元素时递归渲染为缩进的内层卡片，上限 3 层（与解析器 `MAX_FORWARD_DEPTH` 一致）。
- 子消息只是一条嵌套转发时，其正文就是 `[转发消息: N条]` 占位，已由内层卡片表达，去掉避免重复。
- 移除 `.forward-card-content` 的 `max-height: 120px` 截断与渐隐遮罩，使展开后的嵌套内容完整可见（每张卡片仍只取前 5 条子消息，高度可控）；新增 `.forward-card-nested` 缩进样式区分层级。

## 测试

- 新增 `__tests__/unit/ModernHtmlExporter.nestedForward.test.ts`：验证嵌套转发被递归展开、内层发送者/正文出现、占位文本被替换、深层嵌套不抛错。
- `npm run test:unit` 276 全绿，`npm run test:integration` 7 全绿。
- 本地生成样例 HTML 浏览器实测，嵌套卡片正常缩进展示。