### PR TITLE
feat(ui): 会话页与模态框统一为参考设计（垃圾桶图标 / 药丸下拉 / 问号 tooltip / 分段换行 / 退出动画）

### DIFF
--- a/plugins/qq-chat-exporter/package.json
+++ b/plugins/qq-chat-exporter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qq-chat-exporter",
   "plugin": "QQ 聊天记录导出",
-  "version": "5.5.78",
+  "version": "5.5.79",
   "description": "导出 QQ 聊天记录为 HTML / JSON / TXT / Excel，支持时间筛选、批量任务、定时任务、表情图片语音视频资源处理、合并转发展开等。",
   "main": "index.mjs",
   "type": "module",

--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -582,7 +582,7 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
 
   const handleCloseHistoryModal = () => {
     setIsHistoryModalOpen(false)
-    setSelectedHistoryTask(null)
+    setTimeout(() => setSelectedHistoryTask(null), 300)
   }
 
   const handleOpenFilePathModal = (filePath: string, sessionName: string, fileName: string, size?: number) => {
@@ -1931,7 +1931,7 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
                             }}
                             title="删除"
                           >
-                            <X className="w-4 h-4" />
+                            <Trash2 className="w-4 h-4" />
                           </Button>
                         )}
                       </div>
@@ -2237,7 +2237,7 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
                                     })
                                   }}
                                 >
-                                  <X className="w-3.5 h-3.5" />
+                                  <Trash2 className="w-3.5 h-3.5" />
                                 </button>
                               </div>
                             );

--- a/qce-v4-tool/components/ui/batch-export-dialog.tsx
+++ b/qce-v4-tool/components/ui/batch-export-dialog.tsx
@@ -9,7 +9,8 @@ import { Badge } from "@/components/ui/badge"
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import { DateRangePicker } from "@/components/ui/date-range-picker"
-import { CheckCircle2, XCircle, Users, User, FolderOpen } from "lucide-react"
+import { CheckCircle2, XCircle, Users, User, FolderOpen, HelpCircle } from "lucide-react"
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip"
 import { Loader } from "@/components/ui/loader"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { toggleSkipResourceType, type SkipDownloadResourceType } from "@/lib/skip-resource-types"
@@ -322,7 +323,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
               {/* 导出格式 */}
               <section>
                 <h2 className={SECTION_TITLE}>导出格式</h2>
-                <div className="inline-flex items-center gap-1 p-1 rounded-full bg-black/[0.04] dark:bg-white/[0.06] w-fit">
+                <div className="inline-flex items-center flex-wrap gap-1 p-1 rounded-[20px] bg-black/[0.04] dark:bg-white/[0.06] w-fit max-w-full">
                   {(["HTML", "JSON", "TXT", "EXCEL"] as const).map((fmt) => {
                     const active = format === fmt
                     return (
@@ -347,9 +348,19 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
 
               {/* 时间范围 */}
               <section>
-                <h2 className={SECTION_TITLE}>时间范围</h2>
+                <h2 className={SECTION_TITLE + " flex items-center gap-1.5"}>
+                  时间范围
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <HelpCircle className="w-[14px] h-[14px] text-muted-foreground/60 hover:text-muted-foreground transition-colors outline-none cursor-pointer" />
+                    </TooltipTrigger>
+                    <TooltipContent side="top" className="max-w-[250px]">
+                      选择全部消息则导出全部记录
+                    </TooltipContent>
+                  </Tooltip>
+                </h2>
                 <div className="space-y-4">
-                  <div className="inline-flex items-center gap-1 p-1 rounded-full bg-black/[0.04] dark:bg-white/[0.06] w-fit">
+                  <div className="inline-flex items-center flex-wrap gap-1 p-1 rounded-[20px] bg-black/[0.04] dark:bg-white/[0.06] w-fit max-w-full">
                     {[
                       { value: 'all', label: '全部消息' },
                       { value: 'recent', label: '最近 3 个月' },
@@ -451,7 +462,19 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
                       className={["flex items-center justify-between gap-6 group p-3.5 rounded-2xl transition-colors", opt.highlight ? "bg-orange-50/60 dark:bg-orange-950/25 hover:bg-orange-50 dark:hover:bg-orange-950/40" : "bg-black/[0.03] dark:bg-white/[0.04] hover:bg-black/[0.05] dark:hover:bg-white/[0.06]", isExporting ? "opacity-50" : ""].join(" ")}
                     >
                       <div className="flex flex-col gap-0.5 flex-1 pr-4">
-                        <div className={`text-[13px] font-medium ${opt.highlight ? 'text-orange-700 dark:text-orange-400' : 'text-foreground'}`}>{opt.title}</div>
+                        <div className="flex items-center gap-1.5">
+                          <div className={`text-[13px] font-medium ${opt.highlight ? 'text-orange-700 dark:text-orange-400' : 'text-foreground'}`}>{opt.title}</div>
+                          {opt.desc && (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <HelpCircle className="w-[14px] h-[14px] text-muted-foreground/60 hover:text-muted-foreground transition-colors outline-none cursor-pointer" />
+                              </TooltipTrigger>
+                              <TooltipContent side="top" sideOffset={6} className="max-w-[250px]">
+                                {opt.desc}
+                              </TooltipContent>
+                            </Tooltip>
+                          )}
+                        </div>
                         <div className={`text-[12px] leading-snug mt-0.5 ${opt.highlight ? 'text-orange-600/90 dark:text-orange-500/90' : 'text-muted-foreground'}`}>{opt.desc}</div>
                       </div>
                       <div className="flex-shrink-0">

--- a/qce-v4-tool/components/ui/dialog.tsx
+++ b/qce-v4-tool/components/ui/dialog.tsx
@@ -62,6 +62,8 @@ export const DialogContent = React.forwardRef<
             ],
         "data-[state=open]:animate-in data-[state=closed]:animate-out",
         "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
+        "data-[state=open]:zoom-in-[0.97] data-[state=closed]:zoom-out-[0.97]",
+        "data-[state=open]:duration-300 data-[state=closed]:duration-200 ease-[cubic-bezier(0.32,0.72,0,1)]",
         "outline-none",
         className
       )}

--- a/qce-v4-tool/components/ui/group-essence-modal.tsx
+++ b/qce-v4-tool/components/ui/group-essence-modal.tsx
@@ -10,13 +10,10 @@ import {
 } from "lucide-react"
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { PillDropdown } from "@/components/ui/pill-dropdown"
 import { Loader } from "@/components/ui/loader"
 import { useGroupEssence } from "@/hooks/use-group-essence"
 import type { EssenceMessage } from "@/types/api"
-
-const PILL_INPUT =
-  "h-[36px] px-3.5 rounded-full border-0 bg-black/[0.04] dark:bg-white/[0.06] text-[13px] outline-none placeholder:text-muted-foreground/70 focus:bg-black/[0.06] dark:focus:bg-white/[0.09] transition-colors"
 
 interface GroupEssenceModalProps {
   isOpen: boolean
@@ -140,15 +137,15 @@ export function GroupEssenceModal({
         <div className="h-[72px] flex items-center justify-between px-10 flex-shrink-0">
           <div className="flex items-center gap-3">
             <span className="text-[13px] text-muted-foreground">共 {messages.length} 条</span>
-            <Select value={exportFormat} onValueChange={(v) => setExportFormat(v as 'json' | 'html')}>
-              <SelectTrigger className={PILL_INPUT + " w-[110px]"}>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="html">HTML</SelectItem>
-                <SelectItem value="json">JSON</SelectItem>
-              </SelectContent>
-            </Select>
+            <PillDropdown
+              value={exportFormat}
+              onChange={(v) => setExportFormat(v)}
+              align="start"
+              options={[
+                { value: 'html', label: 'HTML' },
+                { value: 'json', label: 'JSON' },
+              ]}
+            />
           </div>
           <div className="flex items-center gap-3">
             <Button variant="outline" onClick={onClose} className="rounded-full text-[13px] h-8">关闭</Button>

--- a/qce-v4-tool/components/ui/pill-dropdown.tsx
+++ b/qce-v4-tool/components/ui/pill-dropdown.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { ChevronDown, Check } from "lucide-react"
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "./dropdown-menu"
+
+export function PillDropdown<T extends string>({
+  value,
+  onChange,
+  options,
+  disabled,
+  align = "end",
+}: {
+  value: T
+  onChange: (v: T) => void
+  options: { value: T; label: string }[]
+  disabled?: boolean
+  align?: "start" | "center" | "end"
+}) {
+  const current = options.find((o) => o.value === value)
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          className="inline-flex items-center gap-1.5 h-8 pl-3 pr-2.5 text-[13px] font-medium rounded-full bg-white dark:bg-neutral-900 border border-black/[0.03] dark:border-white/10 shadow-[0_1px_2px_rgba(0,0,0,0.02)] text-neutral-700 dark:text-neutral-200 outline-none cursor-pointer hover:border-black/[0.08] hover:bg-neutral-50 dark:hover:bg-white/5 transition-all disabled:opacity-50 disabled:pointer-events-none"
+        >
+          <span className="whitespace-nowrap">{current?.label}</span>
+          <ChevronDown className="w-3.5 h-3.5 text-neutral-400" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align={align} className="min-w-[140px]">
+        {options.map((o) => (
+          <DropdownMenuItem
+            key={o.value}
+            onClick={() => onChange(o.value)}
+            className="flex items-center justify-between"
+          >
+            <span>{o.label}</span>
+            {o.value === value && <Check className="w-3.5 h-3.5" />}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/qce-v4-tool/components/ui/session-list.tsx
+++ b/qce-v4-tool/components/ui/session-list.tsx
@@ -1,18 +1,11 @@
 "use client"
 
 import { useCallback, useEffect, useRef } from "react"
+import { motion, AnimatePresence } from "framer-motion"
 import { Button } from "./button"
 import { Input } from "./input"
 import { Avatar, AvatarFallback, AvatarImage } from "./avatar"
-import { Checkbox } from "./checkbox"
 
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "./select"
 import {
   Search,
   ChevronLeft,
@@ -31,6 +24,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from "./dropdown-menu"
+import { PillDropdown } from "./pill-dropdown"
 import type { Group, Friend } from "@/types/api"
 import {
   useSessionFilter,
@@ -236,8 +230,12 @@ export function SessionList({
 
   const hasActiveFilters = search || type !== 'all'
 
-  const renderSessionItem = useCallback((item: SessionItem) => {
+  const renderSessionItem = useCallback((item: SessionItem, index: number, items: SessionItem[]) => {
     const isSelected = selectedItems.has(`${item.type}_${item.id}`)
+    const isPreviousSelected =
+      index > 0 && selectedItems.has(`${items[index - 1].type}_${items[index - 1].id}`)
+    const isNextSelected =
+      index < items.length - 1 && selectedItems.has(`${items[index + 1].type}_${items[index + 1].id}`)
     const isGroup = item.type === 'group'
     const group = isGroup ? (item.raw as Group) : null
     const friend = !isGroup ? (item.raw as Friend) : null
@@ -246,26 +244,55 @@ export function SessionList({
       <div
         key={`${item.type}_${item.id}`}
         className={[
-          "group flex items-center gap-3 px-3 py-3 rounded-xl transition-colors text-sm",
+          "group flex items-center gap-3 px-3 py-3 transition-colors text-sm",
           batchMode
             ? isSelected
               ? "bg-black/[0.045] dark:bg-white/[0.075] cursor-pointer"
               : "hover:bg-black/[0.03] dark:hover:bg-white/[0.03] cursor-pointer"
-            : "hover:bg-black/[0.03] dark:hover:bg-white/[0.03]"
+            : "hover:bg-black/[0.03] dark:hover:bg-white/[0.03]",
+          isSelected && batchMode
+            ? `${isPreviousSelected ? "rounded-t-none" : "rounded-t-xl"} ${isNextSelected ? "rounded-b-none" : "rounded-b-xl"}`
+            : "rounded-xl",
         ].join(" ")}
         onClick={(e: React.MouseEvent) => batchMode && handleRowClick(e, item)}
       >
-        {batchMode && (
-          <Checkbox
-            checked={isSelected}
-            onCheckedChange={() => onToggleItem?.(item.type, item.id)}
-            onClick={(e: React.MouseEvent) => {
-              // 阻止冒泡到 row，避免双触发；shift+click 仍由 row 的 onClick 处理。
-              e.stopPropagation()
-            }}
-          />
-        )}
-        
+        <AnimatePresence initial={false}>
+          {batchMode && (
+            <motion.div
+              initial={{ width: 0, opacity: 0, marginRight: 0 }}
+              animate={{ width: 14, opacity: 1, marginRight: 0 }}
+              exit={{ width: 0, opacity: 0, marginRight: 0 }}
+              transition={{ type: "tween", duration: 0.2, ease: "easeOut" }}
+              className="flex-shrink-0 overflow-hidden"
+            >
+              <div
+                className={[
+                  "flex items-center justify-center w-[14px] h-[14px] rounded-[3.5px] transition-colors cursor-pointer border",
+                  isSelected
+                    ? "bg-[#317CFF] border-[#317CFF]"
+                    : "bg-white dark:bg-neutral-900 border-neutral-300 dark:border-neutral-600 hover:border-[#317CFF]",
+                ].join(" ")}
+              >
+                <AnimatePresence>
+                  {isSelected && (
+                    <motion.svg
+                      initial={{ scale: 0.5, opacity: 0 }}
+                      animate={{ scale: 1, opacity: 1 }}
+                      exit={{ scale: 0.5, opacity: 0 }}
+                      transition={{ type: "tween", duration: 0.15, ease: "easeOut" }}
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      className="w-2.5 h-2.5 text-white"
+                    >
+                      <path d="M4.5 12.75l6 6 9-13.5" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+                    </motion.svg>
+                  )}
+                </AnimatePresence>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
         <Avatar className="w-10 h-10 rounded-full overflow-hidden flex-shrink-0">
           <AvatarImage src={item.avatarUrl} alt={item.name} />
           <AvatarFallback className="rounded-full text-xs">
@@ -414,31 +441,29 @@ export function SessionList({
         {/* Filter Controls */}
         <div className="flex items-center gap-2">
           {/* Type Filter */}
-          <Select value={type} onValueChange={(v: string) => setType(v as SessionType)}>
-            <SelectTrigger size="sm" className="h-8 text-[13px] font-medium rounded-full bg-white dark:bg-neutral-900 border border-black/[0.03] dark:border-white/10 shadow-[0_1px_2px_rgba(0,0,0,0.02)] hover:border-black/[0.08] hover:bg-neutral-50 dark:hover:bg-white/5 px-3 transition-all">
-              <SelectValue placeholder="全部类型" />
-            </SelectTrigger>
-            <SelectContent className="rounded-xl border-black/[0.06] dark:border-white/[0.08] shadow-xl">
-              <SelectItem value="all">全部 ({groupCount + friendCount})</SelectItem>
-              <SelectItem value="group">群组 ({groupCount})</SelectItem>
-              <SelectItem value="friend">好友 ({friendCount})</SelectItem>
-            </SelectContent>
-          </Select>
+          <PillDropdown
+            value={type}
+            onChange={(v) => setType(v as SessionType)}
+            options={[
+              { value: "all", label: `全部 (${groupCount + friendCount})` },
+              { value: "group", label: `群组 (${groupCount})` },
+              { value: "friend", label: `好友 (${friendCount})` },
+            ]}
+          />
 
           {/* Sort Field */}
-          <Select value={sortField} onValueChange={(v: string) => setSortField(v as SortField)}>
-            <SelectTrigger size="sm" className="h-8 text-[13px] font-medium rounded-full bg-white dark:bg-neutral-900 border border-black/[0.03] dark:border-white/10 shadow-[0_1px_2px_rgba(0,0,0,0.02)] hover:border-black/[0.08] hover:bg-neutral-50 dark:hover:bg-white/5 px-3 transition-all">
-              <SelectValue placeholder="排序" />
-            </SelectTrigger>
-            <SelectContent className="rounded-xl border-black/[0.06] dark:border-white/[0.08] shadow-xl">
-              <SelectItem value="name">名称</SelectItem>
-              <SelectItem value="memberCount">人数</SelectItem>
-              <SelectItem value="id">ID</SelectItem>
-              {/* Issue #344: 按最近一条消息时间 / 已导出消息数排序。 */}
-              <SelectItem value="lastActivity">最近活跃</SelectItem>
-              <SelectItem value="exportedCount">已导出条数</SelectItem>
-            </SelectContent>
-          </Select>
+          <PillDropdown
+            value={sortField}
+            onChange={(v) => setSortField(v as SortField)}
+            options={[
+              { value: "name", label: "名称" },
+              { value: "memberCount", label: "人数" },
+              { value: "id", label: "ID" },
+              // Issue #344: 按最近一条消息时间 / 已导出消息数排序。
+              { value: "lastActivity", label: "最近活跃" },
+              { value: "exportedCount", label: "已导出条数" },
+            ]}
+          />
 
           {/* Sort Order Toggle */}
           <button
@@ -510,75 +535,86 @@ export function SessionList({
       )}
 
       {/* Floating Batch Toolbar */}
-      {batchMode && (
-        <div
-          className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 animate-in fade-in duration-300"
-          style={{ animationTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)' }}
-        >
-          <div className="flex items-center gap-1 rounded-full bg-white/80 dark:bg-neutral-900/80 backdrop-blur-xl shadow-[0_4px_24px_rgba(0,0,0,0.06)] border border-black/[0.06] dark:border-white/[0.08] px-2 py-1.5">
-            {selectedItems.size > 0 && (
+      <AnimatePresence>
+        {batchMode && (
+          <motion.div
+            initial={{ opacity: 0, scale: 0.94 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.94 }}
+            transition={{ type: "spring", stiffness: 400, damping: 35, mass: 0.8 }}
+            className="fixed bottom-8 left-1/2 -translate-x-1/2 z-50"
+          >
+            <div className="flex items-center gap-1 rounded-full bg-white/80 dark:bg-neutral-900/80 backdrop-blur-xl shadow-[0_8px_32px_rgba(0,0,0,0.08)] border border-black/[0.06] dark:border-white/[0.08] px-2 py-1.5">
               <span className="text-[13px] font-medium text-foreground px-3 tabular-nums">
-                {selectedItems.size} selected
+                已选择 {selectedItems.size} 项
               </span>
-            )}
-            <span className="w-px h-4 bg-black/[0.08] dark:bg-white/[0.1]" />
-            {type === 'all' && (
-              <>
+              {selectedItems.size > 0 && (
                 <button
-                  onClick={() => {
-                    const ids = new Set<string>()
-                    filteredItems.forEach((item) => {
-                      if (item.type === 'group') ids.add(`group_${item.id}`)
-                    })
-                    onSelectMany ? onSelectMany(ids, 'add') : onSelectAll?.(ids)
-                  }}
-                  className="px-3 py-1.5 text-[13px] text-muted-foreground hover:text-foreground rounded-full hover:bg-black/[0.04] dark:hover:bg-white/[0.06] transition-colors"
+                  onClick={onClearSelection}
+                  className="px-2 py-0.5 text-[12px] text-muted-foreground/60 hover:text-muted-foreground rounded-full hover:bg-black/[0.04] dark:hover:bg-white/[0.06] transition-colors mr-1"
                 >
-                  全选群
+                  清空
                 </button>
-                <button
-                  onClick={() => {
-                    const ids = new Set<string>()
-                    filteredItems.forEach((item) => {
-                      if (item.type === 'friend') ids.add(`friend_${item.id}`)
-                    })
-                    onSelectMany ? onSelectMany(ids, 'add') : onSelectAll?.(ids)
-                  }}
-                  className="px-3 py-1.5 text-[13px] text-muted-foreground hover:text-foreground rounded-full hover:bg-black/[0.04] dark:hover:bg-white/[0.06] transition-colors"
-                >
-                  全选好友
-                </button>
-              </>
-            )}
-            <button
-              onClick={() => {
-                const ids = new Set<string>()
-                filteredItems.forEach(item => {
-                  ids.add(item.type === 'group' ? `group_${item.id}` : `friend_${item.id}`)
-                })
-                onSelectAll?.(ids)
-              }}
-              className="px-3 py-1.5 text-[13px] text-muted-foreground hover:text-foreground rounded-full hover:bg-black/[0.04] dark:hover:bg-white/[0.06] transition-colors"
-            >
-              全选当前
-            </button>
-            <span className="w-px h-4 bg-black/[0.08] dark:bg-white/[0.1]" />
-            <button
-              onClick={onOpenBatchExportDialog}
-              disabled={selectedItems.size === 0}
-              className="px-3 py-1.5 text-[13px] font-medium text-foreground rounded-full hover:bg-black/[0.04] dark:hover:bg-white/[0.06] transition-colors disabled:opacity-40 disabled:pointer-events-none"
-            >
-              导出
-            </button>
-            <button
-              onClick={onToggleBatchMode}
-              className="p-1.5 text-muted-foreground hover:text-foreground rounded-full hover:bg-black/[0.04] dark:hover:bg-white/[0.06] transition-colors"
-            >
-              <X className="w-3.5 h-3.5" />
-            </button>
-          </div>
-        </div>
-      )}
+              )}
+              <span className="w-px h-4 bg-black/[0.08] dark:bg-white/[0.1]" />
+              {type === 'all' && (
+                <>
+                  <button
+                    onClick={() => {
+                      const ids = new Set<string>()
+                      filteredItems.forEach((item) => {
+                        if (item.type === 'group') ids.add(`group_${item.id}`)
+                      })
+                      onSelectMany ? onSelectMany(ids, 'add') : onSelectAll?.(ids)
+                    }}
+                    className="px-3 py-1.5 text-[13px] text-muted-foreground hover:text-foreground rounded-full hover:bg-black/[0.04] dark:hover:bg-white/[0.06] transition-colors"
+                  >
+                    全选群
+                  </button>
+                  <button
+                    onClick={() => {
+                      const ids = new Set<string>()
+                      filteredItems.forEach((item) => {
+                        if (item.type === 'friend') ids.add(`friend_${item.id}`)
+                      })
+                      onSelectMany ? onSelectMany(ids, 'add') : onSelectAll?.(ids)
+                    }}
+                    className="px-3 py-1.5 text-[13px] text-muted-foreground hover:text-foreground rounded-full hover:bg-black/[0.04] dark:hover:bg-white/[0.06] transition-colors"
+                  >
+                    全选好友
+                  </button>
+                </>
+              )}
+              <button
+                onClick={() => {
+                  const ids = new Set<string>()
+                  filteredItems.forEach(item => {
+                    ids.add(item.type === 'group' ? `group_${item.id}` : `friend_${item.id}`)
+                  })
+                  onSelectAll?.(ids)
+                }}
+                className="px-3 py-1.5 text-[13px] text-muted-foreground hover:text-foreground rounded-full hover:bg-black/[0.04] dark:hover:bg-white/[0.06] transition-colors"
+              >
+                全选当前
+              </button>
+              <span className="w-px h-4 bg-black/[0.08] dark:bg-white/[0.1]" />
+              <button
+                onClick={onOpenBatchExportDialog}
+                disabled={selectedItems.size === 0}
+                className="px-4 py-1.5 text-[13px] font-medium text-white bg-[#317CFF] rounded-full hover:bg-[#2867d6] transition-colors disabled:opacity-40 disabled:pointer-events-none"
+              >
+                导出
+              </button>
+              <button
+                onClick={onToggleBatchMode}
+                className="p-1.5 text-muted-foreground hover:text-foreground rounded-full hover:bg-black/[0.04] dark:hover:bg-white/[0.06] transition-colors ml-1"
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
 
 
@@ -587,18 +623,14 @@ export function SessionList({
         <div className="flex items-center justify-between pt-3">
           <div className="flex items-center gap-1.5">
             <span className="text-sm text-muted-foreground/60">每页</span>
-            <Select value={pageSize.toString()} onValueChange={(v: string) => setPageSize(Number(v))}>
-              <SelectTrigger className="w-[72px] h-8 text-sm rounded-full border-0 bg-transparent shadow-none">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {PAGE_SIZE_OPTIONS.map((size) => (
-                  <SelectItem key={size} value={size.toString()}>
-                    {size}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <PillDropdown
+              value={pageSize.toString()}
+              onChange={(v) => setPageSize(Number(v))}
+              options={PAGE_SIZE_OPTIONS.map((size) => ({
+                value: size.toString(),
+                label: size.toString(),
+              }))}
+            />
             <span className="text-sm text-muted-foreground/60">条</span>
           </div>
 

--- a/qce-v4-tool/components/ui/task-wizard.tsx
+++ b/qce-v4-tool/components/ui/task-wizard.tsx
@@ -10,8 +10,9 @@ import { Label } from "./label"
 import { Badge } from "./badge"
 import { Avatar, AvatarImage, AvatarFallback } from "./avatar"
 import {
-  Users, User, Search, ChevronDown, RefreshCw, Settings, Eye, CheckCircle, X, UserMinus, UserPlus, Check
+  Users, User, Search, ChevronDown, RefreshCw, Settings, Eye, CheckCircle, X, UserMinus, UserPlus, Check, HelpCircle
 } from "lucide-react"
+import { Tooltip, TooltipTrigger, TooltipContent } from "./tooltip"
 import { Loader } from "@/components/ui/loader"
 import { useSearch } from "@/hooks/use-search"
 import { useApi } from "@/hooks/use-api"
@@ -887,7 +888,7 @@ export function TaskWizard({
 
             <div className="space-y-2">
               <label className="text-[13px] font-medium text-foreground/80">导出格式</label>
-              <div className="inline-flex items-center gap-1 p-1 rounded-full bg-black/[0.04] dark:bg-white/[0.06] w-fit">
+              <div className="inline-flex items-center flex-wrap gap-1 p-1 rounded-[20px] bg-black/[0.04] dark:bg-white/[0.06] w-fit max-w-full">
                 {(["JSON", "HTML", "TXT", "EXCEL"] as const).map((fmt) => {
                   const active = form.format === fmt
                   return (
@@ -910,7 +911,17 @@ export function TaskWizard({
             </div>
 
             <div className="space-y-2">
-              <label className="text-[13px] font-medium text-foreground/80">时间范围</label>
+              <label className="text-[13px] font-medium text-foreground/80 flex items-center gap-1.5">
+                时间范围
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <HelpCircle className="w-[14px] h-[14px] text-muted-foreground/60 hover:text-muted-foreground transition-colors outline-none cursor-pointer" />
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="max-w-[250px]">
+                    留空则导出全部记录
+                  </TooltipContent>
+                </Tooltip>
+              </label>
               <DateRangePicker
                 startTime={form.startTime}
                 endTime={form.endTime}
@@ -1164,7 +1175,19 @@ export function TaskWizard({
                 className="flex items-center justify-between gap-6 group p-3.5 rounded-2xl bg-black/[0.03] dark:bg-white/[0.04] hover:bg-black/[0.05] dark:hover:bg-white/[0.06] transition-colors"
               >
                 <div className="flex flex-col gap-0.5 flex-1 pr-4">
-                  <div className="text-[13px] font-medium text-foreground">{opt.title}</div>
+                  <div className="flex items-center gap-1.5">
+                    <div className="text-[13px] font-medium text-foreground">{opt.title}</div>
+                    {opt.desc && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <HelpCircle className="w-[14px] h-[14px] text-muted-foreground/60 hover:text-muted-foreground transition-colors outline-none cursor-pointer" />
+                        </TooltipTrigger>
+                        <TooltipContent side="top" sideOffset={6} className="max-w-[250px]">
+                          {opt.desc}
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                  </div>
                   {opt.desc && (
                     <div className="text-[12px] text-muted-foreground leading-snug mt-0.5">{opt.desc}</div>
                   )}

--- a/qce-v4-tool/package-lock.json
+++ b/qce-v4-tool/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qq-chat-exporter-v4-ui",
-  "version": "5.5.77",
+  "version": "5.5.79",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qq-chat-exporter-v4-ui",
-      "version": "5.5.77",
+      "version": "5.5.79",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "1.2.2",
@@ -807,7 +807,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
       "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.61.1"
@@ -2904,9 +2904,9 @@
       "license": "MIT"
     },
     "node_modules/fast-equals": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
-      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.1.tgz",
+      "integrity": "sha512-DjlFSM5Pk9cGcL0q5QXl66eGzx0N6szNgaswwc5ZphlBohjTVJSnGgI+rJVOgOi65qUoQnDZN4nDqi33udtydQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -3488,7 +3488,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
       "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.61.1"
@@ -3507,7 +3507,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
       "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -3568,10 +3568,13 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3598,15 +3601,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.27.0"
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-hook-form": {
@@ -3775,10 +3779,13 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.8.5",

--- a/qce-v4-tool/package.json
+++ b/qce-v4-tool/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qq-chat-exporter-v4-ui",
   "description": "The web interface for QQ Chat Exporter V4.",
-  "version": "5.5.78",
+  "version": "5.5.79",
   "private": true,
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
- 删除操作图标全部换成垃圾桶（任务列表 / 历史记录 / 定时任务）
- 会话页「全部 / 名称 / 分页」下拉与群精华导出格式下拉统一为导出下拉同款药丸样式（新增 components/ui/pill-dropdown.tsx）
- 批量导出会话列表按参考设计重做：动画勾选框（连续选中折叠圆角）、底部悬浮批量工具栏（弹簧动画 / 清空 / 蓝色导出按钮）
- 批量导出与任务向导补齐问号 tooltip（时间范围 + 各开关项，照参考 CreateTaskModal）
- 导出格式 / 时间范围分段控件允许换行，窄屏不再溢出
- 模态框统一阻尼缩放进入/退出动画；执行历史模态框关闭时先播完退出动画再卸载
- 版本 bump 5.5.79