### PR TITLE
fix(installer): stale runtime cleanup, tray icon, stable WebUI token

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -346,7 +346,7 @@ jobs:
 
           [使用文档](https://shuakami.github.io/qq-chat-exporter/) | [问题反馈](https://github.com/shuakami/qq-chat-exporter/issues) | [NapCat 项目](https://github.com/NapNeko/NapCatQQ)
 
-          ### 贡献者鸣谢
+          ### Contributors
 
           <a href="https://github.com/shuakami/qq-chat-exporter/graphs/contributors">
             <img src="https://contrib.rocks/image?repo=shuakami/qq-chat-exporter&max=12&columns=12" width="125" />

--- a/installer/src-tauri/src/install.rs
+++ b/installer/src-tauri/src/install.rs
@@ -391,7 +391,15 @@ fn write_runtime_config(install_dir: &Path, state: &State<'_, AppState>) -> anyh
     let config_dir = install_dir.join("config");
     std::fs::create_dir_all(&config_dir)?;
 
-    let token = util::random_token(16);
+    // Reuse the token of an existing installation: NapCat caches the token at
+    // startup, so an instance left running from a previous session would
+    // reject a freshly generated one.
+    let token = std::fs::read(config_dir.join("webui.json"))
+        .ok()
+        .and_then(|b| serde_json::from_slice::<serde_json::Value>(&b).ok())
+        .and_then(|v| v.get("token").and_then(|t| t.as_str()).map(str::to_string))
+        .filter(|t| !t.is_empty())
+        .unwrap_or_else(|| util::random_token(16));
     let webui = serde_json::json!({
         "host": "127.0.0.1",
         "port": util::NAPCAT_WEBUI_PORT,

--- a/installer/src-tauri/src/lib.rs
+++ b/installer/src-tauri/src/lib.rs
@@ -6,6 +6,19 @@ mod state;
 mod util;
 
 use state::AppState;
+use tauri::{
+    menu::{Menu, MenuItem},
+    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
+    Manager, WindowEvent,
+};
+
+fn show_main_window(app: &tauri::AppHandle) {
+    if let Some(w) = app.get_webview_window("main") {
+        let _ = w.show();
+        let _ = w.unminimize();
+        let _ = w.set_focus();
+    }
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -13,6 +26,46 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .manage(AppState::default())
+        .setup(|app| {
+            let open = MenuItem::with_id(app, "open", "打开面板", true, None::<&str>)?;
+            let quit = MenuItem::with_id(app, "quit", "退出", true, None::<&str>)?;
+            let menu = Menu::with_items(app, &[&open, &quit])?;
+            let mut tray = TrayIconBuilder::with_id("main")
+                .menu(&menu)
+                .show_menu_on_left_click(false)
+                .tooltip("QQ Chat Exporter")
+                .on_menu_event(|app, event| match event.id.as_ref() {
+                    "open" => show_main_window(app),
+                    "quit" => {
+                        service::shutdown(&app.state::<AppState>());
+                        app.exit(0);
+                    }
+                    _ => {}
+                })
+                .on_tray_icon_event(|tray, event| {
+                    if let TrayIconEvent::Click {
+                        button: MouseButton::Left,
+                        button_state: MouseButtonState::Up,
+                        ..
+                    } = event
+                    {
+                        show_main_window(tray.app_handle());
+                    }
+                });
+            if let Some(icon) = app.default_window_icon() {
+                tray = tray.icon(icon.clone());
+            }
+            tray.build(app)?;
+            Ok(())
+        })
+        .on_window_event(|window, event| {
+            // Closing the window hides to the tray; the runtime keeps serving.
+            // Quitting is done from the tray menu.
+            if let WindowEvent::CloseRequested { api, .. } = event {
+                api.prevent_close();
+                let _ = window.hide();
+            }
+        })
         .invoke_handler(tauri::generate_handler![
             install::get_default_install_dir,
             install::get_free_space,
@@ -22,6 +75,7 @@ pub fn run() {
             service::detect_package_kind,
             service::start_service,
             service::stop_service,
+            service::exit_app,
             napcat::napcat_quick_login_list,
             napcat::napcat_is_online,
             napcat::napcat_quick_login,
@@ -32,6 +86,11 @@ pub fn run() {
             qce::get_webui_url,
             qce::open_log_file,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app, event| {
+            if let tauri::RunEvent::Exit = event {
+                service::shutdown(&app.state::<AppState>());
+            }
+        });
 }

--- a/installer/src-tauri/src/napcat.rs
+++ b/installer/src-tauri/src/napcat.rs
@@ -61,21 +61,24 @@ fn password_hash(token: &str) -> String {
         .collect()
 }
 
-/// Authenticate and return a bearer credential, caching it in state.
-async fn ensure_login(state: &State<'_, AppState>) -> Result<String, String> {
-    if let Some(c) = cached_credential(state) {
-        return Ok(c);
-    }
-    let tok = token(state)?;
+/// Token as currently stored on disk (`config/webui.json`) — the source of
+/// truth for whatever NapCat instance is actually serving port 6099.
+fn token_from_config(state: &State<'_, AppState>) -> Option<String> {
+    let dir = state.0.lock().ok()?.install_dir()?;
+    let raw = std::fs::read(dir.join("config").join("webui.json")).ok()?;
+    let json: Value = serde_json::from_slice(&raw).ok()?;
+    json.get("token").and_then(Value::as_str).map(str::to_string)
+}
+
+async fn try_login(tok: &str) -> Result<String, String> {
     let resp = client()
         .post(format!("{}/api/auth/login", base()))
-        .json(&serde_json::json!({ "hash": password_hash(&tok) }))
+        .json(&serde_json::json!({ "hash": password_hash(tok) }))
         .send()
         .await
         .map_err(|e| format!("连接 NapCat WebUI 失败：{e}"))?;
     let body: Value = resp.json().await.map_err(|e| e.to_string())?;
-    let cred = body
-        .pointer("/data/Credential")
+    body.pointer("/data/Credential")
         .or_else(|| body.pointer("/data/credential"))
         .and_then(Value::as_str)
         .map(str::to_string)
@@ -85,7 +88,32 @@ async fn ensure_login(state: &State<'_, AppState>) -> Result<String, String> {
                 .and_then(Value::as_str)
                 .unwrap_or("未返回凭证");
             format!("WebUI 登录失败：{msg}")
-        })?;
+        })
+}
+
+/// Authenticate and return a bearer credential, caching it in state.
+async fn ensure_login(state: &State<'_, AppState>) -> Result<String, String> {
+    if let Some(c) = cached_credential(state) {
+        return Ok(c);
+    }
+    let tok = token(state)?;
+    let cred = match try_login(&tok).await {
+        Ok(c) => c,
+        Err(e) => {
+            // The in-memory token may be out of sync with the running NapCat
+            // instance; retry once with the token from config/webui.json.
+            match token_from_config(state) {
+                Some(disk_tok) if disk_tok != tok => {
+                    let c = try_login(&disk_tok).await.map_err(|_| e)?;
+                    if let Ok(mut s) = state.0.lock() {
+                        s.webui_token = Some(disk_tok);
+                    }
+                    c
+                }
+                _ => return Err(e),
+            }
+        }
+    };
     store_credential(state, &cred);
     Ok(cred)
 }

--- a/installer/src-tauri/src/service.rs
+++ b/installer/src-tauri/src/service.rs
@@ -23,6 +23,18 @@ pub fn detect_package_kind(state: State<'_, AppState>) -> Result<String, String>
     }
 }
 
+/// Kill leftover headless runtimes (NapCatWinBootMain and its QQ children).
+/// A stale instance keeps port 6099 with an outdated token and rejects every
+/// login, and repeated launches would otherwise pile up duplicate processes.
+pub fn kill_stale_runtime() {
+    #[cfg(windows)]
+    {
+        let _ = util::hidden_command("taskkill")
+            .args(["/IM", "NapCatWinBootMain.exe", "/F", "/T"])
+            .status();
+    }
+}
+
 #[tauri::command]
 pub fn start_service(state: State<'_, AppState>) -> Result<(), String> {
     let dir = {
@@ -33,6 +45,9 @@ pub fn start_service(state: State<'_, AppState>) -> Result<(), String> {
         }
         inner.install_dir().ok_or_else(|| "尚未安装".to_string())?
     };
+
+    // Clear any stale/duplicate runtime before spawning a fresh one.
+    kill_stale_runtime();
 
     let launcher = util::find_launcher(&dir)
         .ok_or_else(|| "未找到启动脚本（launcher-user.bat）".to_string())?;
@@ -91,22 +106,29 @@ fn build_launch_command(launcher: &std::path::Path, dir: &std::path::Path) -> st
 
 #[tauri::command]
 pub fn stop_service(state: State<'_, AppState>) -> Result<(), String> {
-    let mut inner = state.0.lock().map_err(|_| "state poisoned".to_string())?;
-    if let Some(mut child) = inner.service.take() {
-        let _ = child.kill();
-        let _ = child.wait();
-    }
-    drop(inner);
-    // Best-effort: also stop the headless QQ/NapCat the launcher spawned.
-    #[cfg(windows)]
-    {
-        for image in ["NapCatWinBootMain.exe", "QQ.exe"] {
-            let _ = util::hidden_command("taskkill")
-                .args(["/IM", image, "/F", "/T"])
-                .status();
+    shutdown(&state);
+    Ok(())
+}
+
+/// Explicit quit from the UI: stop everything and terminate the app
+/// (a plain window close only hides to the tray).
+#[tauri::command]
+pub fn exit_app(app: tauri::AppHandle, state: State<'_, AppState>) {
+    shutdown(&state);
+    app.exit(0);
+}
+
+/// Stop the launcher child and every headless runtime it spawned.
+/// Also called when the user exits from the tray.
+pub fn shutdown(state: &AppState) {
+    if let Ok(mut inner) = state.0.lock() {
+        if let Some(mut child) = inner.service.take() {
+            let _ = child.kill();
+            let _ = child.wait();
         }
     }
-    Ok(())
+    // Best-effort: also stop the headless QQ/NapCat the launcher spawned.
+    kill_stale_runtime();
 }
 
 /// Best-effort discovery of the desktop QQ executable via the registry.

--- a/installer/src/App.tsx
+++ b/installer/src/App.tsx
@@ -425,11 +425,10 @@ export default function App() {
 
   const handleExit = useCallback(async () => {
     try {
-      await api.stopService();
+      await api.exitApp();
     } catch {
-      /* ignore */
+      await api.closeWindow();
     }
-    await api.closeWindow();
   }, []);
 
   const getAnimationClass = () => (step === 'welcome' ? '' : 'animate-fade-in');

--- a/installer/src/tauri.ts
+++ b/installer/src/tauri.ts
@@ -86,7 +86,10 @@ const api = {
   openLogFile: () => invoke<void>('open_log_file'),
   openUrl: (url: string) => openUrl(url),
   pickDirectory: () => openDialog({ directory: true, multiple: false }),
+  /** Hide to the system tray (the runtime keeps serving). */
   closeWindow: () => getCurrentWindow().close(),
+  /** Stop everything and terminate the app. */
+  exitApp: () => invoke<void>('exit_app'),
 
   onInstallProgress: (cb: (p: InstallProgress) => void): Promise<UnlistenFn> =>
     listen<InstallProgress>('install-progress', (e) => cb(e.payload)),


### PR DESCRIPTION
Fixes the "token is invalid" WebUI login failure and duplicate background processes reported in v6.0.0-beta.4.

Root cause: stale `NapCatWinBootMain.exe` instances from earlier runs kept serving port 6099 with the token they were started with. A reinstall generated a fresh token, so every login attempt against the old instance failed, and each new launch added another duplicate process.

Changes:
- Kill leftover `NapCatWinBootMain.exe` (and the headless QQ it spawned) before starting the service and on shutdown, so only one runtime exists at a time.
- Reuse the token already present in `config/webui.json` on reinstall instead of generating a new one; if login is rejected, retry once with the on-disk token.
- Add a system tray icon. Closing the window now hides to the tray while the runtime keeps running; the tray menu provides open/quit. Quit (tray or the in-app exit confirmation) stops the service and cleans up all spawned processes.
- Release notes template: rename the contributors heading to "Contributors".
