### PR TITLE
feat(export): JSON/HTML 区分自定义表情包与普通图片（#510）+ README 措辞（#514）

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 如果导出聊天记录后，想深入分析聊天内容可以试试 [ChatLab](https://chatlab.fun/cn)
 
-如果需要QCE 导出自动导入 ChatLab，支持定时同步可尝试[QCE2ChatLab](https://github.com/Ruoan-486/QCE2Chatlab)
+如果需要把 QCE 导出自动导入 ChatLab（支持定时同步），可以试试 [QCE2ChatLab](https://github.com/Ruoan-486/QCE2Chatlab)
 
 也可以试试 [QQChatAnalyzer](https://github.com/CutrelyAlex/QQChatAnalyzer) - 支持个人分析、群聊分析、社交网络可视化和 AI 摘要
 

--- a/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
+++ b/plugins/qq-chat-exporter/lib/core/exporter/ModernHtmlExporter.ts
@@ -1526,6 +1526,11 @@ export class ModernHtmlExporter {
         }
 
         if (src) {
+            // issue #510: 自定义表情包（picSubType=1）渲染成裸贴纸，与商城表情一致。
+            if (data?.subType === 'sticker') {
+                const n = this.escapeHtml(filename);
+                return `<span class="sticker-wrap"><img src="${src}" alt="${n}" class="sticker sticker-img" title="${n}" loading="lazy" onclick="showImageModal(this.src)"></span>`;
+            }
             // Issue #311: 当 src 为 data URI 时直接传入会让 HTML 体积翻倍，
             // 并可能造成 onclick 字符串字面量超长引发解析问题。改为从 this.src
             // 读取，对外链与 data URI 行为一致。

--- a/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
@@ -702,6 +702,11 @@ export class SimpleMessageParser {
 
     // 图片
     if (element.picElement) {
+      // issue #510: picSubType 0=普通图片，1=自定义表情包；缺失时不猜测、省略字段。
+      const picSubType = (element.picElement as any).picSubType;
+      const subType = typeof picSubType === 'number'
+        ? (picSubType === 1 ? 'sticker' : 'photo')
+        : undefined;
       return {
         type: 'image',
         data: {
@@ -710,7 +715,8 @@ export class SimpleMessageParser {
           width: element.picElement.picWidth,
           height: element.picElement.picHeight,
           md5: element.picElement.md5HexStr,
-          url: element.picElement.originImageUrl || ''
+          url: element.picElement.originImageUrl || '',
+          ...(subType ? { subType } : {})
         }
       };
     }

--- a/qq-chat-export-core/src/modern_html_exporter.rs
+++ b/qq-chat-export-core/src/modern_html_exporter.rs
@@ -1308,6 +1308,13 @@ impl ModernHtmlExporter {
         let filename = str_field(data, "filename").unwrap_or_else(|| "图片".to_owned());
         let src = self.pick_resource_src(data, "images");
         if !src.is_empty() {
+            // issue #510: 自定义表情包（picSubType=1）渲染成裸贴纸，与商城表情一致。
+            if str_field(data, "subType").as_deref() == Some("sticker") {
+                return format!(
+                    "<span class=\"sticker-wrap\"><img src=\"{src}\" alt=\"{n}\" class=\"sticker sticker-img\" title=\"{n}\" loading=\"lazy\" onclick=\"showImageModal(this.src)\"></span>",
+                    n = escape_html(&filename)
+                );
+            }
             // Issue #311: 当 src 为 data URI 时直接传入会让 HTML 体积翻倍，
             // 并可能造成 onclick 字符串字面量超长引发解析问题。改为从 this.src
             // 读取，对外链与 data URI 行为一致。

--- a/qq-chat-export-server/src/parser/simple_parser.rs
+++ b/qq-chat-export-server/src/parser/simple_parser.rs
@@ -495,16 +495,28 @@ impl SimpleMessageParser {
 
         // 图片
         if let Some(pe) = v_get(element, "picElement").filter(|v| !v.is_null()) {
+            // issue #510: picSubType 0=普通图片，1=自定义表情包；缺失时不猜测、省略字段。
+            let sub_type = v_get(pe, "picSubType").and_then(Value::as_i64).map(|v| {
+                if v == 1 {
+                    "sticker"
+                } else {
+                    "photo"
+                }
+            });
+            let mut data = json!({
+                "filename": v_str(pe, "fileName").filter(|s| !s.is_empty()).unwrap_or("图片"),
+                "size": parse_size_value(v_get(pe, "fileSize")),
+                "width": v_get(pe, "picWidth").cloned().unwrap_or(Value::Null),
+                "height": v_get(pe, "picHeight").cloned().unwrap_or(Value::Null),
+                "md5": v_get(pe, "md5HexStr").cloned().unwrap_or(Value::Null),
+                "url": v_str(pe, "originImageUrl").unwrap_or("")
+            });
+            if let (Some(st), Some(obj)) = (sub_type, data.as_object_mut()) {
+                obj.insert("subType".to_string(), json!(st));
+            }
             return Some(MessageElement {
                 element_type: "image".to_string(),
-                data: json!({
-                    "filename": v_str(pe, "fileName").filter(|s| !s.is_empty()).unwrap_or("图片"),
-                    "size": parse_size_value(v_get(pe, "fileSize")),
-                    "width": v_get(pe, "picWidth").cloned().unwrap_or(Value::Null),
-                    "height": v_get(pe, "picHeight").cloned().unwrap_or(Value::Null),
-                    "md5": v_get(pe, "md5HexStr").cloned().unwrap_or(Value::Null),
-                    "url": v_str(pe, "originImageUrl").unwrap_or("")
-                }),
+                data,
             });
         }
 


### PR DESCRIPTION
## 摘要
关闭 #510 / #514 的 README 措辞微调

### #510 自定义表情包与普通图片的区分
QQ 底层 `picElement.picSubType` 本身就区分了两者（0=普通图片，1=自定义表情包），此前两端解析器都丢掉了该字段。现在：
- Rust server（simple_parser.rs）与 TS 插件（SimpleMessageParser.ts）的 image 元素 data 中新增 `subType: "sticker" | "photo"`；底层字段缺失时省略、不猜测
- JSON 导出直接带出该字段（json_exporter 原样透传 element.data）
- HTML 导出中 `subType === "sticker"` 的图片渲染为裸贴纸（sticker-wrap，与商城表情一致），Rust 核心与 TS 插件双端同步

### #514 README
「如果需要QCE 导出自动导入 ChatLab，支持定时同步可尝试[QCE2ChatLab]」→「如果需要把 QCE 导出自动导入 ChatLab（支持定时同步），可以试试 [QCE2ChatLab]」，格式与相邻条目一致。

## 验证
- `cargo check` 全绿
- 插件 `tsc --noEmit` 错误数与 master 完全一致（97，均为既有的 NapCatQQ 类型声明问题）
