### PR TITLE
fix(installer): port auto-detect, single instance, tray notification, version upgrade

### DIFF
--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -17,6 +17,8 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
+tauri-plugin-single-instance = "2"
+tauri-plugin-notification = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/installer/src-tauri/capabilities/default.json
+++ b/installer/src-tauri/capabilities/default.json
@@ -9,6 +9,10 @@
     "core:window:allow-start-dragging",
     "dialog:allow-open",
     "opener:allow-open-url",
-    "opener:default"
+    "opener:default",
+    "notification:default",
+    "notification:allow-notify",
+    "notification:allow-request-permission",
+    "notification:allow-is-permission-granted"
   ]
 }

--- a/installer/src-tauri/src/install.rs
+++ b/installer/src-tauri/src/install.rs
@@ -123,18 +123,27 @@ fn state_file() -> Option<PathBuf> {
     dirs::config_dir().map(|d| d.join("qce-installer").join("state.json"))
 }
 
+fn current_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
 fn save_install_state(install_dir: &Path) {
     if let Some(file) = state_file() {
         if let Some(parent) = file.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
-        let json = serde_json::json!({ "installDir": install_dir.to_string_lossy() });
+        let json = serde_json::json!({
+            "installDir": install_dir.to_string_lossy(),
+            "version": current_version(),
+        });
         let _ = std::fs::write(file, serde_json::to_vec_pretty(&json).unwrap_or_default());
     }
 }
 
 /// Returns the previously installed directory (and rehydrates state) when a
-/// valid installation is found, so the UI can skip the install screens.
+/// valid installation is found **and** the version matches. If the running
+/// exe is a newer version than what was installed, returns None so the UI
+/// triggers a fresh install (overlay) to update the files.
 #[tauri::command]
 pub fn get_install_state(state: State<'_, AppState>) -> Option<String> {
     let file = state_file()?;
@@ -142,6 +151,15 @@ pub fn get_install_state(state: State<'_, AppState>) -> Option<String> {
     let json: serde_json::Value = serde_json::from_slice(&raw).ok()?;
     let dir = PathBuf::from(json.get("installDir")?.as_str()?);
     if !dir.exists() || util::find_launcher(&dir).is_none() {
+        return None;
+    }
+    // Version mismatch → need re-install to update extracted files.
+    let saved_ver = json.get("version").and_then(|v| v.as_str()).unwrap_or("");
+    if saved_ver != current_version() {
+        // Rehydrate the install dir so the UI can pre-fill the path.
+        if let Ok(mut inner) = state.0.lock() {
+            inner.install_dir = Some(dir.clone());
+        }
         return None;
     }
     // Recover the WebUI token from the config written at install time.
@@ -155,6 +173,20 @@ pub fn get_install_state(state: State<'_, AppState>) -> Option<String> {
         inner.webui_token = token;
     }
     Some(dir.to_string_lossy().into_owned())
+}
+
+/// Return the previously-used install path (even when the version no longer
+/// matches) so the UI can pre-fill the directory on an upgrade.
+#[tauri::command]
+pub fn get_saved_install_dir(state: State<'_, AppState>) -> Option<String> {
+    // First try state (set by get_install_state on version mismatch).
+    if let Some(dir) = state.0.lock().ok().and_then(|s| s.install_dir()) {
+        return Some(dir.to_string_lossy().into_owned());
+    }
+    let file = state_file()?;
+    let raw = std::fs::read(file).ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&raw).ok()?;
+    json.get("installDir").and_then(|v| v.as_str()).map(str::to_string)
 }
 
 #[tauri::command]

--- a/installer/src-tauri/src/lib.rs
+++ b/installer/src-tauri/src/lib.rs
@@ -25,6 +25,11 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            // A second instance tried to launch — focus the existing window.
+            show_main_window(app);
+        }))
         .manage(AppState::default())
         .setup(|app| {
             let open = MenuItem::with_id(app, "open", "打开面板", true, None::<&str>)?;
@@ -60,10 +65,17 @@ pub fn run() {
         })
         .on_window_event(|window, event| {
             // Closing the window hides to the tray; the runtime keeps serving.
-            // Quitting is done from the tray menu.
             if let WindowEvent::CloseRequested { api, .. } = event {
                 api.prevent_close();
                 let _ = window.hide();
+                // Notify the user the app is still running in the background.
+                use tauri_plugin_notification::NotificationExt;
+                let _ = window.app_handle()
+                    .notification()
+                    .builder()
+                    .title("QQ Chat Exporter")
+                    .body("已最小化到系统托盘，服务继续运行中")
+                    .show();
             }
         })
         .invoke_handler(tauri::generate_handler![
@@ -71,6 +83,7 @@ pub fn run() {
             install::get_free_space,
             install::validate_install_dir,
             install::get_install_state,
+            install::get_saved_install_dir,
             install::start_install,
             service::detect_package_kind,
             service::start_service,

--- a/installer/src-tauri/src/napcat.rs
+++ b/installer/src-tauri/src/napcat.rs
@@ -4,8 +4,8 @@
 //! NapCat is up we authenticate against its loopback WebUI REST API and drive
 //! the quick-login / QR flow without the user ever seeing a console.
 //!
-//! Endpoint shapes follow NapCat's current WebUI API. Responses are parsed
-//! defensively (tolerant of field-name variants across NapCat versions).
+//! NapCat may auto-increment the port when the configured one is already in
+//! use, so the first API call probes ports 6099-6120 to find the live instance.
 
 use base64::Engine;
 use serde::Serialize;
@@ -15,12 +15,13 @@ use tauri::State;
 use crate::state::AppState;
 use crate::util::NAPCAT_WEBUI_PORT;
 
-fn base() -> String {
-    format!("http://127.0.0.1:{NAPCAT_WEBUI_PORT}")
+fn base_url(port: u16) -> String {
+    format!("http://127.0.0.1:{port}")
 }
 
 fn client() -> reqwest::Client {
     reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
         .user_agent("qce-installer")
         .build()
         .expect("reqwest client")
@@ -37,13 +38,17 @@ fn token(state: &State<'_, AppState>) -> Result<String, String> {
         .ok_or_else(|| "尚未初始化 WebUI 令牌（请先完成安装）".to_string())
 }
 
-fn cached_credential(state: &State<'_, AppState>) -> Option<String> {
-    state.0.lock().ok().and_then(|s| s.credential.clone())
+fn cached_credential(state: &State<'_, AppState>) -> Option<(String, u16)> {
+    let inner = state.0.lock().ok()?;
+    let cred = inner.credential.clone()?;
+    let port = inner.webui_port?;
+    Some((cred, port))
 }
 
-fn store_credential(state: &State<'_, AppState>, cred: &str) {
+fn store_credential(state: &State<'_, AppState>, cred: &str, port: u16) {
     if let Ok(mut s) = state.0.lock() {
         s.credential = Some(cred.to_string());
+        s.webui_port = Some(port);
     }
 }
 
@@ -61,8 +66,7 @@ fn password_hash(token: &str) -> String {
         .collect()
 }
 
-/// Token as currently stored on disk (`config/webui.json`) — the source of
-/// truth for whatever NapCat instance is actually serving port 6099.
+/// Token as currently stored on disk (`config/webui.json`).
 fn token_from_config(state: &State<'_, AppState>) -> Option<String> {
     let dir = state.0.lock().ok()?.install_dir()?;
     let raw = std::fs::read(dir.join("config").join("webui.json")).ok()?;
@@ -70,9 +74,9 @@ fn token_from_config(state: &State<'_, AppState>) -> Option<String> {
     json.get("token").and_then(Value::as_str).map(str::to_string)
 }
 
-async fn try_login(tok: &str) -> Result<String, String> {
+async fn try_login_on(port: u16, tok: &str) -> Result<String, String> {
     let resp = client()
-        .post(format!("{}/api/auth/login", base()))
+        .post(format!("{}/api/auth/login", base_url(port)))
         .json(&serde_json::json!({ "hash": password_hash(tok) }))
         .send()
         .await
@@ -91,37 +95,54 @@ async fn try_login(tok: &str) -> Result<String, String> {
         })
 }
 
-/// Authenticate and return a bearer credential, caching it in state.
-async fn ensure_login(state: &State<'_, AppState>) -> Result<String, String> {
-    if let Some(c) = cached_credential(state) {
-        return Ok(c);
+/// Probe ports starting from NAPCAT_WEBUI_PORT to find the live NapCat
+/// instance, authenticate, and cache the credential + actual port.
+async fn ensure_login(state: &State<'_, AppState>) -> Result<(String, u16), String> {
+    if let Some((c, p)) = cached_credential(state) {
+        return Ok((c, p));
     }
+
     let tok = token(state)?;
-    let cred = match try_login(&tok).await {
-        Ok(c) => c,
-        Err(e) => {
-            // The in-memory token may be out of sync with the running NapCat
-            // instance; retry once with the token from config/webui.json.
-            match token_from_config(state) {
-                Some(disk_tok) if disk_tok != tok => {
-                    let c = try_login(&disk_tok).await.map_err(|_| e)?;
-                    if let Ok(mut s) = state.0.lock() {
-                        s.webui_token = Some(disk_tok);
+    let disk_tok = token_from_config(state);
+
+    let tokens: Vec<&str> = if let Some(ref dt) = disk_tok {
+        if *dt != tok { vec![&tok, dt] } else { vec![&tok] }
+    } else {
+        vec![&tok]
+    };
+
+    // Probe the configured port first, then a range above it.
+    let mut last_err = String::from("NapCat WebUI 未响应");
+    for port in NAPCAT_WEBUI_PORT..NAPCAT_WEBUI_PORT + 20 {
+        for t in &tokens {
+            match try_login_on(port, t).await {
+                Ok(cred) => {
+                    // Sync in-memory token if disk token won.
+                    if *t != tok {
+                        if let Ok(mut s) = state.0.lock() {
+                            s.webui_token = Some(t.to_string());
+                        }
                     }
-                    c
+                    store_credential(state, &cred, port);
+                    return Ok((cred, port));
                 }
-                _ => return Err(e),
+                Err(e) => {
+                    // Connection refused → port not serving, skip remaining tokens.
+                    if e.contains("connect") || e.contains("Connect") {
+                        break;
+                    }
+                    last_err = e;
+                }
             }
         }
-    };
-    store_credential(state, &cred);
-    Ok(cred)
+    }
+    Err(last_err)
 }
 
 async fn get_json(state: &State<'_, AppState>, path: &str) -> Result<Value, String> {
-    let cred = ensure_login(state).await?;
+    let (cred, port) = ensure_login(state).await?;
     let resp = client()
-        .get(format!("{}{}", base(), path))
+        .get(format!("{}{}", base_url(port), path))
         .bearer_auth(&cred)
         .send()
         .await
@@ -130,9 +151,9 @@ async fn get_json(state: &State<'_, AppState>, path: &str) -> Result<Value, Stri
 }
 
 async fn post_json(state: &State<'_, AppState>, path: &str, body: Value) -> Result<Value, String> {
-    let cred = ensure_login(state).await?;
+    let (cred, port) = ensure_login(state).await?;
     let resp = client()
-        .post(format!("{}{}", base(), path))
+        .post(format!("{}{}", base_url(port), path))
         .bearer_auth(&cred)
         .json(&body)
         .send()

--- a/installer/src-tauri/src/state.rs
+++ b/installer/src-tauri/src/state.rs
@@ -16,6 +16,9 @@ pub struct Inner {
     pub credential: Option<String>,
     /// Handle to the launched NapCat process (so we can stop it on exit).
     pub service: Option<Child>,
+    /// Actual port NapCat WebUI ended up listening on (may differ from the
+    /// configured default when the preferred port was already in use).
+    pub webui_port: Option<u16>,
 }
 
 impl Inner {

--- a/installer/src/App.tsx
+++ b/installer/src/App.tsx
@@ -204,7 +204,9 @@ export default function App() {
         /* fall through to fresh-install flow */
       }
       try {
-        const path = await api.getDefaultInstallDir();
+        // Prefer the previously-used dir (upgrade scenario) over the default.
+        const saved = await api.getSavedInstallDir();
+        const path = saved || await api.getDefaultInstallDir();
         setInstallPath(path);
         const space = await api.getFreeSpace(path);
         setFreeSpace(space);

--- a/installer/src/tauri.ts
+++ b/installer/src/tauri.ts
@@ -56,8 +56,10 @@ const api = {
     { dir }
   ),
 
-  /** Install dir of an existing installation, or null on first run. */
+  /** Install dir of an existing installation, or null on first run / version mismatch. */
   getInstallState: () => invoke<string | null>('get_install_state'),
+  /** Previously-used install dir (even on version mismatch), for pre-filling. */
+  getSavedInstallDir: () => invoke<string | null>('get_saved_install_dir'),
 
   // --- installation -----------------------------------------------------
   startInstall: (options: InstallOptions) => invoke<void>('start_install', { options }),


### PR DESCRIPTION
Fixes the stuck quick-login ("处理中..." forever) and several UX issues reported in v6.0.0-beta.5.

Root cause of login failure: NapCat auto-increments the WebUI port when the configured one (6099) is already in use, but the installer was hardcoded to 6099. All login API calls went to the wrong port.

Changes:
- **Port auto-detection**: probe ports 6099-6120 with both in-memory and on-disk tokens; cache the discovered port for subsequent API calls.
- **Single instance**: `tauri-plugin-single-instance` — launching a second exe focuses the existing window instead of spawning duplicates.
- **Tray notification**: system notification when closing to tray so the user knows the service is still running.
- **Version-aware upgrade**: store installer version in install state; version mismatch triggers a re-install (overlay extract) instead of silently reusing old files. Previous install dir is pre-filled.
