### PR TITLE
修复合并转发 messages 为空的bug

### DIFF
--- a/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
+++ b/plugins/qq-chat-exporter/lib/core/parser/SimpleMessageParser.ts
@@ -1223,15 +1223,27 @@ export class SimpleMessageParser {
             peerUid: message.peerUid,
             guildId: ''
           };
-          const result = await msgApi.getMultiMsg({
-            peer,
-            rootMsgId: message.msgId,
-            parentMsgId: message.msgId,
-            forwardId: resId,
-            resId
-          });
-          if (result && Array.isArray(result.msgList)) {
-            raws = result.msgList;
+          // NapCat 4.x may resolve the card by either the outer message id or
+          // the resource id, and different versions return different shapes.
+          const lookupIds = [message.msgId, resId].filter(
+            (id, index, ids): id is string => Boolean(id) && ids.indexOf(id) === index
+          );
+          for (const lookupId of lookupIds) {
+            const result = await msgApi.getMultiMsg({
+              peer,
+              rootMsgId: lookupId,
+              parentMsgId: lookupId,
+              forwardId: resId,
+              resId
+            });
+            if (result && Array.isArray(result.msgList)) {
+              raws = result.msgList;
+            } else if (result && Array.isArray(result.messages)) {
+              return this.normalizeForwardActionMessages(result.messages);
+            } else if (result && Array.isArray(result.data?.messages)) {
+              return this.normalizeForwardActionMessages(result.data.messages);
+            }
+            if (raws.length > 0) break;
           }
         }
       } catch {

--- a/plugins/qq-chat-exporter/tools/create-overlay-runtime.cjs
+++ b/plugins/qq-chat-exporter/tools/create-overlay-runtime.cjs
@@ -42,7 +42,14 @@ export const MsgApi = {
   async getMultiMsg(params) {
     const { core } = getBridge();
     const impl = core?.apis?.MsgApi?.getMultiMsg || core?.apis?.msg?.getMultiMsg;
-    if (impl) return impl.call(core.apis.MsgApi || core.apis.msg, params);
+    if (impl) {
+      return impl.call(
+        core.apis.MsgApi || core.apis.msg,
+        params?.peer,
+        params?.rootMsgId,
+        params?.parentMsgId || params?.rootMsgId
+      );
+    }
     
     const { actions, instance } = getBridge();
     const handler = actions?.get?.('get_forward_msg');

--- a/qq-chat-export-server/src/api/routes/messages.rs
+++ b/qq-chat-export-server/src/api/routes/messages.rs
@@ -27,7 +27,7 @@ use crate::fetcher::{
     chat_type_prefix, classify_chat_type_binary, BatchFetchConfig, BatchMessageFetcher,
     MessageFilter, Peer, GROUP_CHAT_TYPE,
 };
-use crate::parser::{SimpleMessageParser, SimpleParserOptions};
+use crate::parser::{ForwardFetcher, SimpleMessageParser, SimpleParserOptions};
 use crate::paths::PathManager;
 use crate::resource::ResourceBatchSummary;
 use crate::storage::ResourceInfo;
@@ -1320,7 +1320,7 @@ async fn process_export_task(
             .and_then(Value::as_bool)
             .unwrap_or(true),
         sender_title_resolver,
-        forward_fetcher: None,
+        forward_fetcher: Some(Arc::new(state.napcat.clone()) as Arc<dyn ForwardFetcher>),
     });
     let mut clean_messages: Vec<CleanMessage> = parser.parse_messages(&filtered_messages).await;
 

--- a/qq-chat-export-server/src/napcat/client.rs
+++ b/qq-chat-export-server/src/napcat/client.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use serde_json::{json, Value};
 
 use crate::fetcher::{MessageFetchApi, Peer};
+use crate::parser::ForwardFetcher;
 
 /// bridge 调用错误。
 #[derive(Debug, thiserror::Error)]
@@ -238,6 +239,63 @@ impl NapCatBridgeClient {
     ) -> Result<Value, BridgeError> {
         self.call("PacketApi.getGroupFileUrl", json!([group_code, file_id]))
             .await
+    }
+}
+
+fn extract_forward_messages(value: &Value) -> Option<Vec<Value>> {
+    [
+        value.get("msgList"),
+        value.get("messages"),
+        value.get("data").and_then(|data| data.get("messages")),
+    ]
+    .into_iter()
+    .flatten()
+    .find_map(Value::as_array)
+    .cloned()
+}
+
+#[async_trait::async_trait]
+impl ForwardFetcher for NapCatBridgeClient {
+    async fn get_multi_msg(
+        &self,
+        chat_type: i64,
+        peer_uid: &str,
+        root_msg_id: &str,
+        _res_id: &str,
+    ) -> Option<Vec<Value>> {
+        let peer = json!({
+            "chatType": chat_type,
+            "peerUid": peer_uid,
+            "guildId": "",
+        });
+        self.get_multi_msg(&peer, root_msg_id, root_msg_id)
+            .await
+            .ok()
+            .and_then(|value| extract_forward_messages(&value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_forward_messages;
+    use serde_json::json;
+
+    #[test]
+    fn extracts_forward_messages_from_supported_response_shapes() {
+        let message = json!({"msgId": "inner-1"});
+        assert_eq!(
+            extract_forward_messages(&json!({"msgList": [message.clone()]})),
+            Some(vec![message.clone()])
+        );
+        assert_eq!(
+            extract_forward_messages(&json!({"messages": [message.clone()]})),
+            Some(vec![message.clone()])
+        );
+        assert_eq!(
+            extract_forward_messages(&json!({"data": {"messages": [message]}})).map(|v| v.len()),
+            Some(1)
+        );
+        assert_eq!(extract_forward_messages(&json!({"data": {}})), None);
     }
 }
 

--- a/qq-chat-export-server/src/paths/mod.rs
+++ b/qq-chat-export-server/src/paths/mod.rs
@@ -54,6 +54,7 @@ impl PathManager {
     /// 校验路径：只禁止系统关键目录，允许任意其他位置。
     fn validate_path(input: &str) -> Result<PathBuf, PathError> {
         let sanitized = Self::sanitize_path(input);
+        let normalized_input = sanitized.replace('\\', "/").to_lowercase();
         let resolved = if Path::new(&sanitized).is_absolute() {
             PathBuf::from(&sanitized)
         } else {
@@ -64,6 +65,14 @@ impl PathManager {
         let normalized = resolved.to_string_lossy().replace('\\', "/").to_lowercase();
         let dangerous = normalized.contains("/windows/system32")
             || normalized.contains("/windows/syswow64")
+            || normalized_input == "/etc"
+            || normalized_input.starts_with("/etc/")
+            || normalized_input == "/bin"
+            || normalized_input.starts_with("/bin/")
+            || normalized_input == "/usr/bin"
+            || normalized_input.starts_with("/usr/bin/")
+            || normalized_input == "/sbin"
+            || normalized_input.starts_with("/sbin/")
             || normalized.starts_with("/etc/")
             || normalized.starts_with("/bin/")
             || normalized.starts_with("/usr/bin")

--- a/qq-chat-export-server/src/scheduled_executor.rs
+++ b/qq-chat-export-server/src/scheduled_executor.rs
@@ -15,7 +15,7 @@ use qce_server::fetcher::{
     classify_chat_type_binary, BatchFetchConfig, BatchMessageFetcher, MessageFilter, Peer,
 };
 use qce_server::napcat::NapCatBridgeClient;
-use qce_server::parser::{SimpleMessageParser, SimpleParserOptions};
+use qce_server::parser::{ForwardFetcher, SimpleMessageParser, SimpleParserOptions};
 use qce_server::paths::PathManager;
 use qce_server::resource::ResourceHandler;
 use qce_server::scheduler::{ExecutionOutcome, ScheduledExportExecutor};
@@ -181,7 +181,7 @@ impl ScheduledExportExecutor for ApiScheduledExportExecutor {
                 .and_then(Value::as_bool)
                 .unwrap_or(true),
             sender_title_resolver: None,
-            forward_fetcher: None,
+            forward_fetcher: Some(Arc::new(self.napcat.clone()) as Arc<dyn ForwardFetcher>),
         });
         let mut clean_messages: Vec<CleanMessage> = parser.parse_messages(&all_messages).await;
 


### PR DESCRIPTION
修复合并转发 messages 为空
支持多种 NapCat 返回结构
Rust 导出流程启用转发消息获取