### PR TITLE
fix: 修复关键词守卫测试自身含敏感词导致插件被 NapCat 拒绝 (#482)

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/napcatSensitiveKeywords.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/napcatSensitiveKeywords.test.ts
@@ -1,16 +1,19 @@
 /**
  * Guards against NapCat PluginLoader sensitive-keyword false positives
- * (issue #466).
+ * (issues #466, #482).
  *
  * NapCat's PluginLoader scans the shipped plugin source and rejects the plugin
  * outright when it finds a blocked keyword. The plugin ships its TypeScript
- * sources verbatim (tsx loads lib/*.ts at runtime), so even keywords that only
- * appear in comments get scanned. "发卡" — a substring of "转发卡片"
- * ("forward card") used in comments — tripped this and made QCE disappear from
- * the plugin list on Docker NapCat.
+ * sources verbatim (tsx loads lib/*.ts at runtime), and the Shell / Framework
+ * one-click packages additionally ship __tests__/ and tools/, so a blocked
+ * keyword anywhere in the shipped tree trips the loader and makes QCE vanish
+ * from the plugin list ("Scanned 0 plugins").
  *
- * This test fails if any blocked keyword reappears in the shipped source, so a
- * future comment/string does not silently break Docker installs again.
+ * To stop this guard from becoming a landmine itself, the keyword list is built
+ * from escape sequences, so the literal characters never appear in this file.
+ *
+ * This test fails if any blocked keyword reappears anywhere in the shipped
+ * source, so a future comment/string does not silently break installs again.
  */
 
 import test from 'node:test';
@@ -23,15 +26,16 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const PLUGIN_ROOT = path.resolve(__dirname, '../..');
 
-// Keywords NapCat's PluginLoader rejects (observed in #466). Extend as more are
-// reported.
-const BLOCKED_KEYWORDS = ['发卡'];
+// Keywords NapCat's PluginLoader rejects (observed in #466 / #482). Encoded as
+// escape sequences so the literal characters never appear in this guard file.
+// '\u53d1\u5361' is the substring of the Chinese phrase for "forward card".
+const BLOCKED_KEYWORDS = ['\u53d1\u5361'];
 
-// Files NapCat actually scans: the shipped entrypoint and the lib/ sources.
-const SHIPPED_ROOTS = [
-    path.join(PLUGIN_ROOT, 'index.mjs'),
-    path.join(PLUGIN_ROOT, 'lib'),
-];
+// NapCat scans the whole shipped plugin directory, so we check everything that
+// ships except third-party dependencies.
+const IGNORED_DIRS = new Set(['node_modules']);
+
+const SCANNED_EXTENSIONS = new Set(['.ts', '.mjs', '.js', '.cjs', '.json']);
 
 function collectFiles(target: string): string[] {
     if (!fs.existsSync(target)) return [];
@@ -39,23 +43,20 @@ function collectFiles(target: string): string[] {
     if (stat.isFile()) return [target];
     const out: string[] = [];
     for (const entry of fs.readdirSync(target)) {
+        if (IGNORED_DIRS.has(entry)) continue;
         out.push(...collectFiles(path.join(target, entry)));
     }
     return out;
 }
 
-const SCANNED_EXTENSIONS = new Set(['.ts', '.mjs', '.js', '.json']);
-
-test('shipped plugin source is free of NapCat sensitive keywords (#466)', () => {
+test('shipped plugin source is free of NapCat sensitive keywords (#466, #482)', () => {
     const offenders: string[] = [];
-    for (const root of SHIPPED_ROOTS) {
-        for (const file of collectFiles(root)) {
-            if (!SCANNED_EXTENSIONS.has(path.extname(file))) continue;
-            const content = fs.readFileSync(file, 'utf8');
-            for (const keyword of BLOCKED_KEYWORDS) {
-                if (content.includes(keyword)) {
-                    offenders.push(`${path.relative(PLUGIN_ROOT, file)} contains "${keyword}"`);
-                }
+    for (const file of collectFiles(PLUGIN_ROOT)) {
+        if (!SCANNED_EXTENSIONS.has(path.extname(file))) continue;
+        const content = fs.readFileSync(file, 'utf8');
+        for (const keyword of BLOCKED_KEYWORDS) {
+            if (content.includes(keyword)) {
+                offenders.push(`${path.relative(PLUGIN_ROOT, file)} contains "${keyword}"`);
             }
         }
     }

--- a/plugins/qq-chat-exporter/package.json
+++ b/plugins/qq-chat-exporter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qq-chat-exporter",
   "plugin": "QQ 聊天记录导出",
-  "version": "5.5.74",
+  "version": "5.5.75",
   "description": "导出 QQ 聊天记录为 HTML / JSON / TXT / Excel，支持时间筛选、批量任务、定时任务、表情图片语音视频资源处理、合并转发展开等。",
   "main": "index.mjs",
   "type": "module",


### PR DESCRIPTION
## 问题

closes #482

Windows/Linux 一键包用户加载插件时被 NapCat 拒绝，控制台报：

```
[warn] [PluginLoader] Rejected qq-chat-exporter (qq-chat-exporter): sensitive keyword "发卡"
[info] [PluginManager] Scanned 0 plugins
```

插件被整体拒绝，自然也拿不到 token。

## 根因

NapCat 的 PluginLoader 会扫描插件目录里**所有源文件**查找敏感词。Shell / Framework 一键包通过 `copytree` 把整个插件目录原样打包，其中包含 `__tests__/`。

而 `__tests__/unit/napcatSensitiveKeywords.test.ts`（#466 时新增、本意用于**防止**敏感词进入打包产物的守卫测试）为了能检测关键词，自身源码里就写着字面量 `"发卡"`（它是 “转发卡片” 的子串）。这个 `.ts` 文件被打进一键包后，NapCat 扫到字面量 `发卡` → 直接拒绝整个插件。

> 插件商店包 `napcat-plugin-qce.zip` 只拷贝 `index.mjs` / `lib/` 等运行时文件、不含 `__tests__`，所以商店安装不触发；本 issue 报告者用的是 Windows 一键包。

## 改动

- `__tests__/unit/napcatSensitiveKeywords.test.ts`
  - 关键词改用转义写法 `'\u53d1\u5361'` 构造，使该守卫文件自身的源码里**不再出现**字面量字符（字符串运行时值不变，仍能正确匹配其它文件）。
  - 扫描范围从「仅 `index.mjs` + `lib/`」扩大到**整个会被打包的插件目录**（排除 `node_modules`），与 NapCat 实际扫描行为一致，防止 `__tests__/`、`tools/`、`dist/` 等任何文件以后再次埋雷。
- 插件版本 bump 到 v5.5.75。

## 验证

- 全量 grep 确认插件目录（排除 node_modules）已无字面量 `发卡`。
- `npm run test:unit` 全绿：**289 passed / 0 failed**，含改写后的守卫测试（现扫描整棵打包目录）。
