### PR TITLE
fix: add export diagnostics and repair loading UI

### DIFF
--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -964,6 +964,7 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
           // Issue #311: 自包含 HTML
           embedResourcesAsDataUri: config.embedResourcesAsDataUri,
           preferGroupMemberName: config.preferGroupMemberName,
+          debugExport: config.debugExport,
           outputDir: config.outputDir,
           keywords: config.keywords,
           excludeUserUins: config.excludeUserUins,
@@ -2662,7 +2663,25 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
                 )}
 
                 {/* Sticker Packs List */}
-                {stickerPacks.length === 0 ? (
+                {stickerPacksLoading ? (
+                  <div className="flex flex-col items-center justify-center py-20 text-center">
+                    <Loader size={24} />
+                    <p className="mt-3 text-[12px] text-muted-foreground/60">正在加载表情包...</p>
+                  </div>
+                ) : stickerPacksError ? (
+                  <div className="flex flex-col items-center justify-center py-20 text-center">
+                    <p className="text-[13px] font-medium text-foreground">表情包加载失败</p>
+                    <p className="mt-1 max-w-md text-[12px] text-muted-foreground/60">{stickerPacksError}</p>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="mt-4 rounded-full"
+                      onClick={() => void Promise.all([loadStickerPacks(), loadStickerExportRecords()])}
+                    >
+                      重试
+                    </Button>
+                  </div>
+                ) : stickerPacks.length === 0 ? (
                   <div className="flex flex-col items-center justify-center py-20 text-center">
                     <Smile className="w-8 h-8 text-muted-foreground/20 mb-3" />
                     <p className="text-[13px] text-foreground font-medium">暂无表情包</p>

--- a/qce-v4-tool/components/ui/batch-export-dialog.tsx
+++ b/qce-v4-tool/components/ui/batch-export-dialog.tsx
@@ -53,6 +53,7 @@ export interface BatchExportConfig {
   includeSystemMessages: boolean
   filterPureImageMessages: boolean
   preferGroupMemberName: boolean
+  debugExport: boolean
   /** Issue #341: 仅保留元数据、跳过下载的资源类型 */
   skipDownloadResourceTypes?: Array<'image' | 'video' | 'audio' | 'file'>
   outputDir: string
@@ -93,6 +94,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
   const [includeSystemMessages, setIncludeSystemMessages] = useState(true)
   const [filterPureImageMessages, setFilterPureImageMessages] = useState(false) // HTML默认false
   const [preferGroupMemberName, setPreferGroupMemberName] = useState(true)
+  const [debugExport, setDebugExport] = useState(false)
   // Issue #344：批量导出也支持按资源类型逐项跳过下载。
   const [skipDownloadResourceTypes, setSkipDownloadResourceTypes] = useState<SkipDownloadResourceType[] | undefined>(undefined)
   const [outputDir, setOutputDir] = useState('')
@@ -217,6 +219,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
       includeSystemMessages,
       filterPureImageMessages,
       preferGroupMemberName,
+      debugExport,
       ...(!filterPureImageMessages && skipDownloadResourceTypes && skipDownloadResourceTypes.length > 0 && {
         skipDownloadResourceTypes,
       }),
@@ -409,6 +412,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
                     { id: "skipVideoDownload", checked: !!skipDownloadResourceTypes?.includes('video'), set: (v: boolean) => setSkipDownloadResourceTypes((curr) => toggleSkipResourceType(curr, 'video', v)), title: "不下载视频", desc: "批量导出时跳过视频，避免长时间或群聊导出时占用大量带宽和磁盘空间。", tip: EXPORT_OPTION_TOOLTIPS.skipVideos, visible: !filterPureImageMessages, highlight: false, group: "导出内容" },
                     { id: "skipAudioDownload", checked: !!skipDownloadResourceTypes?.includes('audio'), set: (v: boolean) => setSkipDownloadResourceTypes((curr) => toggleSkipResourceType(curr, 'audio', v)), title: "不下载语音", desc: "批量导出时跳过 SILK / AMR 等语音消息。对只想保留文字记录的场景很有用。", tip: EXPORT_OPTION_TOOLTIPS.skipAudio, visible: !filterPureImageMessages, highlight: false, group: "导出内容" },
                     { id: "preferGroupMemberName", checked: preferGroupMemberName, set: setPreferGroupMemberName, title: "优先使用群成员名称", desc: "群聊导出时优先使用群名片或群内名称。关闭后会改用 QQ 昵称或 QQ 号。这个选项仅对群聊生效。", tip: EXPORT_OPTION_TOOLTIPS.preferGroupMemberName, visible: true, highlight: false, group: "导出内容" },
+                    { id: "debugExport", checked: debugExport, set: setDebugExport, title: "调试导出", desc: "额外保存原始消息、解析结果、最终消息及逐资源调用耗时与错误；默认关闭，排查导出问题时再开启。", visible: true, highlight: false, group: "性能与处理" },
                     { id: "exportAsZip", checked: exportAsZip, set: setExportAsZip, title: "导出为ZIP压缩包", desc: "将HTML文件和资源文件打包为ZIP格式（仅HTML格式可用）", tip: EXPORT_OPTION_TOOLTIPS.exportAsZip, visible: format === "HTML" && !streamingZipMode, highlight: false, group: "性能与处理" },
                     { id: "embedAvatarsAsBase64", checked: embedAvatarsAsBase64, set: setEmbedAvatarsAsBase64, title: "嵌入头像为Base64", desc: "将发送者头像以Base64格式嵌入JSON文件（仅JSON格式可用，会增加文件大小）", tip: EXPORT_OPTION_TOOLTIPS.embedAvatars, visible: format === "JSON", highlight: false, group: "导出内容" },
                     // Issue #311: 自包含 HTML

--- a/qce-v4-tool/components/ui/scheduled-export-wizard.tsx
+++ b/qce-v4-tool/components/ui/scheduled-export-wizard.tsx
@@ -76,6 +76,7 @@ export function ScheduledExportWizard({
     includeSystemMessages: true,
     filterPureImageMessages: false,
     preferGroupMemberName: true,
+    debugExport: false,
     // Issue #344：定时导出也支持按资源类型逐项跳过下载。
     skipDownloadResourceTypes: undefined as SkipDownloadResourceType[] | undefined,
   })
@@ -133,6 +134,7 @@ export function ScheduledExportWizard({
           ? prefilledData.filterPureImageMessages 
           : defaultFilter,
         preferGroupMemberName: prefilledData.preferGroupMemberName !== undefined ? prefilledData.preferGroupMemberName : true,
+        debugExport: prefilledData.debugExport ?? false,
         skipDownloadResourceTypes: Array.isArray(prefilledData.skipDownloadResourceTypes) && prefilledData.skipDownloadResourceTypes.length > 0
           ? (prefilledData.skipDownloadResourceTypes as SkipDownloadResourceType[])
           : undefined,
@@ -171,6 +173,7 @@ export function ScheduledExportWizard({
         includeSystemMessages: true,
         filterPureImageMessages: false,
         preferGroupMemberName: true,
+        debugExport: false,
         skipDownloadResourceTypes: undefined,
       })
       setSelectedTargets([])
@@ -228,6 +231,7 @@ export function ScheduledExportWizard({
         includeSystemMessages: baseForm.includeSystemMessages,
         filterPureImageMessages: baseForm.filterPureImageMessages,
         preferGroupMemberName: baseForm.preferGroupMemberName,
+        debugExport: baseForm.debugExport,
         ...(!baseForm.filterPureImageMessages && baseForm.skipDownloadResourceTypes && baseForm.skipDownloadResourceTypes.length > 0 && {
           skipDownloadResourceTypes: baseForm.skipDownloadResourceTypes,
         }),
@@ -891,6 +895,14 @@ export function ScheduledExportWizard({
                       set: (v: boolean) => setBaseForm(p => ({ ...p, preferGroupMemberName: v })),
                       title: "优先使用群成员名称",
                       desc: "群聊导出时优先使用群名片或群内名称。关闭后会改用 QQ 昵称或 QQ 号。这个选项仅对群聊生效。",
+                      visible: true,
+                    },
+                    {
+                      id: "debugExport",
+                      checked: baseForm.debugExport,
+                      set: (v: boolean) => setBaseForm(p => ({ ...p, debugExport: v })),
+                      title: "调试导出",
+                      desc: "额外保存原始消息、解析结果、最终消息及逐资源调用耗时与错误；默认关闭，排查导出问题时再开启。",
                       visible: true,
                     }
                   ].filter((opt) => (opt as any).visible !== false).map((opt) => (

--- a/qce-v4-tool/components/ui/task-wizard.tsx
+++ b/qce-v4-tool/components/ui/task-wizard.tsx
@@ -43,6 +43,7 @@ interface AdvancedPreferences {
   filterPureImageMessages: boolean
   skipDownloadResourceTypes?: SkipDownloadResourceType[]
   preferGroupMemberName: boolean
+  debugExport: boolean
   exportAsZip: boolean
   useNameInFileName: boolean
   useFriendlyFileName: boolean
@@ -74,6 +75,7 @@ const createDefaultForm = (): CreateTaskForm => ({
   useNameInFileName: false,
   useFriendlyFileName: false,
   preferGroupMemberName: true,
+  debugExport: false,
 })
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -92,6 +94,7 @@ const readAdvancedPreferences = (): Partial<AdvancedPreferences> => {
       "includeSystemMessages",
       "filterPureImageMessages",
       "preferGroupMemberName",
+      "debugExport",
       "exportAsZip",
       "useNameInFileName",
       "useFriendlyFileName",
@@ -118,6 +121,7 @@ const selectAdvancedPreferences = (form: CreateTaskForm): AdvancedPreferences =>
   filterPureImageMessages: form.filterPureImageMessages,
   skipDownloadResourceTypes: form.skipDownloadResourceTypes,
   preferGroupMemberName: form.preferGroupMemberName ?? true,
+  debugExport: form.debugExport ?? false,
   exportAsZip: form.exportAsZip ?? false,
   useNameInFileName: form.useNameInFileName ?? false,
   useFriendlyFileName: form.useFriendlyFileName ?? false,
@@ -173,6 +177,7 @@ const mergePrefilledForm = (
       prefilledData.useFriendlyFileName ?? base.useFriendlyFileName,
     preferGroupMemberName:
       prefilledData.preferGroupMemberName ?? base.preferGroupMemberName,
+    debugExport: prefilledData.debugExport ?? base.debugExport,
   }
 }
 
@@ -1120,7 +1125,10 @@ export function TaskWizard({
             type="button"
             aria-expanded={filtersOpen}
             onClick={() => setFiltersOpen((open) => !open)}
-            className="mb-5 inline-flex items-center gap-2 text-left"
+            className={[
+              "inline-flex items-center gap-2 text-left",
+              filtersOpen ? "mb-5" : "",
+            ].join(" ")}
           >
             <div className="flex min-w-0 items-center gap-2">
               <span className="text-[14px] font-medium text-foreground">过滤条件</span>
@@ -1230,6 +1238,15 @@ export function TaskWizard({
                 tip: EXPORT_OPTION_TOOLTIPS.includeSystemMessages,
                 visible: true,
                 group: "导出内容"
+              },
+              {
+                id: "debugExport",
+                checked: form.debugExport || false,
+                set: (v: boolean) => setForm((p) => ({ ...p, debugExport: v })),
+                title: "调试导出",
+                desc: "额外保存原始消息、解析结果、最终消息及逐资源调用耗时与错误；默认关闭，排查导出问题时再开启。",
+                visible: true,
+                group: "性能与处理"
               },
               {
                 id: "filterPureImageMessages",

--- a/qce-v4-tool/hooks/use-export-tasks.ts
+++ b/qce-v4-tool/hooks/use-export-tasks.ts
@@ -501,6 +501,7 @@ export function useExportTasks(_props?: UseExportTasksProps) {
           // Issue #311: 自包含 HTML（资源 base64 内联）。
           embedResourcesAsDataUri: form.embedResourcesAsDataUri,
           preferGroupMemberName: form.preferGroupMemberName ?? true,
+          debugExport: form.debugExport ?? false,
           ...(form.outputDir?.trim() && { outputDir: form.outputDir.trim() }),
           ...(form.useNameInFileName && { useNameInFileName: true }),
           // Issue #134: 友好文件名格式 `<名称>(<QQ号>).<扩展名>`

--- a/qce-v4-tool/hooks/use-scheduled-exports.ts
+++ b/qce-v4-tool/hooks/use-scheduled-exports.ts
@@ -28,6 +28,7 @@ export interface ScheduledExportConfig {
         filterPureImageMessages?: boolean;
         prettyFormat?: boolean;
         preferGroupMemberName?: boolean;
+        debugExport?: boolean;
     };
     enabled: boolean;
     createdAt?: string;
@@ -107,6 +108,7 @@ export function useScheduledExports() {
                     filterPureImageMessages: formData.filterPureImageMessages ?? false,
                     prettyFormat: true,
                     preferGroupMemberName: formData.preferGroupMemberName ?? true,
+                    debugExport: formData.debugExport ?? false,
                     ...(Array.isArray(formData.skipDownloadResourceTypes) && formData.skipDownloadResourceTypes.length > 0 && {
                         skipDownloadResourceTypes: formData.skipDownloadResourceTypes,
                     }),

--- a/qce-v4-tool/types/api.ts
+++ b/qce-v4-tool/types/api.ts
@@ -234,6 +234,8 @@ export interface CreateTaskForm {
   useFriendlyFileName?: boolean
   /** 群聊导出时优先使用群成员名称（Issue #358） */
   preferGroupMemberName?: boolean
+  /** 保存原始消息、解析结果、最终消息和资源调用事件。 */
+  debugExport?: boolean
   /**
    * 仅保留元数据、跳过下载的资源类型（Issue #341）。
    * 'image' | 'video' | 'audio' | 'file'
@@ -275,6 +277,7 @@ export interface CreateTaskRequest {
     useFriendlyFileName?: boolean
     /** 群聊导出时优先使用群成员名称（Issue #358） */
     preferGroupMemberName?: boolean
+    debugExport?: boolean
     /** 仅保留元数据、跳过下载的资源类型（Issue #341） */
     skipDownloadResourceTypes?: Array<'image' | 'video' | 'audio' | 'file'>
   }
@@ -385,6 +388,7 @@ export interface ScheduledExport {
     filterPureImageMessages?: boolean
     prettyFormat?: boolean
     preferGroupMemberName?: boolean
+    debugExport?: boolean
     /** Issue #341: 仅保留元数据、跳过下载的资源类型 */
     skipDownloadResourceTypes?: Array<'image' | 'video' | 'audio' | 'file'>
     /** Issue #311: 自包含 HTML（资源 base64 内联）。 */
@@ -432,6 +436,7 @@ export interface CreateScheduledExportForm {
   includeSystemMessages?: boolean
   filterPureImageMessages?: boolean
   preferGroupMemberName?: boolean
+  debugExport?: boolean
   /** Issue #341: 仅保留元数据、跳过下载的资源类型 */
   skipDownloadResourceTypes?: Array<'image' | 'video' | 'audio' | 'file'>
 }

--- a/qq-chat-export-server/src/api/routes/messages.rs
+++ b/qq-chat-export-server/src/api/routes/messages.rs
@@ -24,6 +24,7 @@ use crate::api::helpers::{
 };
 use crate::api::response::{self, ApiError, RequestId};
 use crate::api::state::{MessageCacheEntry, SharedState, CACHE_EXPIRE_TIME_MS};
+use crate::export_debug::ExportDebugSession;
 use crate::fetcher::{
     chat_type_prefix, classify_chat_type_binary, BatchFetchConfig, BatchMessageFetcher,
     MessageFilter, Peer, GROUP_CHAT_TYPE,
@@ -942,7 +943,7 @@ pub async fn export_streaming_jsonl(
 }
 
 /// 导出模式。
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ExportMode {
     /// 普通导出（TXT / JSON / HTML / EXCEL）。
     Standard,
@@ -1294,6 +1295,21 @@ async fn process_export_task(
     )
     .await;
     broadcast_progress(state, task_id, 0, "开始获取消息...", 0);
+    let debug_session = if req.options.get("debugExport").and_then(Value::as_bool) == Some(true) {
+        let session = ExportDebugSession::start(&req.output_dir, file_name).await?;
+        session
+            .trace()
+            .record(json!({
+                "type": "export_started",
+                "taskId": task_id,
+                "format": format,
+                "mode": format!("{mode:?}"),
+            }))
+            .await;
+        Some(session)
+    } else {
+        None
+    };
 
     // ============ 阶段 1：抓取消息（0 → 50） ============
     let batch_size = loose_i64(req.options.get("batchSize")).unwrap_or(5000);
@@ -1384,6 +1400,11 @@ async fn process_export_task(
     );
 
     filtered_messages.sort_by_key(msg_time_ms);
+    if let Some(debug) = &debug_session {
+        debug
+            .write_jsonl("01-raw-messages.jsonl", &filtered_messages)
+            .await?;
+    }
 
     let sender_title_resolver = title_map.map(|map| {
         let map = Arc::new(map);
@@ -1403,6 +1424,11 @@ async fn process_export_task(
         forward_fetcher: Some(Arc::new(state.napcat.clone()) as Arc<dyn ForwardFetcher>),
     });
     let mut clean_messages: Vec<CleanMessage> = parser.parse_messages(&filtered_messages).await;
+    if let Some(debug) = &debug_session {
+        debug
+            .write_jsonl("02-parsed-messages.jsonl", &clean_messages)
+            .await?;
+    }
     let mut resource_messages = filtered_messages.clone();
     resource_messages.extend(parser.take_forward_raw_messages());
     let mut resource_message_ids = HashSet::new();
@@ -1491,7 +1517,11 @@ async fn process_export_task(
 
         resource_map = state
             .resource_handler
-            .process_message_resources_with_cancel(&resource_messages, Arc::clone(cancel_flag))
+            .process_message_resources_with_cancel_and_trace(
+                &resource_messages,
+                Arc::clone(cancel_flag),
+                debug_session.as_ref().map(ExportDebugSession::trace),
+            )
             .await;
         let summary = state.resource_handler.last_batch_summary().await;
         state.resource_handler.set_progress_callback(None).await;
@@ -1539,6 +1569,11 @@ async fn process_export_task(
         SimpleMessageParser::update_message_resource_paths_recursive(message, &value_resource_map);
     }
     SimpleMessageParser::backfill_reply_preview_local_paths(&mut clean_messages);
+    if let Some(debug) = &debug_session {
+        debug
+            .write_jsonl("03-final-messages.jsonl", &clean_messages)
+            .await?;
+    }
 
     let message_count = clean_messages.len();
     let self_info = state.napcat.self_info().await.unwrap_or(Value::Null);
@@ -1791,6 +1826,25 @@ async fn process_export_task(
     let summary_message = build_resource_summary_message(resource_summary.as_ref());
     let completion_message =
         summary_message.map_or_else(|| "导出完成".to_string(), |s| format!("导出完成 · {s}"));
+    let debug_path = if let Some(debug) = debug_session {
+        debug
+            .write_json(
+                "summary.json",
+                &json!({
+                    "taskId": task_id,
+                    "format": format,
+                    "mode": format!("{mode:?}"),
+                    "messageCount": message_count,
+                    "resourceSummary": resource_summary,
+                    "finalFileName": final_file_name,
+                    "finalFileSize": file_size,
+                }),
+            )
+            .await?;
+        Some(debug.finish().await?)
+    } else {
+        None
+    };
 
     update_task(
         state,
@@ -1809,6 +1863,9 @@ async fn process_export_task(
                 .as_ref()
                 .map_or(Value::Null, |p| Value::String(p.to_string_lossy().to_string())),
             "resourceSummary": resource_summary_value.clone().unwrap_or(Value::Null),
+            "debugPath": debug_path
+                .as_ref()
+                .map_or(Value::Null, |path| Value::String(path.to_string_lossy().to_string())),
         }),
     )
     .await;
@@ -1841,6 +1898,9 @@ async fn process_export_task(
                 .as_ref()
                 .map_or(Value::Null, |p| Value::String(p.to_string_lossy().to_string())),
             "resourceSummary": resource_summary_value.unwrap_or(Value::Null),
+            "debugPath": debug_path
+                .as_ref()
+                .map_or(Value::Null, |path| Value::String(path.to_string_lossy().to_string())),
         },
     }));
 

--- a/qq-chat-export-server/src/export_debug.rs
+++ b/qq-chat-export-server/src/export_debug.rs
@@ -1,0 +1,149 @@
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use serde_json::{json, Value};
+use tokio::io::AsyncWriteExt;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+
+enum DebugCommand {
+    Event(String),
+    Finish(oneshot::Sender<Result<(), String>>),
+}
+
+#[derive(Clone)]
+pub struct ExportDebugTrace {
+    sender: mpsc::Sender<DebugCommand>,
+}
+
+impl ExportDebugTrace {
+    pub async fn record(&self, event: Value) {
+        let payload = json!({
+            "timestamp": chrono::Utc::now().to_rfc3339(),
+            "event": event,
+        });
+        let _ = self
+            .sender
+            .send(DebugCommand::Event(payload.to_string()))
+            .await;
+    }
+}
+
+pub struct ExportDebugSession {
+    directory: PathBuf,
+    trace: ExportDebugTrace,
+    writer: JoinHandle<()>,
+}
+
+impl ExportDebugSession {
+    pub async fn start(output_dir: &Path, export_name: &str) -> Result<Self, String> {
+        tokio::fs::create_dir_all(output_dir)
+            .await
+            .map_err(|error| format!("创建调试导出目录失败: {error}"))?;
+        let base_name = Path::new(export_name)
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .filter(|value| !value.is_empty())
+            .unwrap_or("export");
+        let mut directory = output_dir.join(format!("{base_name}.debug"));
+        let mut suffix = 2;
+        while tokio::fs::try_exists(&directory).await.unwrap_or(false) {
+            directory = output_dir.join(format!("{base_name}.debug-{suffix}"));
+            suffix += 1;
+        }
+        tokio::fs::create_dir(&directory)
+            .await
+            .map_err(|error| format!("创建调试导出目录失败: {error}"))?;
+
+        let (sender, mut receiver) = mpsc::channel(1024);
+        let event_path = directory.join("04-events.jsonl");
+        let writer = tokio::spawn(async move {
+            let result = async {
+                let mut file = tokio::fs::File::create(&event_path)
+                    .await
+                    .map_err(|error| error.to_string())?;
+                while let Some(command) = receiver.recv().await {
+                    match command {
+                        DebugCommand::Event(line) => {
+                            file.write_all(line.as_bytes())
+                                .await
+                                .map_err(|error| error.to_string())?;
+                            file.write_all(b"\n")
+                                .await
+                                .map_err(|error| error.to_string())?;
+                        }
+                        DebugCommand::Finish(reply) => {
+                            let result = file.flush().await.map_err(|error| error.to_string());
+                            let _ = reply.send(result);
+                            return Ok::<(), String>(());
+                        }
+                    }
+                }
+                Ok(())
+            }
+            .await;
+            if let Err(error) = result {
+                tracing::warn!("写入调试导出事件失败: {error}");
+            }
+        });
+
+        Ok(Self {
+            directory,
+            trace: ExportDebugTrace { sender },
+            writer,
+        })
+    }
+
+    #[must_use]
+    pub fn trace(&self) -> ExportDebugTrace {
+        self.trace.clone()
+    }
+
+    #[must_use]
+    pub fn directory(&self) -> &Path {
+        &self.directory
+    }
+
+    pub async fn write_jsonl<T: Serialize>(
+        &self,
+        file_name: &str,
+        values: &[T],
+    ) -> Result<(), String> {
+        let mut file = tokio::fs::File::create(self.directory.join(file_name))
+            .await
+            .map_err(|error| error.to_string())?;
+        for value in values {
+            let line = serde_json::to_vec(value).map_err(|error| error.to_string())?;
+            file.write_all(&line)
+                .await
+                .map_err(|error| error.to_string())?;
+            file.write_all(b"\n")
+                .await
+                .map_err(|error| error.to_string())?;
+        }
+        file.flush().await.map_err(|error| error.to_string())
+    }
+
+    pub async fn write_json<T: Serialize>(&self, file_name: &str, value: &T) -> Result<(), String> {
+        let bytes = serde_json::to_vec_pretty(value).map_err(|error| error.to_string())?;
+        tokio::fs::write(self.directory.join(file_name), bytes)
+            .await
+            .map_err(|error| error.to_string())
+    }
+
+    pub async fn finish(self) -> Result<PathBuf, String> {
+        let (reply, result) = oneshot::channel();
+        self.trace
+            .sender
+            .send(DebugCommand::Finish(reply))
+            .await
+            .map_err(|_| "调试导出事件写入器已关闭".to_string())?;
+        result
+            .await
+            .map_err(|_| "调试导出事件写入器未返回结果".to_string())??;
+        self.writer
+            .await
+            .map_err(|error| format!("等待调试导出事件写入器失败: {error}"))?;
+        Ok(self.directory)
+    }
+}

--- a/qq-chat-export-server/src/lib.rs
+++ b/qq-chat-export-server/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod export_debug;
 pub mod fetcher;
 pub mod napcat;
 pub mod parser;

--- a/qq-chat-export-server/src/napcat/client.rs
+++ b/qq-chat-export-server/src/napcat/client.rs
@@ -207,7 +207,7 @@ impl NapCatBridgeClient {
     ) -> Result<Value, BridgeError> {
         self.call(
             "FileApi.downloadMedia",
-            json!([
+            download_media_params(
                 msg_id,
                 chat_type,
                 peer_uid,
@@ -215,8 +215,8 @@ impl NapCatBridgeClient {
                 this_path,
                 source_path,
                 timeout_ms,
-                force
-            ]),
+                force,
+            ),
         )
         .await
     }
@@ -334,7 +334,7 @@ impl crate::resource::MediaDownloader for NapCatBridgeClient {
         timeout_ms: u64,
     ) -> Result<String, String> {
         let result = NapCatBridgeClient::download_media(
-            self, msg_id, chat_type, peer_uid, element_id, dest_path, "", timeout_ms, true,
+            self, msg_id, chat_type, peer_uid, element_id, "", dest_path, timeout_ms, true,
         )
         .await
         .map_err(|error| error.to_string())?;
@@ -413,9 +413,32 @@ fn peer_to_value(peer: &Peer) -> Value {
     })
 }
 
+#[allow(clippy::too_many_arguments)]
+fn download_media_params(
+    msg_id: &str,
+    chat_type: i64,
+    peer_uid: &str,
+    element_id: &str,
+    thumb_path: &str,
+    source_path: &str,
+    timeout_ms: u64,
+    force: bool,
+) -> Value {
+    json!([
+        msg_id,
+        chat_type,
+        peer_uid,
+        element_id,
+        thumb_path,
+        source_path,
+        timeout_ms,
+        force
+    ])
+}
+
 #[cfg(test)]
 mod tests {
-    use super::extract_forward_messages;
+    use super::{download_media_params, extract_forward_messages};
     use serde_json::json;
 
     #[test]
@@ -434,5 +457,22 @@ mod tests {
             Some(1)
         );
         assert_eq!(extract_forward_messages(&json!({"data": {}})), None);
+    }
+
+    #[test]
+    fn media_download_uses_source_path_as_destination() {
+        let params = download_media_params(
+            "msg",
+            2,
+            "peer",
+            "element",
+            "",
+            "C:/exports/image.jpg",
+            30_000,
+            true,
+        );
+        let params = params.as_array().expect("download parameters");
+        assert_eq!(params[4], "");
+        assert_eq!(params[5], "C:/exports/image.jpg");
     }
 }

--- a/qq-chat-export-server/src/resource/handler.rs
+++ b/qq-chat-export-server/src/resource/handler.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use serde::Serialize;
@@ -10,6 +10,7 @@ use serde_json::Value;
 use tokio::sync::{Mutex, Semaphore};
 use tokio::task::JoinSet;
 
+use crate::export_debug::ExportDebugTrace;
 use crate::resource::circuit_breaker::CircuitBreaker;
 use crate::resource::health::{ResourceHealthChecker, RESOURCE_HEALTH_CACHE_MS};
 use crate::storage::{DatabaseManager, ResourceInfo};
@@ -284,6 +285,17 @@ impl ResourceHandler {
         messages: &[Value],
         cancel_flag: Arc<AtomicBool>,
     ) -> HashMap<String, Vec<ResourceInfo>> {
+        self.process_message_resources_with_cancel_and_trace(messages, cancel_flag, None)
+            .await
+    }
+
+    /// 批量处理消息资源，并把资源排队、调用耗时及重试结果写入可选调试轨迹。
+    pub async fn process_message_resources_with_cancel_and_trace(
+        self: &Arc<Self>,
+        messages: &[Value],
+        cancel_flag: Arc<AtomicBool>,
+        debug_trace: Option<ExportDebugTrace>,
+    ) -> HashMap<String, Vec<ResourceInfo>> {
         {
             let mut progress = self.progress.lock().await;
             *progress = ProgressCounters::default();
@@ -357,7 +369,7 @@ impl ResourceHandler {
         }
         if !tasks.is_empty() {
             self.emit_progress(None).await;
-            self.run_downloads(tasks, cancel_flag).await;
+            self.run_downloads(tasks, cancel_flag, debug_trace).await;
         }
 
         // 计算本批次摘要（issue #363）
@@ -516,6 +528,7 @@ impl ResourceHandler {
         self: &Arc<Self>,
         mut tasks: Vec<DownloadTask>,
         cancel_flag: Arc<AtomicBool>,
+        debug_trace: Option<ExportDebugTrace>,
     ) {
         tasks.sort_by_key(|task| std::cmp::Reverse(task.priority));
         self.is_downloading
@@ -527,9 +540,14 @@ impl ResourceHandler {
         for task in tasks {
             let handler = Arc::clone(self);
             let task_cancel_flag = Arc::clone(&cancel_flag);
+            let task_debug_trace = debug_trace.clone();
             join_set.spawn(async move {
                 handler
-                    .execute_download_with_retries(&task, task_cancel_flag.as_ref())
+                    .execute_download_with_retries(
+                        &task,
+                        task_cancel_flag.as_ref(),
+                        task_debug_trace.as_ref(),
+                    )
                     .await;
                 handler.pending_downloads.fetch_sub(1, Ordering::SeqCst);
             });
@@ -553,12 +571,18 @@ impl ResourceHandler {
     }
 
     /// 带重试的下载执行（对应 TS `executeDownload` + 队列重投逻辑）。
-    async fn execute_download_with_retries(&self, task: &DownloadTask, cancel_flag: &AtomicBool) {
+    async fn execute_download_with_retries(
+        &self,
+        task: &DownloadTask,
+        cancel_flag: &AtomicBool,
+        debug_trace: Option<&ExportDebugTrace>,
+    ) {
         let mut retries: u32 = 0;
         loop {
             if cancel_flag.load(Ordering::SeqCst) {
                 return;
             }
+            let queued_at = Instant::now();
             let permit = tokio::select! {
                 result = self.download_semaphore.acquire() => result.ok(),
                 () = wait_for_cancellation(cancel_flag) => None,
@@ -566,6 +590,29 @@ impl ResourceHandler {
             let Some(permit) = permit else {
                 return;
             };
+            let attempt = retries + 1;
+            let (resource_type, file_name) = {
+                let resource = task.resource.lock().await;
+                (
+                    resource.resource_type.clone(),
+                    resource.file_name.clone().unwrap_or_default(),
+                )
+            };
+            if let Some(trace) = debug_trace {
+                trace
+                    .record(serde_json::json!({
+                        "type": "resource_attempt_started",
+                        "messageId": task.msg_id,
+                        "elementId": task.element_id,
+                        "resourceType": resource_type,
+                        "fileName": file_name,
+                        "attempt": attempt,
+                        "queueWaitMs": queued_at.elapsed().as_millis(),
+                        "timeoutMs": self.config.download_timeout_ms,
+                    }))
+                    .await;
+            }
+            let started_at = Instant::now();
             let result = tokio::select! {
                 result = self.execute_download_once(task) => result,
                 () = wait_for_cancellation(cancel_flag) => return,
@@ -573,6 +620,20 @@ impl ResourceHandler {
             drop(permit);
             match result {
                 Ok(()) => {
+                    if let Some(trace) = debug_trace {
+                        trace
+                            .record(serde_json::json!({
+                                "type": "resource_attempt_finished",
+                                "messageId": task.msg_id,
+                                "elementId": task.element_id,
+                                "resourceType": resource_type,
+                                "fileName": file_name,
+                                "attempt": attempt,
+                                "durationMs": started_at.elapsed().as_millis(),
+                                "outcome": "downloaded",
+                            }))
+                            .await;
+                    }
                     let file_name = { task.resource.lock().await.file_name.clone() };
                     {
                         let mut progress = self.progress.lock().await;
@@ -597,6 +658,21 @@ impl ResourceHandler {
                             (is_retriable_error(&error_message), false)
                         }
                     };
+                    if let Some(trace) = debug_trace {
+                        trace
+                            .record(serde_json::json!({
+                                "type": "resource_attempt_finished",
+                                "messageId": task.msg_id,
+                                "elementId": task.element_id,
+                                "resourceType": resource_type,
+                                "fileName": file_name,
+                                "attempt": attempt,
+                                "durationMs": started_at.elapsed().as_millis(),
+                                "outcome": if retriable { "retry" } else if skipped { "skipped" } else { "failed" },
+                                "error": error_message,
+                            }))
+                            .await;
+                    }
                     {
                         let resource = task.resource.lock().await.clone();
                         if let Err(error) = self.db.save_resource_info(&resource).await {
@@ -1392,6 +1468,7 @@ mod tests {
                     .execute_download_with_retries(
                         &download_task("retry", "retry.jpg"),
                         cancel_flag.as_ref(),
+                        None,
                     )
                     .await;
             })
@@ -1406,6 +1483,7 @@ mod tests {
                     .execute_download_with_retries(
                         &download_task("next", "next.jpg"),
                         cancel_flag.as_ref(),
+                        None,
                     )
                     .await;
             })

--- a/qq-chat-export-server/src/scheduled_executor.rs
+++ b/qq-chat-export-server/src/scheduled_executor.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use async_trait::async_trait;
@@ -12,6 +13,7 @@ use qce_exporter::types::MessageResource;
 use qce_exporter::{ChatInfo, CleanMessage, ExportOptions};
 
 use qce_server::api::helpers::{chat_avatar_url, resolve_peer_uin};
+use qce_server::export_debug::ExportDebugSession;
 use qce_server::fetcher::{
     classify_chat_type_binary, BatchFetchConfig, BatchMessageFetcher, MessageFilter, Peer,
 };
@@ -84,6 +86,30 @@ impl ScheduledExportExecutor for ApiScheduledExportExecutor {
             .unwrap_or("HTML")
             .to_uppercase();
         let options = task.get("options").cloned().unwrap_or(Value::Null);
+        let output_dir = task
+            .get("outputDir")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map_or_else(|| self.path_manager.scheduled_exports_dir(), PathBuf::from);
+        let debug_session = if options.get("debugExport").and_then(Value::as_bool) == Some(true) {
+            let export_name = format!(
+                "scheduled-{}-{}",
+                sanitize_task_name(&task_name, 40),
+                chrono::Local::now().format("%Y%m%d_%H%M%S%3f")
+            );
+            let session = ExportDebugSession::start(&output_dir, &export_name).await?;
+            session
+                .trace()
+                .record(serde_json::json!({
+                    "type": "scheduled_export_started",
+                    "format": format,
+                }))
+                .await;
+            Some(session)
+        } else {
+            None
+        };
 
         // ============ 阶段 1：抓取消息 ============
         let fetcher = BatchMessageFetcher::new(
@@ -131,6 +157,11 @@ impl ScheduledExportExecutor for ApiScheduledExportExecutor {
 
         // 按时间升序排序（抓取返回的是倒序）。
         all_messages.sort_by_key(msg_time_ms);
+        if let Some(debug) = &debug_session {
+            debug
+                .write_jsonl("01-raw-messages.jsonl", &all_messages)
+                .await?;
+        }
 
         // ============ 阶段 2：资源下载（issue #341 跳过类型） ============
         let requested_skip_types: Vec<String> = options
@@ -165,7 +196,11 @@ impl ScheduledExportExecutor for ApiScheduledExportExecutor {
 
         let resource_map = self
             .resource_handler
-            .process_message_resources(&all_messages)
+            .process_message_resources_with_cancel_and_trace(
+                &all_messages,
+                Arc::new(AtomicBool::new(false)),
+                debug_session.as_ref().map(ExportDebugSession::trace),
+            )
             .await;
         // issue #363：资源下载摘要。
         let resource_summary =
@@ -174,12 +209,6 @@ impl ScheduledExportExecutor for ApiScheduledExportExecutor {
         self.resource_handler.set_skip_download_types(None).await;
 
         // ============ 阶段 3：文件名 / 输出目录 ============
-        let output_dir = task
-            .get("outputDir")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map_or_else(|| self.path_manager.scheduled_exports_dir(), PathBuf::from);
         tokio::fs::create_dir_all(&output_dir)
             .await
             .map_err(|e| format!("创建输出目录失败: {e}"))?;
@@ -211,6 +240,11 @@ impl ScheduledExportExecutor for ApiScheduledExportExecutor {
             forward_fetcher: Some(Arc::new(self.napcat.clone()) as Arc<dyn ForwardFetcher>),
         });
         let mut clean_messages: Vec<CleanMessage> = parser.parse_messages(&all_messages).await;
+        if let Some(debug) = &debug_session {
+            debug
+                .write_jsonl("02-parsed-messages.jsonl", &clean_messages)
+                .await?;
+        }
 
         // issue #277：把已下载资源的本地路径写回消息。
         let value_resource_map = to_value_resource_map(&resource_map);
@@ -220,6 +254,11 @@ impl ScheduledExportExecutor for ApiScheduledExportExecutor {
             }
         }
         SimpleMessageParser::backfill_reply_preview_local_paths(&mut clean_messages);
+        if let Some(debug) = &debug_session {
+            debug
+                .write_jsonl("03-final-messages.jsonl", &clean_messages)
+                .await?;
+        }
 
         let message_count = clean_messages.len() as i64;
         let self_info = self.napcat.self_info().await.unwrap_or(Value::Null);
@@ -331,6 +370,21 @@ impl ScheduledExportExecutor for ApiScheduledExportExecutor {
             .await
             .ok()
             .and_then(|meta| i64::try_from(meta.len()).ok());
+        if let Some(debug) = debug_session {
+            debug
+                .write_json(
+                    "summary.json",
+                    &serde_json::json!({
+                        "format": format,
+                        "messageCount": message_count,
+                        "resourceSummary": resource_summary,
+                        "finalFileName": file_name,
+                        "finalFileSize": file_size,
+                    }),
+                )
+                .await?;
+            debug.finish().await?;
+        }
 
         Ok(ExecutionOutcome {
             message_count,


### PR DESCRIPTION
## Summary
- fix NapCat `downloadMedia` destination argument ordering and record per-resource timing/retry outcomes in opt-in debug exports
- add default-off debug export options to normal, batch, and scheduled workflows
- distinguish sticker loading/error/empty states and remove collapsed filter spacing inflation

## Debug artifacts
`01-raw-messages.jsonl`, `02-parsed-messages.jsonl`, `03-final-messages.jsonl`, `04-events.jsonl`, and `summary.json` are written beside the export only when enabled.

## Verification
- `git diff --check`
- focused Rust regression started; full builds skipped at requester direction for immediate release