### PR TITLE
Optimize release workflow artifact reuse

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -28,7 +28,80 @@ jobs:
           echo "version=${NAPCAT_VERSION}" >> $GITHUB_OUTPUT
           echo "检测到 NapCat 版本: ${NAPCAT_VERSION}"
 
+  build-frontend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+
+      - name: "Setup pnpm"
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
+      - name: "Setup Node.js"
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: pnpm
+          cache-dependency-path: qce-v4-tool/pnpm-lock.yaml
+
+      - name: "Build frontend"
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm run build
+        working-directory: qce-v4-tool
+
+      - name: "Upload frontend artifact"
+        uses: actions/upload-artifact@v4
+        with:
+          name: qce-frontend-out
+          path: qce-v4-tool/out
+          retention-days: 7
+
+  build-server-binaries:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            arch: x64
+            binary_path: qq-chat-export-server/target/release/qce-server
+          - os: windows-latest
+            platform: windows
+            arch: x64
+            binary_path: qq-chat-export-server/target/release/qce-server.exe
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+
+      - name: "Setup Rust"
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: "Restore Rust cache"
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: qq-chat-export-server
+          key: release-${{ matrix.platform }}-${{ matrix.arch }}
+
+      - name: "Build Rust server"
+        run: cargo build --release
+        working-directory: qq-chat-export-server
+
+      - name: "Upload Rust server artifact"
+        uses: actions/upload-artifact@v4
+        with:
+          name: qce-server-${{ matrix.platform }}-${{ matrix.arch }}
+          path: ${{ matrix.binary_path }}
+          retention-days: 7
+
   build-shell-packages:
+    needs: [build-frontend, build-server-binaries]
     strategy:
       matrix:
         include:
@@ -36,10 +109,14 @@ jobs:
             platform: Windows
             arch: x64
             artifact_ext: zip
+            server_artifact: qce-server-windows-x64
+            server_binary: qce-server.exe
           - os: ubuntu-latest
             platform: Linux
             arch: x64
             artifact_ext: tar.gz
+            server_artifact: qce-server-linux-x64
+            server_binary: qce-server
     
     runs-on: ${{ matrix.os }}
     
@@ -53,19 +130,18 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-      
-      - name: "Setup pnpm"
-        uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
-      - name: "Setup Rust"
-        uses: dtolnay/rust-toolchain@stable
-      
-      - name: "Rust 缓存"
-        uses: swatinem/rust-cache@v2
+      - name: "Download frontend artifact"
+        uses: actions/download-artifact@v4
         with:
-          workspaces: qq-chat-export-server
+          name: qce-frontend-out
+          path: qce-v4-tool/out
+
+      - name: "Download Rust server artifact"
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.server_artifact }}
+          path: prebuilt-server
       
       - name: "Sync version from tag"
         run: |
@@ -80,8 +156,10 @@ jobs:
           NODE_ENV: production
           NODE_OPTIONS: --max-old-space-size=4096
           QCE_VERSION: ${{ github.ref_name }}
+          QCE_FRONTEND_OUT: qce-v4-tool/out
+          QCE_SERVER_BINARY: prebuilt-server/${{ matrix.server_binary }}
       
-      - name: "上传 Shell 构建产物"
+      - name: "Upload Shell package artifact"
         uses: actions/upload-artifact@v4
         with:
           name: NapCat-QCE-${{ matrix.platform }}-${{ matrix.arch }}
@@ -89,6 +167,7 @@ jobs:
           retention-days: 7
 
   build-framework-package:
+    needs: [build-frontend, build-server-binaries]
     runs-on: ubuntu-latest
     
     steps:
@@ -101,33 +180,28 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-      
-      - name: "Setup pnpm"
-        uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
-      - name: "Setup Rust"
-        uses: dtolnay/rust-toolchain@stable
+      - name: "Download frontend artifact"
+        uses: actions/download-artifact@v4
         with:
-          targets: x86_64-pc-windows-gnu
+          name: qce-frontend-out
+          path: qce-v4-tool/out
 
-      - name: "Install Windows cross compiler"
-        run: sudo apt-get update && sudo apt-get install -y mingw-w64
-      
-      - name: "Build Frontend"
-        run: |
-          cd qce-v4-tool
-          pnpm install
-          pnpm run build
+      - name: "Download Windows Rust server artifact"
+        uses: actions/download-artifact@v4
+        with:
+          name: qce-server-windows-x64
+          path: prebuilt-server
       
       - name: "Build Framework package"
         run: python3 scripts/build-framework-plugin.py
         env:
           NODE_ENV: production
           QCE_VERSION: ${{ github.ref_name }}
+          QCE_FRONTEND_OUT: qce-v4-tool/out
+          QCE_SERVER_WINDOWS_X64: prebuilt-server/qce-server.exe
       
-      - name: "上传 Framework 构建产物"
+      - name: "Upload Framework package artifact"
         uses: actions/upload-artifact@v4
         with:
           name: NapCat-Framework-QCE
@@ -135,6 +209,7 @@ jobs:
           retention-days: 7
 
   build-napcat-plugin:
+    needs: [build-frontend, build-server-binaries]
     runs-on: ubuntu-latest
 
     steps:
@@ -148,30 +223,29 @@ jobs:
         with:
           node-version: 20.x
 
-      - name: "Setup pnpm"
-        uses: pnpm/action-setup@v4
+      - name: "Download frontend artifact"
+        uses: actions/download-artifact@v4
         with:
-          version: 8
+          name: qce-frontend-out
+          path: qce-v4-tool/out
 
-      - name: "Setup Rust"
-        uses: dtolnay/rust-toolchain@stable
+      - name: "Download Linux Rust server artifact"
+        uses: actions/download-artifact@v4
         with:
-          targets: x86_64-pc-windows-gnu
+          name: qce-server-linux-x64
+          path: prebuilt-server/linux
 
-      - name: "Install Windows cross compiler"
-        run: sudo apt-get update && sudo apt-get install -y mingw-w64
+      - name: "Download Windows Rust server artifact"
+        uses: actions/download-artifact@v4
+        with:
+          name: qce-server-windows-x64
+          path: prebuilt-server/windows
 
       - name: "Sync version from tag"
         run: |
           VERSION="${GITHUB_REF#refs/tags/}"
           node scripts/sync-version.js "$VERSION"
         shell: bash
-
-      - name: "Build Frontend"
-        run: |
-          cd qce-v4-tool
-          pnpm install
-          pnpm run build
 
       - name: "Generate NapCatQQ overlay runtime"
         run: node tools/create-overlay-runtime.cjs
@@ -182,8 +256,11 @@ jobs:
         env:
           NODE_ENV: production
           QCE_VERSION: ${{ github.ref_name }}
+          QCE_FRONTEND_OUT: qce-v4-tool/out
+          QCE_SERVER_LINUX_X64: prebuilt-server/linux/qce-server
+          QCE_SERVER_WINDOWS_X64: prebuilt-server/windows/qce-server.exe
 
-      - name: "上传 NapCat 插件构建产物"
+      - name: "Upload NapCat plugin artifact"
         uses: actions/upload-artifact@v4
         with:
           name: napcat-plugin-qce

--- a/scripts/build-framework-plugin.py
+++ b/scripts/build-framework-plugin.py
@@ -182,13 +182,16 @@ def main():
     
     # Copy frontend
     print("[7.6/8] Copying frontend...")
-    frontend_out = "qce-v4-tool/out"
+    frontend_out = os.environ.get("QCE_FRONTEND_OUT", "qce-v4-tool/out")
     static_dir = os.path.join(output_dir, "static", "qce")
     
     if os.path.exists(f"{frontend_out}/index.html"):
         shutil.copytree(frontend_out, static_dir)
         print("[x] Done")
     else:
+        if os.environ.get("QCE_FRONTEND_OUT"):
+            print(f"[!] QCE_FRONTEND_OUT is missing index.html: {frontend_out}")
+            sys.exit(1)
         print("[-] Frontend not built, building...")
         os_name = platform.system()
         pnpm_cmd = "pnpm.cmd" if os_name == "Windows" else "pnpm"

--- a/scripts/build-napcat-plugin.py
+++ b/scripts/build-napcat-plugin.py
@@ -32,7 +32,7 @@ PLUGIN_ID = "napcat-plugin-qce"
 PLUGIN_DISPLAY_NAME = "QQ 聊天记录导出"
 SOURCE_PLUGIN_DIR = Path("plugins/qq-chat-exporter")
 FRONTEND_DIR = Path("qce-v4-tool")
-FRONTEND_OUT_DIR = FRONTEND_DIR / "out"
+FRONTEND_OUT_DIR = Path(os.environ.get("QCE_FRONTEND_OUT", FRONTEND_DIR / "out"))
 
 
 def get_qce_version() -> str:
@@ -52,6 +52,9 @@ def ensure_frontend_built() -> None:
     if (FRONTEND_OUT_DIR / "index.html").exists():
         print(f"[PASS] Frontend found at {FRONTEND_OUT_DIR}")
         return
+
+    if os.environ.get("QCE_FRONTEND_OUT"):
+        sys.exit(f"[ERROR] QCE_FRONTEND_OUT is missing index.html: {FRONTEND_OUT_DIR}")
 
     print("[INFO] Frontend is missing; starting build")
     pnpm_cmd = "pnpm.cmd" if platform.system() == "Windows" else "pnpm"

--- a/scripts/plugin_runtime.py
+++ b/scripts/plugin_runtime.py
@@ -7,6 +7,7 @@ import os
 import platform
 import shutil
 import subprocess
+import stat
 from pathlib import Path
 
 
@@ -17,6 +18,26 @@ def run_command(command: list[str], cwd: Path | None = None) -> None:
     result = subprocess.run(command, cwd=cwd)
     if result.returncode != 0:
         raise RuntimeError(f"command failed: {' '.join(command)}")
+
+
+def resolve_prebuilt_binary(*env_names: str) -> Path | None:
+    for env_name in env_names:
+        value = os.environ.get(env_name)
+        if not value:
+            continue
+        binary = Path(value)
+        if not binary.is_file():
+            raise FileNotFoundError(
+                f"{env_name} points to a missing server binary: {binary}"
+            )
+        return binary
+    return None
+
+
+def ensure_executable(binary: Path) -> None:
+    if binary.name.endswith(".exe"):
+        return
+    binary.chmod(binary.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
 def stage_plugin_runtime(
@@ -53,7 +74,11 @@ def build_server_binary(target: str | None = None) -> Path:
         command.extend(["--target", target])
     run_command(command, SERVER_DIR)
 
-    executable = "qce-server.exe" if target and "windows" in target else "qce-server"
+    executable = (
+        "qce-server.exe"
+        if (target and "windows" in target) or (target is None and platform.system() == "Windows")
+        else "qce-server"
+    )
     target_dir = SERVER_DIR / "target"
     if target:
         target_dir /= target
@@ -64,17 +89,29 @@ def build_server_binary(target: str | None = None) -> Path:
 
 
 def copy_native_server_binary(destination: Path) -> Path:
-    binary = build_server_binary()
+    if platform.system() == "Windows":
+        binary = resolve_prebuilt_binary("QCE_SERVER_WINDOWS_X64", "QCE_SERVER_BINARY")
+        target_name = "qce-server.exe"
+    else:
+        binary = resolve_prebuilt_binary("QCE_SERVER_LINUX_X64", "QCE_SERVER_BINARY")
+        target_name = "qce-server"
+
+    if binary is None:
+        binary = build_server_binary()
+        target_name = binary.name
+
     destination.mkdir(parents=True, exist_ok=True)
-    target = destination / binary.name
+    target = destination / target_name
     shutil.copy2(binary, target)
+    ensure_executable(target)
     return target
 
 
 def copy_windows_server_binary(destination: Path) -> Path:
-    if platform.system() == "Windows":
+    binary = resolve_prebuilt_binary("QCE_SERVER_WINDOWS_X64")
+    if binary is None and platform.system() == "Windows":
         binary = build_server_binary()
-    else:
+    elif binary is None:
         binary = build_server_binary("x86_64-pc-windows-gnu")
     destination.mkdir(parents=True, exist_ok=True)
     target = destination / "qce-server.exe"
@@ -83,16 +120,16 @@ def copy_windows_server_binary(destination: Path) -> Path:
 
 
 def copy_store_server_binaries(destination: Path) -> None:
-    linux_override = os.environ.get("QCE_SERVER_LINUX_X64")
-    windows_override = os.environ.get("QCE_SERVER_WINDOWS_X64")
+    linux_override = resolve_prebuilt_binary("QCE_SERVER_LINUX_X64")
+    windows_override = resolve_prebuilt_binary("QCE_SERVER_WINDOWS_X64")
 
     linux_binary = (
-        Path(linux_override)
+        linux_override
         if linux_override
         else build_server_binary()
     )
     windows_binary = (
-        Path(windows_override)
+        windows_override
         if windows_override
         else build_server_binary("x86_64-pc-windows-gnu")
     )
@@ -101,5 +138,7 @@ def copy_store_server_binaries(destination: Path) -> None:
     windows_dir = destination / "bin" / "windows-x64"
     linux_dir.mkdir(parents=True)
     windows_dir.mkdir(parents=True)
-    shutil.copy2(linux_binary, linux_dir / "qce-server")
+    linux_target = linux_dir / "qce-server"
+    shutil.copy2(linux_binary, linux_target)
+    ensure_executable(linux_target)
     shutil.copy2(windows_binary, windows_dir / "qce-server.exe")

--- a/scripts/quick-pack.py
+++ b/scripts/quick-pack.py
@@ -12,7 +12,7 @@ import tarfile
 from pathlib import Path
 from urllib.request import urlretrieve, urlopen
 from datetime import datetime
-from plugin_runtime import stage_plugin_runtime
+from plugin_runtime import copy_native_server_binary, stage_plugin_runtime
 
 def get_qce_version():
     """Get QCE version from package.json or environment variable"""
@@ -78,16 +78,11 @@ def run_command(cmd, cwd=None, shell=False):
 
 def build_rust_server(pack_dir):
     """Build the Rust server (qce-server) and place it in the package root."""
-    exe_name = "qce-server.exe" if platform.system() == "Windows" else "qce-server"
-    if not run_command(["cargo", "build", "--release"], cwd="qq-chat-export-server"):
-        print("[FAIL] Rust server build failed")
+    try:
+        dest = copy_native_server_binary(Path(pack_dir))
+    except Exception as e:
+        print(f"[FAIL] Rust server binary staging failed: {e}")
         sys.exit(1)
-    src = os.path.join("qq-chat-export-server", "target", "release", exe_name)
-    if not os.path.exists(src):
-        print(f"[FAIL] Rust server binary not found: {src}")
-        sys.exit(1)
-    dest = os.path.join(pack_dir, exe_name)
-    shutil.copy2(src, dest)
     print(f"[PASS] Rust server binary added: {dest}")
 
 def extract_zip(zip_path, dest_dir):
@@ -648,8 +643,11 @@ pause
     
     # Copy frontend files
     print("[8/11] Copying frontend files...")
-    frontend_out = "qce-v4-tool/out"
+    frontend_out = os.environ.get("QCE_FRONTEND_OUT", "qce-v4-tool/out")
     if not os.path.exists(f"{frontend_out}/index.html"):
+        if os.environ.get("QCE_FRONTEND_OUT"):
+            print(f"[FAIL] QCE_FRONTEND_OUT is missing index.html: {frontend_out}")
+            sys.exit(1)
         print("[-] Building frontend...")
         pnpm_cmd = "pnpm.cmd" if os_name == "Windows" else "pnpm"
         run_command([pnpm_cmd, "install"], cwd="qce-v4-tool")


### PR DESCRIPTION
## Summary
- build the frontend once and reuse it across release packages
- build Linux and Windows qce-server binaries once in parallel and reuse them across Shell, Framework, and NapCat plugin packages
- remove mingw-w64 installs and repeated Rust/frontend builds from packaging jobs
- make packaging scripts accept QCE_FRONTEND_OUT and prebuilt server binary env vars

## Validation
- YAML parse: PASS
- Python py_compile: PASS
- prebuilt server copy helper test: PASS
- git diff --check: PASS