### PR TITLE
fix(installer): process cleanup before extract, handle 'already logged in', retry login list

### DIFF
--- a/installer/src-tauri/src/install.rs
+++ b/installer/src-tauri/src/install.rs
@@ -196,6 +196,12 @@ pub async fn start_install(
     options: InstallOptions,
 ) -> Result<(), String> {
     let install_dir = PathBuf::from(&options.install_path);
+
+    // Kill any running NapCat / headless QQ first — they hold file locks on
+    // the install directory that would make extraction fail with "另一个程序
+    // 正在使用此文件".
+    crate::service::kill_stale_runtime();
+
     check_writable(&install_dir)
         .map_err(|e| format!("无法写入安装目录（{e}），请更换安装位置后重试"))?;
 

--- a/installer/src-tauri/src/service.rs
+++ b/installer/src-tauri/src/service.rs
@@ -29,9 +29,15 @@ pub fn detect_package_kind(state: State<'_, AppState>) -> Result<String, String>
 pub fn kill_stale_runtime() {
     #[cfg(windows)]
     {
-        let _ = util::hidden_command("taskkill")
-            .args(["/IM", "NapCatWinBootMain.exe", "/F", "/T"])
-            .status();
+        // Kill the launcher and its entire process tree (QQ, node, etc.).
+        for image in ["NapCatWinBootMain.exe", "QQ.exe"] {
+            let _ = util::hidden_command("taskkill")
+                .args(["/IM", image, "/F", "/T"])
+                .status();
+        }
+        // Brief pause so Windows releases file handles before we try to
+        // overwrite the files during extraction.
+        std::thread::sleep(std::time::Duration::from_millis(800));
     }
 }
 

--- a/installer/src/App.tsx
+++ b/installer/src/App.tsx
@@ -291,7 +291,18 @@ export default function App() {
       try {
         setPackageKind(await api.detectPackageKind());
         await api.startService();
-        const list = await api.getQuickLoginList();
+        // NapCat needs a few seconds to boot its WebUI; retry up to 15 times
+        // with a 2-second gap so we don't give up before it's ready.
+        let list: Awaited<ReturnType<typeof api.getQuickLoginList>> = [];
+        for (let attempt = 0; attempt < 15; attempt++) {
+          if (cancelled) return;
+          try {
+            list = await api.getQuickLoginList();
+            break;
+          } catch {
+            if (attempt < 14) await new Promise((r) => setTimeout(r, 2000));
+          }
+        }
         if (cancelled) return;
         setAccounts(list);
         if (list.length > 0) {
@@ -356,12 +367,25 @@ export default function App() {
       }
       const res = await api.quickLogin(selectedAccount.uin);
       if (!res.ok) {
-        setLoginError(res.error || '快速登录失败');
+        const err = res.error || '快速登录失败';
+        // NapCat returns this when the account is already logged in via
+        // desktop QQ — route to the kill-QQ confirmation instead of just
+        // showing an error string.
+        if (err.includes('已登录')) {
+          setSetupStep('warning');
+          return;
+        }
+        setLoginError(err);
         return;
       }
       startConfiguring();
     } catch (err) {
-      setLoginError(String(err));
+      const msg = String(err);
+      if (msg.includes('已登录')) {
+        setSetupStep('warning');
+        return;
+      }
+      setLoginError(msg);
     } finally {
       setBusy(false);
     }
@@ -373,6 +397,8 @@ export default function App() {
     setLoginError('');
     try {
       await api.killQq();
+      // Give NapCat a moment to detect the process exit before retrying.
+      await new Promise((r) => setTimeout(r, 2000));
       const res = await api.quickLogin(selectedAccount.uin);
       if (!res.ok) {
         setLoginError(res.error || '快速登录失败');


### PR DESCRIPTION
Fixes three issues from v6.0.0-beta.6 testing:

1. **Extraction fails on upgrade** ("另一个程序正在使用此文件"): stale NapCat/QQ processes hold file locks. Now `kill_stale_runtime()` runs at the start of `start_install`, killing both `NapCatWinBootMain.exe` and `QQ.exe` with an 800ms settle delay.

2. **Quick login shows raw "已登录" error**: when the selected account is already online, NapCat returns "当前账号已登录,无法重复登录". The UI now detects this and routes to the kill-QQ confirmation screen.

3. **Login list empty on first load**: NapCat needs several seconds to boot its WebUI after `start_service`. The UI now retries `getQuickLoginList` up to 15 times (2s apart) instead of giving up immediately.

Also adds a 2s delay after killing QQ before retrying quick login, so NapCat can detect the process exit.