### PR TITLE
feat: 一键触发所有定时导出任务

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/ScheduledExportManager.triggerAll.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/ScheduledExportManager.triggerAll.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Issue #445: 一键执行所有定时（自动）导出任务。
+ *
+ * 验证 triggerAllScheduledExports：
+ *   1. 默认只触发已启用的任务，跳过未启用的；
+ *   2. includeDisabled=true 时连同未启用任务一起触发；
+ *   3. 立即返回被排入执行的任务列表，实际执行在后台串行进行；
+ *   4. 单个任务执行抛错不影响其余任务。
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ScheduledExportManager, ScheduledExportConfig } from '../../lib/core/scheduler/ScheduledExportManager.js';
+
+function makeTask(id: string, enabled: boolean): ScheduledExportConfig {
+    const now = new Date();
+    return {
+        id,
+        name: `任务-${id}`,
+        peer: { chatType: 2, peerUid: id, guildId: '' },
+        scheduleType: 'daily',
+        executeTime: '08:00',
+        timeRangeType: 'yesterday',
+        format: 'JSON',
+        options: {},
+        enabled,
+        createdAt: now,
+        updatedAt: now
+    } as ScheduledExportConfig;
+}
+
+function newManager(): ScheduledExportManager {
+    return new ScheduledExportManager({} as any, {} as any, {} as any);
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 20));
+
+test('triggerAllScheduledExports only triggers enabled tasks by default (#445)', async () => {
+    const mgr = newManager();
+    const executed: string[] = [];
+    (mgr as any).executeExportTask = async (task: ScheduledExportConfig) => {
+        executed.push(task.id);
+        return { id: 'h', scheduledExportId: task.id, executedAt: new Date(), status: 'success', duration: 1 };
+    };
+    (mgr as any).scheduledTasks = new Map([
+        ['a', makeTask('a', true)],
+        ['b', makeTask('b', false)],
+        ['c', makeTask('c', true)]
+    ]);
+
+    const triggered = mgr.triggerAllScheduledExports();
+    assert.deepEqual(triggered.map((t) => t.id).sort(), ['a', 'c']);
+    assert.deepEqual(triggered.find((t) => t.id === 'a')?.name, '任务-a');
+
+    await flush();
+    assert.deepEqual(executed.sort(), ['a', 'c'], 'only enabled tasks should be executed');
+});
+
+test('triggerAllScheduledExports includes disabled tasks when requested (#445)', async () => {
+    const mgr = newManager();
+    const executed: string[] = [];
+    (mgr as any).executeExportTask = async (task: ScheduledExportConfig) => {
+        executed.push(task.id);
+        return { id: 'h', scheduledExportId: task.id, executedAt: new Date(), status: 'success', duration: 1 };
+    };
+    (mgr as any).scheduledTasks = new Map([
+        ['a', makeTask('a', true)],
+        ['b', makeTask('b', false)]
+    ]);
+
+    const triggered = mgr.triggerAllScheduledExports({ includeDisabled: true });
+    assert.deepEqual(triggered.map((t) => t.id).sort(), ['a', 'b']);
+
+    await flush();
+    assert.deepEqual(executed.sort(), ['a', 'b']);
+});
+
+test('a failing task does not abort the rest of the queue (#445)', async () => {
+    const mgr = newManager();
+    const executed: string[] = [];
+    (mgr as any).executeExportTask = async (task: ScheduledExportConfig) => {
+        executed.push(task.id);
+        if (task.id === 'a') throw new Error('boom');
+        return { id: 'h', scheduledExportId: task.id, executedAt: new Date(), status: 'success', duration: 1 };
+    };
+    (mgr as any).scheduledTasks = new Map([
+        ['a', makeTask('a', true)],
+        ['b', makeTask('b', true)]
+    ]);
+
+    const triggered = mgr.triggerAllScheduledExports();
+    assert.equal(triggered.length, 2);
+
+    await flush();
+    assert.deepEqual(executed.sort(), ['a', 'b'], 'both tasks should run even if the first throws');
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -2833,6 +2833,20 @@ export class QQChatExporterApiServer {
             }
         });
 
+        // 一键触发所有定时导出任务（issue #445）
+        // 默认只触发已启用的任务，传 includeDisabled=true 可包含未启用的；
+        // 任务在后台串行执行，接口立即返回被排入执行的任务列表。
+        this.app.post('/api/scheduled-exports/trigger-all', async (req, res) => {
+            try {
+                const includeDisabled = req.body?.includeDisabled === true
+                    || req.query['includeDisabled'] === 'true';
+                const triggered = this.scheduledExportManager.triggerAllScheduledExports({ includeDisabled });
+                this.sendSuccessResponse(res, { triggered, count: triggered.length }, (req as any).requestId);
+            } catch (error) {
+                this.sendErrorResponse(res, error, (req as any).requestId);
+            }
+        });
+
         // 获取指定的定时导出任务
         this.app.get('/api/scheduled-exports/:id', async (req, res) => {
             try {

--- a/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
+++ b/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
@@ -346,6 +346,32 @@ export class ScheduledExportManager {
     }
 
     /**
+     * 一键触发所有定时导出任务（issue #445）。
+     *
+     * 默认只触发已启用的任务；任务在后台串行执行，避免多个导出并发争抢 NapCat 资源。
+     * 立即返回被排入执行的任务列表，每个任务的实际结果通过其执行历史查询。
+     */
+    triggerAllScheduledExports(options: { includeDisabled?: boolean } = {}): Array<{ id: string; name: string }> {
+        const includeDisabled = options.includeDisabled === true;
+        const targets = Array.from(this.scheduledTasks.values())
+            .filter((task) => includeDisabled || task.enabled);
+
+        // 串行执行，逐个 await，避免并发导出互相争抢资源；executeExportTask 内部已捕获
+        // 异常并写入执行历史，这里再兜一层防止意外抛出中断整个队列。
+        void (async () => {
+            for (const task of targets) {
+                try {
+                    await this.executeExportTask(task);
+                } catch {
+                    // 单个任务失败不影响后续任务，结果已记录在执行历史中。
+                }
+            }
+        })();
+
+        return targets.map((task) => ({ id: task.id, name: task.name }));
+    }
+
+    /**
      * 获取任务执行历史
      */
     async getExecutionHistory(scheduledExportId: string, limit: number = 50): Promise<ExecutionHistory[]> {


### PR DESCRIPTION
## 需求

#445：自动（定时）任务多的时候，需要在列表里一个个点击手动执行，效率很低，希望有「一键导出/执行」。

## 改动

- `ScheduledExportManager.triggerAllScheduledExports({ includeDisabled? })`：默认只触发已启用任务，`includeDisabled=true` 时连未启用的一起触发。任务在后台**串行** await 执行，避免多个导出并发争抢 NapCat 资源；单个任务异常不会中断队列（`executeExportTask` 内部已捕获并写入执行历史）。
- 新增 `POST /api/scheduled-exports/trigger-all`，立即返回被排入执行的任务列表 `{ triggered: [{id,name}], count }`，实际结果通过各任务的执行历史接口查询。

## 测试

- 新增 `__tests__/unit/ScheduledExportManager.triggerAll.test.ts`：验证默认只触发已启用任务、`includeDisabled` 行为、以及单任务失败不影响其余任务。
- `npm run test:unit` 279 全绿，`npm run test:integration` 7 全绿。

前端「一键执行」按钮调用此接口即可，可后续单独跟进。