### PR TITLE
fix: package QCE with NapCat official plugin id

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,8 @@ RUN pnpm run build
 FROM mlikiowa/napcat-docker:latest
 
 # Copy plugin (source + production node_modules)
-COPY --from=build /build/plugins/qq-chat-exporter /app/napcat/plugins/qq-chat-exporter
+COPY --from=build /build/plugins/qq-chat-exporter /app/napcat/plugins/napcat-plugin-qce
+RUN node -e "const fs=require('fs'); const p='/app/napcat/plugins/napcat-plugin-qce/package.json'; const pkg=JSON.parse(fs.readFileSync(p,'utf8')); pkg.name='napcat-plugin-qce'; fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');"
 
 # Copy frontend static export
 COPY --from=build /build/qce-v4-tool/out /app/napcat/static/qce-v4-tool

--- a/docker/config/plugins.json
+++ b/docker/config/plugins.json
@@ -1,4 +1,4 @@
 {
   "napcat-plugin-builtin": true,
-  "qq-chat-exporter": true
+  "napcat-plugin-qce": true
 }

--- a/docker/docker-entrypoint-qce.sh
+++ b/docker/docker-entrypoint-qce.sh
@@ -9,12 +9,12 @@ if [ ! -f "$CONFIG_DIR/plugins.json" ]; then
     cat > "$CONFIG_DIR/plugins.json" << 'EOF'
 {
   "napcat-plugin-builtin": true,
-  "qq-chat-exporter": true
+  "napcat-plugin-qce": true
 }
 EOF
-elif ! grep -q '"qq-chat-exporter"' "$CONFIG_DIR/plugins.json"; then
-    # plugins.json 存在但缺少 qq-chat-exporter，用 sed 注入
-    sed -i 's/}/  ,"qq-chat-exporter": true\n}/' "$CONFIG_DIR/plugins.json"
+elif ! grep -q '"napcat-plugin-qce"' "$CONFIG_DIR/plugins.json"; then
+    # plugins.json 存在但缺少 napcat-plugin-qce，用 sed 注入
+    sed -i 's/}/  ,"napcat-plugin-qce": true\n}/' "$CONFIG_DIR/plugins.json"
 fi
 
 # napcat.json（仅不存在时创建）

--- a/docs/docker-napcat-deployment.md
+++ b/docs/docker-napcat-deployment.md
@@ -81,7 +81,7 @@ napcat/
 │   └── plugins.json          ← 必须创建
 ├── plugins/
 │   ├── napcat-plugin-builtin/ ← 从容器复制
-│   └── qq-chat-exporter/      ← QCE 插件
+│   └── napcat-plugin-qce/      ← QCE 插件
 └── qce-v4-tool/               ← 前端静态文件
 ```
 
@@ -105,7 +105,7 @@ docker cp napcat:/app/napcat/plugins/napcat-plugin-builtin plugins/napcat-plugin
 tar -xzf NapCat-QCE-*.tar.gz -C /tmp/qce-release
 
 # 复制插件
-cp -r /tmp/qce-release/plugins/qq-chat-exporter plugins/
+cp -r /tmp/qce-release/plugins/napcat-plugin-qce plugins/
 
 # 复制前端静态文件
 cp -r /tmp/qce-release/static/qce-v4-tool ./qce-v4-tool
@@ -117,16 +117,16 @@ cp -r /tmp/qce-release/static/qce-v4-tool ./qce-v4-tool
 
 ```bash
 # 方法一：使用辅助脚本（推荐）
-docker exec napcat bash /app/napcat/plugins/qq-chat-exporter/tools/docker-setup.sh
+docker exec napcat bash /app/napcat/plugins/napcat-plugin-qce/tools/docker-setup.sh
 
 # 方法二：手动安装
 # 1. 查看当前 esbuild 版本
-docker exec napcat node -e "console.log(require('/app/napcat/plugins/qq-chat-exporter/node_modules/esbuild/package.json').version)"
+docker exec napcat node -e "console.log(require('/app/napcat/plugins/napcat-plugin-qce/node_modules/esbuild/package.json').version)"
 # 2. 在宿主机下载对应版本的 ARM64 包
 npm pack @esbuild/linux-arm64@<版本号>
 # 3. 解压到插件目录
-mkdir -p plugins/qq-chat-exporter/node_modules/@esbuild/linux-arm64
-tar -xzf esbuild-linux-arm64-*.tgz -C plugins/qq-chat-exporter/node_modules/@esbuild/linux-arm64 --strip-components=1
+mkdir -p plugins/napcat-plugin-qce/node_modules/@esbuild/linux-arm64
+tar -xzf esbuild-linux-arm64-*.tgz -C plugins/napcat-plugin-qce/node_modules/@esbuild/linux-arm64 --strip-components=1
 ```
 
 ### 4. 启用插件
@@ -136,7 +136,7 @@ NapCat 默认仅启用内置插件，需创建 `config/plugins.json`：
 ```json
 {
   "napcat-plugin-builtin": true,
-  "qq-chat-exporter": true
+  "napcat-plugin-qce": true
 }
 ```
 
@@ -175,7 +175,7 @@ docker logs -f napcat 2>&1 | grep -i "plugin\|qce\|chat-exporter"
 预期日志：
 ```
 [Plugins] 加载插件: napcat-plugin-builtin
-[Plugins] 加载插件: qq-chat-exporter
+[Plugins] 加载插件: napcat-plugin-qce
 [QCE] Running mode: Shell (headless)
 [QCE] API server started on port 40653
 ```
@@ -217,7 +217,7 @@ server {
 架构不匹配，参见步骤 3。
 
 ### 插件未加载（日志中无 QCE 相关输出）
-检查 `config/plugins.json` 是否存在且 `"qq-chat-exporter": true`。
+检查 `config/plugins.json` 是否存在且 `"napcat-plugin-qce": true`。
 
 ### 前端 404
 检查 `qce-v4-tool/` 目录是否包含 `index.html` 和 `_next/` 目录，且已正确挂载到 `/app/napcat/static/qce-v4-tool`。

--- a/plugins/qq-chat-exporter/package.json
+++ b/plugins/qq-chat-exporter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qq-chat-exporter",
   "plugin": "QQ 聊天记录导出",
-  "version": "5.5.76",
+  "version": "5.5.77",
   "description": "导出 QQ 聊天记录为 HTML / JSON / TXT / Excel，支持时间筛选、批量任务、定时任务、表情图片语音视频资源处理、合并转发展开等。",
   "main": "index.mjs",
   "type": "module",

--- a/qce-v4-tool/package.json
+++ b/qce-v4-tool/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qq-chat-exporter-v4-ui",
   "description": "The web interface for QQ Chat Exporter V4.",
-  "version": "5.5.76",
+  "version": "5.5.77",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/scripts/build-framework-plugin.py
+++ b/scripts/build-framework-plugin.py
@@ -15,6 +15,9 @@ from pathlib import Path
 from urllib.request import urlretrieve, urlopen
 from datetime import datetime
 
+SOURCE_PLUGIN_DIR = "plugins/qq-chat-exporter"
+RUNTIME_PLUGIN_ID = "napcat-plugin-qce"
+
 def get_qce_version():
     """Get QCE version from environment or package.json"""
     if os.environ.get('QCE_VERSION'):
@@ -51,6 +54,16 @@ def write_napcat_builtin_plugin_config(config_dir):
 
     with open(os.path.join(builtin_config_dir, "config.json"), "w", encoding="utf-8") as f:
         json.dump(builtin_config, f, indent=2, ensure_ascii=False)
+
+def rewrite_runtime_plugin_package(plugin_dir):
+    """Rewrite release package metadata to the NapCat official plugin ID."""
+    package_json = os.path.join(plugin_dir, "package.json")
+    with open(package_json, "r", encoding="utf-8") as f:
+        package_data = json.load(f)
+    package_data["name"] = RUNTIME_PLUGIN_ID
+    with open(package_json, "w", encoding="utf-8") as f:
+        json.dump(package_data, f, indent=2, ensure_ascii=False)
+        f.write("\n")
 
 def download_file(url, dest):
     """Download file"""
@@ -122,8 +135,9 @@ def main():
     
     # Copy QCE plugin
     print("[5/8] Copying QCE plugin...")
-    qce_dest = os.path.join(plugins_dir, "qq-chat-exporter")
-    shutil.copytree("plugins/qq-chat-exporter", qce_dest)
+    qce_dest = os.path.join(plugins_dir, RUNTIME_PLUGIN_ID)
+    shutil.copytree(SOURCE_PLUGIN_DIR, qce_dest)
+    rewrite_runtime_plugin_package(qce_dest)
     print("[x] Done")
     print()
     
@@ -177,7 +191,7 @@ def main():
 
     plugins_config = {
         "napcat-plugin-builtin": True,
-        "qq-chat-exporter": True
+        RUNTIME_PLUGIN_ID: True
     }
 
     with open(os.path.join(config_dir, "napcat.json"), "w", encoding="utf-8") as f:

--- a/scripts/quick-pack.py
+++ b/scripts/quick-pack.py
@@ -27,6 +27,8 @@ def get_qce_version():
         return 'unknown'
 
 VERSION = get_qce_version()
+SOURCE_PLUGIN_DIR = "plugins/qq-chat-exporter"
+RUNTIME_PLUGIN_ID = "napcat-plugin-qce"
 
 def get_platform_info():
     """Detect current platform"""
@@ -99,6 +101,16 @@ def copy_directory(src, dst):
     if os.path.exists(dst):
         shutil.rmtree(dst)
     shutil.copytree(src, dst)
+
+def rewrite_runtime_plugin_package(plugin_dir):
+    """Rewrite release package metadata to the NapCat official plugin ID."""
+    package_json = os.path.join(plugin_dir, "package.json")
+    with open(package_json, "r", encoding="utf-8") as f:
+        package_data = json.load(f)
+    package_data["name"] = RUNTIME_PLUGIN_ID
+    with open(package_json, "w", encoding="utf-8") as f:
+        json.dump(package_data, f, indent=2, ensure_ascii=False)
+        f.write("\n")
 
 def create_archive(source_dir, output_file, format_type):
     """Create archive (zip or tar.gz)"""
@@ -603,13 +615,14 @@ pause
     
     # Copy plugin files
     print("[6/11] Copying plugin files...")
-    copy_directory("plugins/qq-chat-exporter", f"{pack_dir}/plugins/qq-chat-exporter")
+    plugin_dir = f"{pack_dir}/plugins/{RUNTIME_PLUGIN_ID}"
+    copy_directory(SOURCE_PLUGIN_DIR, plugin_dir)
+    rewrite_runtime_plugin_package(plugin_dir)
     print("[x] Copied")
     print()
     
     # Install plugin dependencies
     print("[7/11] Installing plugin dependencies...")
-    plugin_dir = f"{pack_dir}/plugins/qq-chat-exporter"
     npm_cmd = ["npm.cmd" if os_name == "Windows" else "npm", "install", "--omit=dev"]
     if not run_command(npm_cmd, cwd=plugin_dir):
         print("[!] Dependency install failed")
@@ -655,7 +668,7 @@ pause
 
     plugins_config = {
         "napcat-plugin-builtin": True,
-        "qq-chat-exporter": True
+        RUNTIME_PLUGIN_ID: True
     }
     
     onebot_config = {
@@ -823,7 +836,7 @@ async function main() {
 main();
 '''
     
-    with open(f"{pack_dir}/plugins/qq-chat-exporter/standalone.mjs", "w", encoding="utf-8", newline="\n") as f:
+    with open(f"{pack_dir}/plugins/{RUNTIME_PLUGIN_ID}/standalone.mjs", "w", encoding="utf-8", newline="\n") as f:
         f.write(standalone_mjs)
     
     # Create Windows batch launcher for standalone mode
@@ -869,10 +882,10 @@ exit /b 1
 :found_node
 echo [信息] 正在启动独立模式服务器...
 echo.
-"%NODE_EXE%" plugins/qq-chat-exporter/standalone.mjs %1
+"%NODE_EXE%" plugins/__RUNTIME_PLUGIN_ID__/standalone.mjs %1
 
 pause
-'''
+'''.replace("__RUNTIME_PLUGIN_ID__", RUNTIME_PLUGIN_ID)
         with open(f"{pack_dir}/start-standalone.bat", "w", encoding="utf-8") as f:
             f.write(standalone_bat)
     
@@ -902,8 +915,8 @@ fi
 
 echo "[信息] 正在启动独立模式服务器..."
 echo ""
-node plugins/qq-chat-exporter/standalone.mjs "$@"
-'''
+node plugins/__RUNTIME_PLUGIN_ID__/standalone.mjs "$@"
+'''.replace("__RUNTIME_PLUGIN_ID__", RUNTIME_PLUGIN_ID)
         standalone_sh_path = f"{pack_dir}/start-standalone.sh"
         with open(standalone_sh_path, "w", encoding="utf-8", newline="\n") as f:
             f.write(standalone_sh)


### PR DESCRIPTION
## Summary
- install Shell and Framework release packages under 
apcat-plugin-qce instead of qq-chat-exporter`n- rewrite packaged plugin package.json.name to 
apcat-plugin-qce so NapCat's official-plugin whitelist accepts it
- update Docker runtime plugin path/config and Docker deployment docs
- bump release version to 5.5.77

Fixes #489.

## Verification
- python -m py_compile scripts/quick-pack.py scripts/build-framework-plugin.py scripts/build-napcat-plugin.py
- Node runtime plugin ID assertions for Shell/Framework/Docker paths
- git diff --check
- node __tests__/scripts/run-tests.mjs __tests__/unit/napcatSensitiveKeywords.test.ts __tests__/unit/napcatLinuxLauncher.test.ts __tests__/unit/napcatLinuxLauncherLegacy.test.ts

Note: an accidental broad npm test invocation also ran integration snapshots and failed on existing snapshot differences; no snapshots were updated.