### PR TITLE
test: 语音内联断言对齐 voice-bubble 新 markup，修复 CI unit 卡死

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/ModernHtmlExporter.embedDataUri.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/ModernHtmlExporter.embedDataUri.test.ts
@@ -162,5 +162,5 @@ test('embedResourcesAsDataUri=true: audio file is inlined as data URI with audio
         embed: true
     });
 
-    assert.match(html, /<audio src="data:audio\/silk;base64,[A-Za-z0-9+/=]+"/);
+    assert.match(html, /class="voice-bubble" data-src="data:audio\/silk;base64,[A-Za-z0-9+/=]+"/);
 });


### PR DESCRIPTION
## 摘要
修复 #517 之后 CI unit 测试挂掉的问题。

#517 把语音渲染从 `<audio controls>` 换成了 voice-bubble 波形气泡，但 `ModernHtmlExporter.embedDataUri.test.ts` 里的内联语音断言还在匹配 `<audio src="data:audio/...">`。断言失败后 node:assert 生成错误信息时要 inspect 整个内联导出的多 MB HTML，导致本地/CI 上测试进程 100% CPU 长时间卡死。

断言改为匹配新 markup：`class="voice-bubble" data-src="data:audio/silk;base64,..."`（语义不变：仍然验证音频被内联为 data URI）。

## 验证
本地 `npm run test:unit` 289/289 全绿，不再卡死。
