### PR TITLE
fix: 打包内置全平台 esbuild 二进制，修复 Windows/macOS API 服务器无法启动 (#485)

### DIFF
--- a/plugins/qq-chat-exporter/package.json
+++ b/plugins/qq-chat-exporter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qq-chat-exporter",
   "plugin": "QQ 聊天记录导出",
-  "version": "5.5.73",
+  "version": "5.5.74",
   "description": "导出 QQ 聊天记录为 HTML / JSON / TXT / Excel，支持时间筛选、批量任务、定时任务、表情图片语音视频资源处理、合并转发展开等。",
   "main": "index.mjs",
   "type": "module",

--- a/scripts/build-framework-plugin.py
+++ b/scripts/build-framework-plugin.py
@@ -122,7 +122,21 @@ def main():
         sys.exit(1)
     print("[x] Done")
     print()
-    
+
+    # Ensure the Windows esbuild binary is bundled. The Framework package only
+    # ever runs on Windows desktop QQ, but `npm install` on a Linux runner would
+    # fetch the linux-x64 esbuild binary, so tsx fails to load esbuild and the
+    # API server never starts. Drop the win32 binaries in explicitly.
+    print("[6.5/8] Bundling Windows esbuild binary...")
+    ensure_cmd = ["node.exe" if os_name == "Windows" else "node",
+                  "scripts/ensure-esbuild-platforms.mjs", qce_dest,
+                  "win32-x64,win32-arm64"]
+    if not run_command(ensure_cmd):
+        print("[!] esbuild platform bundling failed")
+        sys.exit(1)
+    print("[x] Done")
+    print()
+
     # Generate overlay runtime
     print("[7/8] Generating overlay runtime...")
     node_cmd = ["node.exe" if os_name == "Windows" else "node", "tools/create-overlay-runtime.cjs"]

--- a/scripts/build-napcat-plugin.py
+++ b/scripts/build-napcat-plugin.py
@@ -82,6 +82,21 @@ def install_prod_deps(staging_plugin_dir: Path) -> None:
         sys.exit("[!] npm install --omit=dev failed")
 
 
+def bundle_esbuild_platforms(staging_plugin_dir: Path) -> None:
+    """补齐所有平台的 esbuild 原生二进制。
+
+    npm install 只会拉取构建机所属平台的 @esbuild/<platform> 包，导致在
+    Linux 上打出的插件商店包只带 linux-x64，Windows / macOS 用户安装后
+    tsx 加载 esbuild 失败、API 服务器静默无法启动。插件商店包是跨平台的，
+    因此需要内置所有受支持平台的二进制。
+    """
+    print("[-] Bundling esbuild binaries for all platforms...")
+    node_cmd = "node.exe" if platform.system() == "Windows" else "node"
+    script = str(Path("scripts") / "ensure-esbuild-platforms.mjs")
+    if not run_command([node_cmd, script, str(staging_plugin_dir)]):
+        sys.exit("[!] Failed to bundle esbuild platform binaries")
+
+
 def copy_overlay_runtime(staging_plugin_dir: Path) -> None:
     src = SOURCE_PLUGIN_DIR / "node_modules" / "NapCatQQ"
     dest = staging_plugin_dir / "node_modules" / "NapCatQQ"
@@ -246,6 +261,9 @@ def main() -> None:
 
     # 5) 安装生产依赖（基于刚写入的 package.json）
     install_prod_deps(staging_plugin_dir)
+
+    # 5.5) 补齐所有平台的 esbuild 原生二进制（插件商店包跨平台）
+    bundle_esbuild_platforms(staging_plugin_dir)
 
     # 6) 把 NapCatQQ overlay runtime 复制到 staging 的 node_modules
     copy_overlay_runtime(staging_plugin_dir)

--- a/scripts/ensure-esbuild-platforms.mjs
+++ b/scripts/ensure-esbuild-platforms.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Ensures esbuild platform binaries exist under <pluginDir>/node_modules/@esbuild.
+ *
+ * The plugin loads its TypeScript runtime through `tsx.register()`, which pulls
+ * in esbuild. esbuild ships its native binary as a per-platform optional
+ * dependency (`@esbuild/<platform>-<arch>`), and `npm install` only fetches the
+ * binary matching the machine that ran the install. Because the release packages
+ * are produced on a Linux runner, the resulting `@esbuild` directory would only
+ * contain `linux-x64`, leaving Windows / macOS users with a runtime that throws
+ * "You installed esbuild for another platform than the one you're currently using"
+ * and silently fails to start the API server.
+ *
+ * This tool drops every requested platform binary into place so the package
+ * works regardless of the OS that produced the build.
+ *
+ * Usage:
+ *   node scripts/ensure-esbuild-platforms.mjs <pluginDir> [slug1,slug2,...]
+ *
+ * When the platform list is omitted, every supported platform is bundled
+ * (cross-platform package). Pass an explicit comma-separated list to target a
+ * specific subset, e.g. `win32-x64,win32-arm64`.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const ALL_PLATFORMS = [
+    'win32-x64',
+    'win32-arm64',
+    'linux-x64',
+    'linux-arm64',
+    'darwin-x64',
+    'darwin-arm64'
+];
+
+function parseArgs(argv) {
+    const pluginDir = path.resolve(argv[2] || '.');
+    const platforms = argv[3]
+        ? argv[3].split(',').map((s) => s.trim()).filter(Boolean)
+        : ALL_PLATFORMS;
+    return { pluginDir, platforms };
+}
+
+function getEsbuildVersion(pluginDir) {
+    const pkgPath = path.join(pluginDir, 'node_modules/esbuild/package.json');
+    if (!fs.existsSync(pkgPath)) {
+        return null;
+    }
+    return JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version;
+}
+
+function targetExists(pluginDir, slug) {
+    const dir = path.join(pluginDir, 'node_modules/@esbuild', slug);
+    return (
+        fs.existsSync(path.join(dir, 'bin/esbuild')) ||
+        fs.existsSync(path.join(dir, 'esbuild.exe'))
+    );
+}
+
+function installPlatformBinary(pluginDir, slug, version) {
+    const dest = path.join(pluginDir, 'node_modules/@esbuild', slug);
+    fs.mkdirSync(dest, { recursive: true });
+    const tmpDir = fs.mkdtempSync(path.join(pluginDir, '.esbuild-platform-'));
+    try {
+        const packed = execFileSync(
+            'npm',
+            ['pack', `@esbuild/${slug}@${version}`, '--silent'],
+            { cwd: tmpDir, encoding: 'utf8' }
+        );
+        const tarball = packed.trim().split(/\r?\n/).pop().trim();
+        execFileSync('tar', ['-xzf', tarball], { cwd: tmpDir, stdio: 'inherit' });
+        const extracted = path.join(tmpDir, 'package');
+        for (const name of fs.readdirSync(extracted)) {
+            const src = path.join(extracted, name);
+            const dst = path.join(dest, name);
+            if (fs.lstatSync(src).isDirectory()) {
+                fs.cpSync(src, dst, { recursive: true });
+            } else {
+                fs.copyFileSync(src, dst);
+            }
+        }
+        const bin = path.join(dest, 'bin/esbuild');
+        if (fs.existsSync(bin)) {
+            fs.chmodSync(bin, 0o755);
+        }
+    } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+}
+
+function main() {
+    const { pluginDir, platforms } = parseArgs(process.argv);
+    const version = getEsbuildVersion(pluginDir);
+    if (!version) {
+        console.log(`[esbuild] no esbuild under ${pluginDir}; nothing to bundle`);
+        return;
+    }
+
+    let installed = 0;
+    for (const slug of platforms) {
+        if (targetExists(pluginDir, slug)) {
+            continue;
+        }
+        console.log(`[esbuild] adding @esbuild/${slug}@${version}`);
+        installPlatformBinary(pluginDir, slug, version);
+        if (!targetExists(pluginDir, slug)) {
+            throw new Error(`[esbuild] failed to install @esbuild/${slug}@${version}`);
+        }
+        installed++;
+    }
+
+    console.log(
+        `[esbuild] platform binaries ready for ${version} ` +
+        `(${platforms.length} targets, ${installed} newly installed)`
+    );
+}
+
+main();


### PR DESCRIPTION
## 问题

closes #485

Framework v5.5.73 及插件商店包在 Windows 上 QCE API 服务器（40653）始终不启动，控制台无任何 `[QCE]` 日志。

根因：插件通过 `tsx.register()` 加载 TypeScript 运行时，tsx 依赖 esbuild，而 esbuild 的原生二进制是按平台拆分的可选依赖 `@esbuild/<platform>-<arch>`。`npm install` 只会下载**构建机所在平台**的二进制。由于 `napcat-plugin-qce.zip` 和 Framework 包都在 Linux runner 上打包，产物里只带了 `@esbuild/linux-x64`，Windows/macOS 用户安装后 esbuild 抛：

```
You installed esbuild for another platform than the one you're currently using.
Specifically the "@esbuild/linux-x64" package is present but this platform
needs the "@esbuild/win32-x64" package instead.
```

该异常在 `index.mjs` 的 `startApiServer()` 外层被 catch 吞掉，所以表现为「无日志、端口不监听」。

## 改动

- 新增 `scripts/ensure-esbuild-platforms.mjs`：读取已安装的 esbuild 版本，通过 `npm pack` 把缺失平台的 `@esbuild/<platform>` 二进制补齐到 `node_modules/@esbuild` 下，幂等可重复执行。
- `build-napcat-plugin.py`：在 `npm install --omit=dev` 之后补齐**全部平台**二进制（插件商店包跨平台）。
- `build-framework-plugin.py`：确保 win32 二进制存在（Framework 包面向 Windows 桌面 QQ）。
- 插件版本 bump 到 v5.5.74。

## 验证

本地执行 `build-napcat-plugin.py`，产物 `napcat-plugin-qce.zip` 的 `node_modules/@esbuild/` 现包含全部 6 个平台：

```
@esbuild/win32-x64   (esbuild.exe, 10.5MB)
@esbuild/win32-arm64
@esbuild/linux-x64
@esbuild/linux-arm64
@esbuild/darwin-x64
@esbuild/darwin-arm64
```
