### PR TITLE
fix(installer): WebUI auth, shortcut relaunch, install permissions

### DIFF
--- a/installer/src-tauri/Cargo.lock
+++ b/installer/src-tauri/Cargo.lock
@@ -2886,6 +2886,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2",
  "sysinfo",
  "tauri",
  "tauri-build",

--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ chrono = { version = "0.4", features = ["clock"] }
 qrcode = "0.14"
 image = { version = "0.25", default-features = false, features = ["png"] }
 futures-util = "0.3"
+sha2 = "0.10"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52"

--- a/installer/src-tauri/src/install.rs
+++ b/installer/src-tauri/src/install.rs
@@ -46,11 +46,12 @@ pub struct ValidateResult {
 
 #[tauri::command]
 pub fn get_default_install_dir() -> String {
-    // Program Files on Windows; a sensible home fallback elsewhere.
+    // Per-user LocalAppData on Windows: writable without elevation, unlike
+    // Program Files which fails with access-denied for non-admin installs.
     #[cfg(windows)]
     {
-        if let Some(pf) = std::env::var_os("ProgramFiles") {
-            return Path::new(&pf)
+        if let Some(local) = std::env::var_os("LOCALAPPDATA") {
+            return Path::new(&local)
                 .join("QQChatExporter")
                 .to_string_lossy()
                 .into_owned();
@@ -98,7 +99,62 @@ pub fn validate_install_dir(dir: String) -> ValidateResult {
             return ValidateResult { ok: false, error: Some("上级目录不存在".into()) };
         }
     }
+    if let Err(e) = check_writable(&path) {
+        return ValidateResult {
+            ok: false,
+            error: Some(format!("该目录无写入权限，请更换安装位置：{e}")),
+        };
+    }
     ValidateResult { ok: true, error: None }
+}
+
+/// Verify the target directory can actually be created and written to.
+fn check_writable(dir: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    let probe = dir.join(".qce-write-test");
+    std::fs::write(&probe, b"ok")?;
+    std::fs::remove_file(&probe)?;
+    Ok(())
+}
+
+/// Location of the small json that remembers where QCE was installed, so a
+/// relaunch (desktop shortcut / autostart) goes straight to the launch flow.
+fn state_file() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("qce-installer").join("state.json"))
+}
+
+fn save_install_state(install_dir: &Path) {
+    if let Some(file) = state_file() {
+        if let Some(parent) = file.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let json = serde_json::json!({ "installDir": install_dir.to_string_lossy() });
+        let _ = std::fs::write(file, serde_json::to_vec_pretty(&json).unwrap_or_default());
+    }
+}
+
+/// Returns the previously installed directory (and rehydrates state) when a
+/// valid installation is found, so the UI can skip the install screens.
+#[tauri::command]
+pub fn get_install_state(state: State<'_, AppState>) -> Option<String> {
+    let file = state_file()?;
+    let raw = std::fs::read(file).ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&raw).ok()?;
+    let dir = PathBuf::from(json.get("installDir")?.as_str()?);
+    if !dir.exists() || util::find_launcher(&dir).is_none() {
+        return None;
+    }
+    // Recover the WebUI token from the config written at install time.
+    let token = std::fs::read(dir.join("config").join("webui.json"))
+        .ok()
+        .and_then(|b| serde_json::from_slice::<serde_json::Value>(&b).ok())
+        .and_then(|v| v.get("token").and_then(|t| t.as_str()).map(str::to_string));
+    let mut inner = state.0.lock().ok()?;
+    inner.install_dir = Some(dir.clone());
+    if inner.webui_token.is_none() {
+        inner.webui_token = token;
+    }
+    Some(dir.to_string_lossy().into_owned())
 }
 
 #[tauri::command]
@@ -108,7 +164,8 @@ pub async fn start_install(
     options: InstallOptions,
 ) -> Result<(), String> {
     let install_dir = PathBuf::from(&options.install_path);
-    std::fs::create_dir_all(&install_dir).map_err(|e| format!("创建安装目录失败：{e}"))?;
+    check_writable(&install_dir)
+        .map_err(|e| format!("无法写入安装目录（{e}），请更换安装位置后重试"))?;
 
     // The release build appends the full Shell package to the end of this exe,
     // so a normal run is a single self-contained file with no network download.
@@ -149,14 +206,18 @@ pub async fn start_install(
     emit(&app, "install-progress", 92.0, "正在写入配置...", "Configuring");
     write_runtime_config(&install_dir, &state).map_err(|e| e.to_string())?;
 
+    // Copy this exe into the install dir so shortcuts / autostart survive the
+    // user deleting the original download. On relaunch it detects the saved
+    // install state and goes straight to the launch flow instead of installing.
+    let launcher_exe = install_launcher_exe(&install_dir);
+
     if options.create_shortcut {
-        let _ = create_desktop_shortcut(&install_dir);
+        let _ = create_desktop_shortcut(&install_dir, &launcher_exe);
     }
-    if options.auto_start {
-        let _ = set_auto_start(&install_dir, true);
-    }
+    let _ = set_auto_start(&launcher_exe, options.auto_start);
 
     // Remember where we installed for later launch commands.
+    save_install_state(&install_dir);
     {
         let mut inner = state.0.lock().map_err(|_| "state poisoned".to_string())?;
         inner.install_dir = Some(install_dir.clone());
@@ -354,12 +415,28 @@ fn write_runtime_config(install_dir: &Path, state: &State<'_, AppState>) -> anyh
     Ok(())
 }
 
+/// Copy the running exe into the install dir and return the path shortcuts
+/// should target. Falls back to the current exe if the copy fails.
+fn install_launcher_exe(install_dir: &Path) -> PathBuf {
+    let current = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(_) => return install_dir.join("QQ Chat Exporter.exe"),
+    };
+    let dest = install_dir.join("QQ Chat Exporter.exe");
+    if current == dest {
+        return dest;
+    }
+    match std::fs::copy(&current, &dest) {
+        Ok(_) => dest,
+        Err(_) => current,
+    }
+}
+
 #[cfg(windows)]
-fn create_desktop_shortcut(install_dir: &Path) -> anyhow::Result<()> {
+fn create_desktop_shortcut(install_dir: &Path, target: &Path) -> anyhow::Result<()> {
     // Create a .lnk via a throwaway PowerShell one-liner (WScript.Shell).
     let desktop = dirs::desktop_dir().ok_or_else(|| anyhow::anyhow!("无法定位桌面目录"))?;
     let lnk = desktop.join("QQ Chat Exporter.lnk");
-    let target = std::env::current_exe()?;
     let ps = format!(
         "$s=(New-Object -ComObject WScript.Shell).CreateShortcut('{}');$s.TargetPath='{}';$s.WorkingDirectory='{}';$s.Save()",
         lnk.display(),
@@ -373,20 +450,18 @@ fn create_desktop_shortcut(install_dir: &Path) -> anyhow::Result<()> {
 }
 
 #[cfg(not(windows))]
-fn create_desktop_shortcut(_install_dir: &Path) -> anyhow::Result<()> {
+fn create_desktop_shortcut(_install_dir: &Path, _target: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
 #[cfg(windows)]
-fn set_auto_start(install_dir: &Path, enable: bool) -> anyhow::Result<()> {
+fn set_auto_start(target: &Path, enable: bool) -> anyhow::Result<()> {
     use winreg::enums::HKEY_CURRENT_USER;
     use winreg::RegKey;
     let hkcu = RegKey::predef(HKEY_CURRENT_USER);
     let (run, _) = hkcu.create_subkey(r"Software\Microsoft\Windows\CurrentVersion\Run")?;
     if enable {
-        let exe = std::env::current_exe()?;
-        let _ = install_dir;
-        run.set_value("QQChatExporter", &exe.to_string_lossy().to_string())?;
+        run.set_value("QQChatExporter", &target.to_string_lossy().to_string())?;
     } else {
         let _ = run.delete_value("QQChatExporter");
     }
@@ -394,6 +469,6 @@ fn set_auto_start(install_dir: &Path, enable: bool) -> anyhow::Result<()> {
 }
 
 #[cfg(not(windows))]
-fn set_auto_start(_install_dir: &Path, _enable: bool) -> anyhow::Result<()> {
+fn set_auto_start(_target: &Path, _enable: bool) -> anyhow::Result<()> {
     Ok(())
 }

--- a/installer/src-tauri/src/lib.rs
+++ b/installer/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ pub fn run() {
             install::get_default_install_dir,
             install::get_free_space,
             install::validate_install_dir,
+            install::get_install_state,
             install::start_install,
             service::detect_package_kind,
             service::start_service,

--- a/installer/src-tauri/src/napcat.rs
+++ b/installer/src-tauri/src/napcat.rs
@@ -47,6 +47,20 @@ fn store_credential(state: &State<'_, AppState>, cred: &str) {
     }
 }
 
+/// NapCat's WebUI expects `sha256(token + ".napcat")` as the login hash
+/// (see AuthHelper.generatePasswordHash in napcat-webui-backend).
+fn password_hash(token: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(token.as_bytes());
+    hasher.update(b".napcat");
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
 /// Authenticate and return a bearer credential, caching it in state.
 async fn ensure_login(state: &State<'_, AppState>) -> Result<String, String> {
     if let Some(c) = cached_credential(state) {
@@ -55,7 +69,7 @@ async fn ensure_login(state: &State<'_, AppState>) -> Result<String, String> {
     let tok = token(state)?;
     let resp = client()
         .post(format!("{}/api/auth/login", base()))
-        .json(&serde_json::json!({ "token": tok, "hash": tok }))
+        .json(&serde_json::json!({ "hash": password_hash(&tok) }))
         .send()
         .await
         .map_err(|e| format!("连接 NapCat WebUI 失败：{e}"))?;
@@ -64,9 +78,14 @@ async fn ensure_login(state: &State<'_, AppState>) -> Result<String, String> {
         .pointer("/data/Credential")
         .or_else(|| body.pointer("/data/credential"))
         .and_then(Value::as_str)
-        .or_else(|| body.get("data").and_then(Value::as_str))
-        .ok_or_else(|| "WebUI 登录失败：未返回凭证".to_string())?
-        .to_string();
+        .map(str::to_string)
+        .ok_or_else(|| {
+            let msg = body
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("未返回凭证");
+            format!("WebUI 登录失败：{msg}")
+        })?;
     store_credential(state, &cred);
     Ok(cred)
 }
@@ -165,7 +184,7 @@ pub async fn napcat_quick_login_list(
 /// Used to decide whether the Shell package must kill QQ first.
 #[tauri::command]
 pub async fn napcat_is_online(state: State<'_, AppState>, uin: String) -> Result<bool, String> {
-    let body = get_json(&state, "/api/QQLogin/CheckLoginStatus").await?;
+    let body = post_json(&state, "/api/QQLogin/CheckLoginStatus", serde_json::json!({})).await?;
     let data = body.get("data").unwrap_or(&body);
     let is_login = data
         .get("isLogin")
@@ -206,7 +225,15 @@ pub async fn napcat_quick_login(
 /// Fetch the current QR-login URL from NapCat and render it to a PNG data URL.
 #[tauri::command]
 pub async fn napcat_qrcode(state: State<'_, AppState>) -> Result<String, String> {
-    let body = get_json(&state, "/api/QQLogin/CheckLoginStatus").await?;
+    // GetQQLoginQrcode returns { data: { qrcode } }; fall back to the URL
+    // included in CheckLoginStatus if the dedicated endpoint has no code yet.
+    if let Ok(body) = post_json(&state, "/api/QQLogin/GetQQLoginQrcode", serde_json::json!({})).await {
+        let data = body.get("data").unwrap_or(&body);
+        if let Some(qr) = str_field(data, &["qrcode", "qrcodeurl", "qrcodeUrl", "url"]) {
+            return render_qr_png(qr);
+        }
+    }
+    let body = post_json(&state, "/api/QQLogin/CheckLoginStatus", serde_json::json!({})).await?;
     let data = body.get("data").unwrap_or(&body);
     let qr = str_field(data, &["qrcodeurl", "qrcodeUrl", "qrcode", "url"])
         .ok_or_else(|| "NapCat 尚未生成登录二维码".to_string())?;
@@ -216,7 +243,7 @@ pub async fn napcat_qrcode(state: State<'_, AppState>) -> Result<String, String>
 /// Poll whether login has completed (QR scanned or quick login done).
 #[tauri::command]
 pub async fn napcat_login_status(state: State<'_, AppState>) -> Result<bool, String> {
-    let body = get_json(&state, "/api/QQLogin/CheckLoginStatus").await?;
+    let body = post_json(&state, "/api/QQLogin/CheckLoginStatus", serde_json::json!({})).await?;
     let data = body.get("data").unwrap_or(&body);
     Ok(data
         .get("isLogin")

--- a/installer/src/App.tsx
+++ b/installer/src/App.tsx
@@ -169,7 +169,7 @@ export default function App() {
   const [webuiUrl, setWebuiUrl] = useState<string>('');
   const [setupHint, setSetupHint] = useState('请稍候，我们正在为您初始化导出组件...');
 
-  const [options, setOptions] = useState({ shortcut: true, autoStart: true });
+  const [options, setOptions] = useState({ shortcut: true, autoStart: false });
 
   const tipsTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const qrPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -187,16 +187,29 @@ export default function App() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  // Init default install path
+  // Detect an existing installation (launched from the desktop shortcut or
+  // autostart) and skip straight to the setup flow; otherwise prepare the
+  // default install path for a fresh install.
   useEffect(() => {
     (async () => {
+      try {
+        const installed = await api.getInstallState();
+        if (installed) {
+          setInstallPath(installed);
+          setStep('setup');
+          setSetupStep('login');
+          return;
+        }
+      } catch {
+        /* fall through to fresh-install flow */
+      }
       try {
         const path = await api.getDefaultInstallDir();
         setInstallPath(path);
         const space = await api.getFreeSpace(path);
         setFreeSpace(space);
       } catch {
-        setInstallPath('C:\\Program Files\\QQChatExporter');
+        setInstallPath('C:\\QQChatExporter');
       }
     })();
   }, []);

--- a/installer/src/tauri.ts
+++ b/installer/src/tauri.ts
@@ -56,6 +56,9 @@ const api = {
     { dir }
   ),
 
+  /** Install dir of an existing installation, or null on first run. */
+  getInstallState: () => invoke<string | null>('get_install_state'),
+
   // --- installation -----------------------------------------------------
   startInstall: (options: InstallOptions) => invoke<void>('start_install', { options }),
 


### PR DESCRIPTION
Fixes four issues reported against the v6.0.0-beta.3 installer:

- **WebUI login failed ("未返回凭证")**: the login request sent the raw token, but NapCat's WebUI expects `sha256(token + ".napcat")` as the `hash` field. Also switched `CheckLoginStatus` / `GetQQLoginQrcode` to POST — the WebUI routes are POST-only, so quick-login detection, QR codes and login polling all failed.
- **Desktop shortcut reopened the install wizard**: the installer now writes a small state file and copies itself into the install dir. The shortcut and autostart entry target the installed copy, and on relaunch the app detects the existing installation and goes straight to the login/launch flow.
- **Install failed with os error 5 (access denied)**: default install dir moved from `Program Files` to `%LOCALAPPDATA%\QQChatExporter`, and the chosen directory is probed for writability before installing, with a clear error asking to pick another location.
- **Autostart enabled by default**: now off unless the user opts in.
