### PR TITLE
fix: disable NapCat builtin replies by default

### DIFF
--- a/plugins/qq-chat-exporter/package.json
+++ b/plugins/qq-chat-exporter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qq-chat-exporter",
   "plugin": "QQ 聊天记录导出",
-  "version": "5.5.75",
+  "version": "5.5.76",
   "description": "导出 QQ 聊天记录为 HTML / JSON / TXT / Excel，支持时间筛选、批量任务、定时任务、表情图片语音视频资源处理、合并转发展开等。",
   "main": "index.mjs",
   "type": "module",
@@ -12,7 +12,9 @@
     "url": "https://github.com/shuakami/qq-chat-exporter.git"
   },
   "napcat": {
-    "tags": ["工具"],
+    "tags": [
+      "工具"
+    ],
     "minVersion": "4.14.0",
     "homepage": "https://github.com/shuakami/qq-chat-exporter"
   },

--- a/qce-v4-tool/package.json
+++ b/qce-v4-tool/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qq-chat-exporter-v4-ui",
   "description": "The web interface for QQ Chat Exporter V4.",
-  "version": "5.5.3",
+  "version": "5.5.76",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/scripts/build-framework-plugin.py
+++ b/scripts/build-framework-plugin.py
@@ -38,6 +38,20 @@ def get_napcat_latest_version():
         print(f"[!] Failed to get latest version: {e}")
         return "v4.8.119"
 
+def write_napcat_builtin_plugin_config(config_dir):
+    """Disable the builtin #napcat reply command by default."""
+    builtin_config_dir = os.path.join(config_dir, "plugins", "napcat-plugin-builtin")
+    os.makedirs(builtin_config_dir, exist_ok=True)
+
+    builtin_config = {
+        "prefix": "#napcat",
+        "enableReply": False,
+        "description": "这是一个内置插件的配置示例"
+    }
+
+    with open(os.path.join(builtin_config_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(builtin_config, f, indent=2, ensure_ascii=False)
+
 def download_file(url, dest):
     """Download file"""
     print(f"[->] Downloading: {url}")
@@ -162,6 +176,7 @@ def main():
     }
 
     plugins_config = {
+        "napcat-plugin-builtin": True,
         "qq-chat-exporter": True
     }
 
@@ -170,6 +185,8 @@ def main():
 
     with open(os.path.join(config_dir, "plugins.json"), "w", encoding="utf-8") as f:
         json.dump(plugins_config, f, indent=2, ensure_ascii=False)
+
+    write_napcat_builtin_plugin_config(config_dir)
     print("[x] Done")
     print()
     

--- a/scripts/quick-pack.py
+++ b/scripts/quick-pack.py
@@ -80,6 +80,20 @@ def extract_zip(zip_path, dest_dir):
         zip_ref.extractall(dest_dir)
     print(f"[x] Extracted to: {dest_dir}")
 
+def write_napcat_builtin_plugin_config(config_dir):
+    """Disable the builtin #napcat reply command by default."""
+    builtin_config_dir = os.path.join(config_dir, "plugins", "napcat-plugin-builtin")
+    os.makedirs(builtin_config_dir, exist_ok=True)
+
+    builtin_config = {
+        "prefix": "#napcat",
+        "enableReply": False,
+        "description": "这是一个内置插件的配置示例"
+    }
+
+    with open(os.path.join(builtin_config_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(builtin_config, f, indent=2, ensure_ascii=False)
+
 def copy_directory(src, dst):
     """Copy directory recursively"""
     if os.path.exists(dst):
@@ -626,7 +640,8 @@ pause
     
     # Update config files
     print("[9/11] Updating config files...")
-    os.makedirs(f"{pack_dir}/config", exist_ok=True)
+    config_dir = f"{pack_dir}/config"
+    os.makedirs(config_dir, exist_ok=True)
     
     napcat_config = {
         "fileLog": False,
@@ -639,6 +654,7 @@ pause
     }
 
     plugins_config = {
+        "napcat-plugin-builtin": True,
         "qq-chat-exporter": True
     }
     
@@ -660,14 +676,16 @@ pause
         "token": ""
     }
     
-    with open(f"{pack_dir}/config/napcat.json", "w") as f:
+    with open(f"{config_dir}/napcat.json", "w") as f:
         json.dump(napcat_config, f, indent=2)
 
-    with open(f"{pack_dir}/config/plugins.json", "w") as f:
+    with open(f"{config_dir}/plugins.json", "w") as f:
         json.dump(plugins_config, f, indent=2)
 
-    with open(f"{pack_dir}/config/onebot11.json", "w") as f:
+    with open(f"{config_dir}/onebot11.json", "w") as f:
         json.dump(onebot_config, f, indent=2)
+
+    write_napcat_builtin_plugin_config(config_dir)
     
     print("[x] Updated")
     print()


### PR DESCRIPTION
## Summary
- write NapCat builtin plugin config into release packages with enableReply disabled
- keep napcat-plugin-builtin explicitly enabled so the plugin remains available without replying to #napcat
- sync package versions to 5.5.10 for the next tag

Fixes #465.

## Verification
- python -m py_compile scripts/quick-pack.py scripts/build-framework-plugin.py
- Node content assertion for plugins.json and builtin config generation
- git diff --check