### PR TITLE
feat: 支持停止运行中的导出任务 (#446)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/BatchMessageFetcher.cancel.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/BatchMessageFetcher.cancel.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Issue #446: 导出任务需要能被「停止」。BatchMessageFetcher 暴露 cancel() / isCancelled()，
+ * 分页抓取在每批之间检查取消标记并提前结束；同时确认取消标记不会被下一批次清掉，
+ * 且新一轮抓取会从未取消状态重新开始。
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { BatchMessageFetcher } from '../../lib/core/fetcher/BatchMessageFetcher.js';
+import { createMockCore } from '../helpers/MockNapCatCore.js';
+
+function makeFetcher(): BatchMessageFetcher {
+    const core = createMockCore();
+    return new BatchMessageFetcher(core as any, { batchSize: 100, timeout: 5000, retryCount: 0, retryInterval: 1 });
+}
+
+const peer: any = { chatType: 2, peerUid: '10001', guildId: '' };
+
+/** 让 fetchMessages 永远返回一条消息且 hasMore=true，模拟一个抓不完的大群。 */
+function stubInfinite(fetcher: BatchMessageFetcher): () => number {
+    let produced = 0;
+    (fetcher as any).fetchMessages = async () => {
+        produced++;
+        return {
+            messages: [{ msgId: String(produced), msgTime: '1700000000' }],
+            hasMore: true,
+            actualCount: 1,
+            fetchTime: 1,
+        };
+    };
+    return () => produced;
+}
+
+test('cancel() / isCancelled() reflect cancellation state (#446)', () => {
+    const fetcher = makeFetcher();
+    assert.equal(fetcher.isCancelled(), false);
+    fetcher.cancel();
+    assert.equal(fetcher.isCancelled(), true);
+});
+
+test('fetchAllMessagesInTimeRange stops after cancel() (#446)', async () => {
+    const fetcher = makeFetcher();
+    stubInfinite(fetcher);
+
+    let received = 0;
+    for await (const batch of fetcher.fetchAllMessagesInTimeRange(peer, 0, Date.now())) {
+        received += batch.length;
+        if (received === 2) {
+            fetcher.cancel();
+        }
+        if (received >= 50) break; // 安全阀：取消若失效则在这里兜底
+    }
+
+    assert.equal(fetcher.isCancelled(), true);
+    assert.ok(received < 50, `取消后抓取应尽快停止，实际收到 ${received} 批`);
+    assert.equal(received, 2, '取消应在当前批次结束后立即停止后续抓取');
+});
+
+test('a fresh fetch resets cancellation so prior cancel does not block it (#446)', async () => {
+    const fetcher = makeFetcher();
+    stubInfinite(fetcher);
+
+    // 先取消一次。
+    fetcher.cancel();
+    assert.equal(fetcher.isCancelled(), true);
+
+    // 新一轮抓取应从未取消状态开始，至少能产出一批。
+    let received = 0;
+    for await (const batch of fetcher.fetchAllMessagesInTimeRange(peer, 0, Date.now())) {
+        received += batch.length;
+        fetcher.cancel();
+        if (received >= 50) break;
+    }
+    assert.ok(received >= 1, '新一轮抓取不应被上一轮的取消标记直接挡死');
+    assert.ok(received < 50, '随后再次取消仍应能停止');
+});

--- a/plugins/qq-chat-exporter/lib/api/ApiServer.ts
+++ b/plugins/qq-chat-exporter/lib/api/ApiServer.ts
@@ -183,6 +183,11 @@ export class QQChatExporterApiServer {
     
     // 任务资源处理器管理（每个任务使用独立的 ResourceHandler）
     private taskResourceHandlers: Map<string, ResourceHandler> = new Map();
+
+    // issue #446：跟踪运行中导出任务的消息抓取器，用于「停止任务」时打断分页抓取。
+    private runningExportFetchers: Map<string, BatchMessageFetcher> = new Map();
+    // issue #446：被用户主动停止的任务ID。导出流程据此把状态标记为 cancelled 而非 failed。
+    private cancelledTaskIds: Set<string> = new Set();
     
     // 资源文件名缓存 (shortName -> fullFileName 映射)
     // 例如: "A1D18D97.jpg" -> "a1d18d97b45c620add5133050c00044c_A1D18D97.jpg"
@@ -2100,6 +2105,45 @@ export class QQChatExporterApiServer {
             }
         });
 
+        // issue #446：停止/取消一个运行中的导出任务。
+        // 给抓取器发取消信号，分页抓取会在当前批次结束后停止，任务标记为 cancelled。
+        this.app.post('/api/tasks/:taskId/cancel', async (req, res) => {
+            try {
+                const { taskId } = req.params;
+                if (!this.exportTasks.has(taskId)) {
+                    throw new SystemError(ErrorType.VALIDATION_ERROR, '任务不存在', 'TASK_NOT_FOUND');
+                }
+
+                const task = this.exportTasks.get(taskId);
+                const status = task?.status;
+                // 已结束的任务无需取消，幂等返回。
+                if (status === 'completed' || status === 'failed' || status === 'cancelled') {
+                    this.sendSuccessResponse(res, { taskId, cancelled: false, status }, (req as any).requestId);
+                    return;
+                }
+
+                this.cancelledTaskIds.add(taskId);
+                const fetcher = this.runningExportFetchers.get(taskId);
+                if (fetcher) {
+                    fetcher.cancel();
+                }
+
+                await this.updateTaskStatus(taskId, {
+                    status: 'cancelled',
+                    message: '任务已停止',
+                    completedAt: new Date().toISOString()
+                });
+                this.broadcastWebSocketMessage({
+                    type: 'export_progress',
+                    data: { taskId, status: 'cancelled', message: '任务已停止' }
+                });
+
+                this.sendSuccessResponse(res, { taskId, cancelled: true }, (req as any).requestId);
+            } catch (error) {
+                this.sendErrorResponse(res, error, (req as any).requestId);
+            }
+        });
+
         // 删除ZIP导出任务的原始文件
         this.app.delete('/api/tasks/:taskId/original-files', async (req, res) => {
             try {
@@ -3755,6 +3799,9 @@ export class QQChatExporterApiServer {
                 endTimeMs = endTimeMs * 1000;
             }
             
+            // issue #446：注册抓取器，使「停止任务」接口能打断本任务的分页抓取。
+            this.runningExportFetchers.set(taskId, fetcher);
+
             const allMessages: RawMessage[] = [];
             const messageGenerator = fetcher.fetchAllMessagesInTimeRange(peer, startTimeMs, endTimeMs);
             
@@ -3813,6 +3860,11 @@ export class QQChatExporterApiServer {
             }
             
             // 消息收集完成
+
+            // issue #446：用户已停止任务，跳过后续解析/下载/写文件，交由 catch 标记为 cancelled。
+            if (this.cancelledTaskIds.has(taskId) || fetcher.isCancelled()) {
+                throw new SystemError(ErrorType.VALIDATION_ERROR, '任务已被用户停止', 'EXPORT_CANCELLED');
+            }
 
             // 补全群消息的群昵称（sendMemberName）+ 构建群头衔映射（issue #331）
             let memberSpecialTitleMap: Map<string, string> | null = null;
@@ -4190,20 +4242,32 @@ export class QQChatExporterApiServer {
             this.clearResourceCache('audios');
 
         } catch (error) {
-            console.error(`[ApiServer] 导出任务失败: ${taskId}`, error);
-            
-            // 更新任务为失败状态
+            // issue #446：区分「用户主动停止」与真正的失败，停止时状态记为 cancelled。
+            const wasCancelled = this.cancelledTaskIds.has(taskId);
+            if (wasCancelled) {
+                console.info(`[ApiServer] 导出任务已被用户停止: ${taskId}`);
+            } else {
+                console.error(`[ApiServer] 导出任务失败: ${taskId}`, error);
+            }
+
             task = this.exportTasks.get(taskId);
             if (task) {
-                await this.updateTaskStatus(taskId, {
+                await this.updateTaskStatus(taskId, wasCancelled ? {
+                    status: 'cancelled',
+                    message: '任务已停止',
+                    completedAt: new Date().toISOString()
+                } : {
                     status: 'failed',
                     error: error instanceof Error ? error.message : '导出失败',
                     completedAt: new Date().toISOString()
                 });
             }
 
-            // 发送错误通知
-            this.broadcastWebSocketMessage({
+            // 发送通知
+            this.broadcastWebSocketMessage(wasCancelled ? {
+                type: 'export_progress',
+                data: { taskId, status: 'cancelled', message: '任务已停止' }
+            } : {
                 type: 'export_error',
                 data: {
                     taskId,
@@ -4212,6 +4276,10 @@ export class QQChatExporterApiServer {
                 }
             });
         } finally {
+            // issue #446：清理停止任务的跟踪状态。
+            this.runningExportFetchers.delete(taskId);
+            this.cancelledTaskIds.delete(taskId);
+
             // 清理任务的资源处理器（无论成功还是失败）
             const resourceHandler = this.taskResourceHandlers.get(taskId);
             if (resourceHandler) {

--- a/plugins/qq-chat-exporter/lib/core/fetcher/BatchMessageFetcher.ts
+++ b/plugins/qq-chat-exporter/lib/core/fetcher/BatchMessageFetcher.ts
@@ -122,8 +122,9 @@ export class BatchMessageFetcher {
         }
 
         this.isFetching = true;
-        this.cancelToken.cancelled = false;
-        
+        // 注意：不在每个批次开始时重置取消标记，否则在分页抓取过程中调用 cancel()
+        // 会被下一批次清掉，导致取消失效（issue #446）。取消标记由抓取序列起点统一重置。
+
         try {
             const startTime = Date.now();
             
@@ -172,6 +173,9 @@ export class BatchMessageFetcher {
             endTime,
             ...additionalFilter
         };
+
+        // 抓取序列起点重置取消标记，保证本次抓取从未取消状态开始（issue #446）。
+        this.cancelToken.cancelled = false;
 
         let hasMore = true;
         let nextMessageId: string | undefined;
@@ -694,6 +698,13 @@ export class BatchMessageFetcher {
      */
     cancel(): void {
         this.cancelToken.cancelled = true;
+    }
+
+    /**
+     * 当前抓取是否已被取消（issue #446）。
+     */
+    isCancelled(): boolean {
+        return this.cancelToken.cancelled;
     }
 
     /**

--- a/plugins/qq-chat-exporter/package.json
+++ b/plugins/qq-chat-exporter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qq-chat-exporter",
   "plugin": "QQ 聊天记录导出",
-  "version": "5.5.72",
+  "version": "5.5.73",
   "description": "导出 QQ 聊天记录为 HTML / JSON / TXT / Excel，支持时间筛选、批量任务、定时任务、表情图片语音视频资源处理、合并转发展开等。",
   "main": "index.mjs",
   "type": "module",

--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -64,6 +64,7 @@ import {
   PanelLeftOpen,
   ChevronRight,
   Search,
+  Square,
 } from "lucide-react"
 import type { CreateTaskForm, CreateScheduledExportForm } from "@/types/api"
 import { useQCE } from "@/hooks/use-qce"
@@ -305,6 +306,7 @@ export default function QCEDashboard() {
     tasks,
     loadTasks,
     deleteTask,
+    cancelTask,
     createTask,
     downloadTask,
     getTaskStats,
@@ -1819,6 +1821,23 @@ export default function QCEDashboard() {
                       </div>
 
                       <div className="ml-3 flex items-center gap-1.5 flex-shrink-0">
+                        {/* issue #446：运行中的任务可以停止，打断分页抓取，不必干等。 */}
+                        {(task.status === "running" || task.status === "pending") && (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            className="h-8 w-8 rounded-full p-0 text-muted-foreground/60 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950/30"
+                            onClick={() => {
+                              showDeleteConfirmationToast(`停止任务「${task.sessionName}」？`, "已获取的消息不会保存", async () => {
+                                const success = await cancelTask(task.id)
+                                if (!success) throw new Error("停止失败")
+                              })
+                            }}
+                            title="停止"
+                          >
+                            <Square className="w-4 h-4" />
+                          </Button>
+                        )}
                         {task.status === "completed" && (
                           <>
                             <Button

--- a/qce-v4-tool/hooks/use-export-tasks.ts
+++ b/qce-v4-tool/hooks/use-export-tasks.ts
@@ -399,6 +399,29 @@ export function useExportTasks(_props?: UseExportTasksProps) {
     }
   }, [apiCall, dismissTaskToast])
 
+  // issue #446：停止一个运行中的导出任务。后端会打断分页抓取并把任务标记为 cancelled。
+  const cancelTask = useCallback(async (taskId: string): Promise<boolean> => {
+    try {
+      setError(null)
+
+      const response = await apiCall(`/api/tasks/${taskId}/cancel`, {
+        method: "POST",
+      })
+
+      if (response.success) {
+        return true
+      }
+
+      setError(response.error?.message || "停止任务失败")
+      return false
+    } catch (err) {
+      const errorMessage = `停止任务失败: ${err instanceof Error ? err.message : "未知错误"}`
+      setError(errorMessage)
+      console.error("[QCE] Cancel task error:", err)
+      return false
+    }
+  }, [apiCall])
+
   const createTask = useCallback(async (form: CreateTaskForm): Promise<boolean> => {
     if (!form.peerUid || !form.sessionName) {
       setError("请填写完整信息")
@@ -749,6 +772,7 @@ export function useExportTasks(_props?: UseExportTasksProps) {
     loadTasks,
     refreshTasks,
     deleteTask,
+    cancelTask,
     createTask,
     updateTaskProgress,
     handleWebSocketProgress,

--- a/qce-v4-tool/hooks/use-qce.ts
+++ b/qce-v4-tool/hooks/use-qce.ts
@@ -69,6 +69,7 @@ export function useQCE(props?: { onNotification?: UseExportTasksProps['onNotific
     tasks: exportTasks.tasks,
     loadTasks: exportTasks.loadTasks,
     deleteTask: exportTasks.deleteTask,
+    cancelTask: exportTasks.cancelTask,
     createTask: exportTasks.createTask,
     downloadTask: exportTasks.downloadTask,
     deleteOriginalFiles: exportTasks.deleteOriginalFiles,


### PR DESCRIPTION
## 解决 #446（停止任务部分）

导出大群时分页抓取可能持续很久，此前没有中断手段，任务挂在 running 只能干等或重启程序。本 PR 让运行中的导出任务可以被主动停止。

### 改动

**后端**
- `BatchMessageFetcher` 暴露 `isCancelled()`；取消标记的重置从「每批 `fetchMessages` 开头」挪到「抓取序列起点 `fetchAllMessagesInTimeRange`」。
  - 原先每批开头都会 `cancelToken.cancelled = false`，在分页过程中调用 `cancel()` 会被下一批清掉，导致取消时灵时不灵。
- `ApiServer` 用 `runningExportFetchers` 跟踪运行中任务的抓取器，新增 `POST /api/tasks/:taskId/cancel`：
  - 给抓取器发取消信号，抓取在当前批次结束后停止；
  - 收尾后跳过解析/资源下载/写文件，任务状态标记为 `cancelled`（区别于真正的 `failed`）；
  - 已结束的任务幂等返回。

**前端**
- 任务列表为 `running` / `pending` 的任务增加「停止」按钮，二次确认后调用上面的接口。

### 不在本 PR 范围
- 暂停/恢复（需要保存抓取游标续传）与「关闭程序释放 QQ 占用」（启动器/进程层面）后续再处理。

### 测试
- 新增 `BatchMessageFetcher.cancel.test.ts`：取消状态、取消后及时停止、新一轮抓取不被上一轮取消标记挡死。
- `npm run test:unit` 289 通过，`npm run test:integration` 7 通过。