### PR TITLE
fix(installer): kill stale processes before extraction

### DIFF
--- a/installer/src-tauri/src/install.rs
+++ b/installer/src-tauri/src/install.rs
@@ -196,6 +196,12 @@ pub async fn start_install(
     options: InstallOptions,
 ) -> Result<(), String> {
     let install_dir = PathBuf::from(&options.install_path);
+
+    // Kill any running NapCat / headless QQ first — they hold file locks on
+    // the install directory that would make extraction fail with "另一个程序
+    // 正在使用此文件".
+    crate::service::kill_stale_runtime();
+
     check_writable(&install_dir)
         .map_err(|e| format!("无法写入安装目录（{e}），请更换安装位置后重试"))?;
 

--- a/installer/src-tauri/src/service.rs
+++ b/installer/src-tauri/src/service.rs
@@ -29,9 +29,15 @@ pub fn detect_package_kind(state: State<'_, AppState>) -> Result<String, String>
 pub fn kill_stale_runtime() {
     #[cfg(windows)]
     {
-        let _ = util::hidden_command("taskkill")
-            .args(["/IM", "NapCatWinBootMain.exe", "/F", "/T"])
-            .status();
+        // Kill the launcher and its entire process tree (QQ, node, etc.).
+        for image in ["NapCatWinBootMain.exe", "QQ.exe"] {
+            let _ = util::hidden_command("taskkill")
+                .args(["/IM", image, "/F", "/T"])
+                .status();
+        }
+        // Brief pause so Windows releases file handles before we try to
+        // overwrite the files during extraction.
+        std::thread::sleep(std::time::Duration::from_millis(800));
     }
 }
 


### PR DESCRIPTION
Extraction fails with "另一个程序正在使用此文件" when upgrading because the old NapCat/QQ processes are still running and hold file locks on the install directory.

Call `kill_stale_runtime()` at the start of `start_install` before attempting extraction. Also kill `QQ.exe` explicitly (not just `NapCatWinBootMain.exe`) and add a brief 800ms sleep so Windows releases the file handles.