### PR TITLE
feat: HTML 导出增加打印/PDF 友好开关

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/ModernHtmlExporter.printOptions.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/ModernHtmlExporter.printOptions.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Issue #467: 单文件 HTML 导出新增两个打印 / PDF 友好开关：
+ *   - showSearchBar：是否显示底部胶囊式搜索/工具栏；
+ *   - enableVirtualScroll：是否启用虚拟滚动。
+ * 都默认开启，关闭后分别隐藏工具栏、让所有消息留在 DOM。
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { ModernHtmlExporter, HtmlExportOptions } from '../../lib/core/exporter/ModernHtmlExporter.js';
+import { createTempDir } from '../helpers/tempDir.js';
+import { silenceConsole } from '../helpers/silenceConsole.js';
+
+let console_!: ReturnType<typeof silenceConsole>;
+let tmp!: ReturnType<typeof createTempDir>;
+
+test.beforeEach(() => {
+    console_ = silenceConsole();
+    tmp = createTempDir();
+});
+
+test.afterEach(() => {
+    tmp.cleanup();
+    console_.restore();
+});
+
+async function renderHtml(extraOptions: Partial<HtmlExportOptions> = {}): Promise<string> {
+    const outputDir = path.join(tmp.path, 'out');
+    fs.mkdirSync(outputDir, { recursive: true });
+    const outputPath = path.join(outputDir, 'chat.html');
+    const exporter = new ModernHtmlExporter({
+        outputPath,
+        includeResourceLinks: true,
+        includeSystemMessages: true,
+        ...extraOptions
+    });
+    const message: any = {
+        id: 'm_1',
+        timestamp: Date.now(),
+        sender: { id: 'u_1', uin: '10001', name: '张三' },
+        chatType: 1,
+        peer: { peerUid: 'u_1' },
+        content: { elements: [{ type: 'text', data: { text: '你好' } }] }
+    };
+    async function* iter() { yield message; }
+    await exporter.exportFromIterable(iter(), { name: 'Alice', type: 'private' });
+    return fs.readFileSync(outputPath, 'utf8');
+}
+
+test('defaults keep the toolbar visible and virtual scroll enabled (#467)', async () => {
+    const html = await renderHtml();
+    assert.ok(html.includes('<div class="toolbar">'), 'toolbar should render by default');
+    assert.ok(!html.includes('<div class="toolbar" style="display:none">'), 'toolbar should not be hidden by default');
+    assert.ok(html.includes('window.__QCE_ENABLE_VIRTUAL_SCROLL = true'), 'virtual scroll enabled by default');
+});
+
+test('showSearchBar=false hides the capsule toolbar (#467)', async () => {
+    const html = await renderHtml({ showSearchBar: false });
+    assert.ok(html.includes('<div class="toolbar" style="display:none">'), 'toolbar should be hidden');
+    assert.ok(!html.includes('<div class="toolbar">'), 'no visible toolbar element should remain');
+});
+
+test('enableVirtualScroll=false disables virtual scrolling (#467)', async () => {
+    const html = await renderHtml({ enableVirtualScroll: false });
+    assert.ok(html.includes('window.__QCE_ENABLE_VIRTUAL_SCROLL = false'), 'virtual scroll should be disabled');
+    // 渲染脚本中的开关判断仍在，只是运行期被关掉。
+    assert.ok(html.includes('window.__QCE_ENABLE_VIRTUAL_SCROLL !== false && messageBlocks.length > 100'),
+        'virtual scroll init should be gated on the runtime flag');
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -4061,6 +4061,9 @@ export class QQChatExporterApiServer {
                         encoding: exportOptions.encoding,
                         // Issue #311: 自包含 HTML（资源以 base64 内联）。
                         embedResourcesAsDataUri: options?.embedResourcesAsDataUri === true,
+                        // Issue #467: 打印 / PDF 友好开关，默认开启。
+                        showSearchBar: options?.showSearchBar !== false,
+                        enableVirtualScroll: options?.enableVirtualScroll !== false,
                         ...(typeof options?.maxEmbedFileSizeBytes === 'number'
                             ? { maxEmbedFileSizeBytes: options.maxEmbedFileSizeBytes }
                             : {})
@@ -4551,6 +4554,9 @@ export class QQChatExporterApiServer {
                 includeResourceLinks: !options?.filterPureImageMessages,
                 includeSystemMessages: options?.includeSystemMessages ?? true,
                 encoding: 'utf-8',
+                // Issue #467: 打印 / PDF 友好开关，默认开启。
+                showSearchBar: options?.showSearchBar !== false,
+                enableVirtualScroll: options?.enableVirtualScroll !== false,
                 senderTitleResolver
             });
 

--- a/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
@@ -43,6 +43,17 @@ export interface HtmlExportOptions {
      * 因为体积过大而崩溃，因此默认值偏保守。
      */
     maxEmbedFileSizeBytes?: number;
+    /**
+     * Issue #467: 是否在导出的 HTML 中显示底部胶囊式搜索/工具栏。默认 true。
+     * 关闭后工具栏不渲染，便于打印 / 导出 PDF 时不被虚拟打印机一并捕获。
+     */
+    showSearchBar?: boolean;
+    /**
+     * Issue #467: 是否启用虚拟滚动（消息超过 100 条时只渲染可视区域）。默认 true。
+     * 关闭后所有消息一次性留在 DOM 中，打印 / 转 PDF 不会因为虚拟滚动而出现空白页，
+     * 代价是超大聊天记录在浏览器里打开会更吃内存。
+     */
+    enableVirtualScroll?: boolean;
 }
 
 /**
@@ -173,6 +184,8 @@ export class ModernHtmlExporter {
             encoding: 'utf8', // 更稳妥的 Node 编码常量
             embedResourcesAsDataUri: false,
             maxEmbedFileSizeBytes: 50 * 1024 * 1024,
+            showSearchBar: true,
+            enableVirtualScroll: true,
             ...options
         };
     }
@@ -1186,14 +1199,22 @@ export class ModernHtmlExporter {
     }
 
     private generateScripts(): string {
-        // 保持原结构：lucide CDN + 内联脚本
-        return MODERN_SINGLE_SCRIPTS_HTML;
+        // 保持原结构：lucide CDN + 内联脚本。
+        // Issue #467: 注入运行期开关，控制是否启用虚拟滚动。
+        const enableVirtualScroll = this.options.enableVirtualScroll !== false;
+        const runtimeConfig = `<script>window.__QCE_ENABLE_VIRTUAL_SCROLL = ${enableVirtualScroll};</script>\n`;
+        return runtimeConfig + MODERN_SINGLE_SCRIPTS_HTML;
     }
 
     /**
      * 生成Toolbar（底部胶囊）
      */
     private generateToolbar(): string {
+        // Issue #467: 关闭搜索栏时隐藏整条工具栏（保留 DOM 节点，避免脚本里的
+        // 事件绑定取到 null 报错），display:none 同时让打印 / PDF 不再捕获它。
+        if (this.options.showSearchBar === false) {
+            return MODERN_TOOLBAR_HTML.replace('<div class="toolbar">', '<div class="toolbar" style="display:none">');
+        }
         return MODERN_TOOLBAR_HTML;
     }
 

--- a/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlTemplates.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlTemplates.ts
@@ -1721,8 +1721,10 @@ export const MODERN_SINGLE_APP_JS = `
                 document.getElementById('info-range').textContent = firstTime + ' ~ ' + lastTime;
             }
             // 初始化虚拟滚动（消息超过100条时启用）
+            // issue #467：导出时可通过 window.__QCE_ENABLE_VIRTUAL_SCROLL=false 关闭，
+            // 让所有消息留在 DOM 中，便于打印 / 导出 PDF（默认仍启用）。
             var virtualScroller = null;
-            if (messageBlocks.length > 100) {
+            if (window.__QCE_ENABLE_VIRTUAL_SCROLL !== false && messageBlocks.length > 100) {
                 var chatContent = document.querySelector('.chat-content');
                 var originalBlocks = messageBlocks.map(function(block) { return block.cloneNode(true); });
                 chatContent.innerHTML = '';

--- a/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
+++ b/plugins/qq-chat-exporter/lib/core/scheduler/ScheduledExportManager.ts
@@ -158,6 +158,10 @@ export interface ScheduledExportConfig {
         embedResourcesAsDataUri?: boolean;
         /** Issue #311: 单个资源内联上限（字节）。 */
         maxEmbedFileSizeBytes?: number;
+        /** Issue #467: 仅对 HTML 格式生效，是否显示底部胶囊式搜索/工具栏（默认 true）。 */
+        showSearchBar?: boolean;
+        /** Issue #467: 仅对 HTML 格式生效，是否启用虚拟滚动（默认 true）。 */
+        enableVirtualScroll?: boolean;
     };
     /** 备份模式（新增） */
     backupMode?: BackupMode;
@@ -653,6 +657,9 @@ export class ScheduledExportManager {
                         includeSystemMessages: task.options.includeSystemMessages ?? true,
                         // Issue #311: 自包含 HTML（资源 base64 内联）
                         embedResourcesAsDataUri: task.options.embedResourcesAsDataUri === true,
+                        // Issue #467: 打印 / PDF 友好开关，默认开启。
+                        showSearchBar: task.options.showSearchBar !== false,
+                        enableVirtualScroll: task.options.enableVirtualScroll !== false,
                         ...(typeof task.options.maxEmbedFileSizeBytes === 'number'
                             ? { maxEmbedFileSizeBytes: task.options.maxEmbedFileSizeBytes }
                             : {})


### PR DESCRIPTION
## 需求

#467：用户用虚拟打印机把「特定单日」聊天记录导成 PDF / 实体打印时遇到两个问题：
1. 每个 HTML 内置的底部**胶囊式搜索栏**会被打印驱动一并捕获，输出排版混乱；
2. **虚拟滚动**只渲染约 100 条可视消息，导致大量页面在转换时变成空白页。

希望在「以 HTML 格式输出」时能开关这两项。

## 改动

`HtmlExportOptions` 新增两个开关，默认 `true`（行为不变）：
- `showSearchBar`：为 `false` 时给底部工具栏加 `style="display:none"`，不再渲染/打印（保留 DOM 节点，避免脚本里的事件绑定取到 null）。
- `enableVirtualScroll`：注入 `window.__QCE_ENABLE_VIRTUAL_SCROLL`，单文件脚本的虚拟滚动初始化改为 `if (window.__QCE_ENABLE_VIRTUAL_SCROLL !== false && messageBlocks.length > 100)`，为 `false` 时所有消息一次性留在 DOM。

两个开关已在手动导出（`/api/export`）与定时导出（`ScheduledExportConfig.options`）两条路径透传。

## 测试

- 新增 `__tests__/unit/ModernHtmlExporter.printOptions.test.ts`：默认工具栏可见 + 虚拟滚动开启；`showSearchBar=false` 工具栏隐藏；`enableVirtualScroll=false` 注入 `false` 且初始化判断被门控。
- `npm run test:unit` 282 全绿，`npm run test:integration` 7 全绿。
- 本地导出 `showSearchBar=false`+`enableVirtualScroll=false` 的 HTML，浏览器实测：无底部胶囊、消息完整渲染。