### PR TITLE
fix: restore frontend type checking

### DIFF
--- a/qce-v4-tool/components/ui/command.tsx
+++ b/qce-v4-tool/components/ui/command.tsx
@@ -34,13 +34,11 @@ function CommandDialog({
   description = "Search for a command to run...",
   children,
   className,
-  showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof Dialog> & {
   title?: string
   description?: string
   className?: string
-  showCloseButton?: boolean
 }) {
   return (
     <Dialog {...props}>
@@ -48,10 +46,7 @@ function CommandDialog({
         <DialogTitle>{title}</DialogTitle>
         <DialogDescription>{description}</DialogDescription>
       </DialogHeader>
-      <DialogContent
-        className={cn("overflow-hidden p-0", className)}
-        showCloseButton={showCloseButton}
-      >
+      <DialogContent className={cn("overflow-hidden p-0", className)}>
         <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/qce-v4-tool/hooks/use-config.ts
+++ b/qce-v4-tool/hooks/use-config.ts
@@ -9,6 +9,10 @@ export interface ConfigData {
   currentScheduledExportsDir: string
 }
 
+interface ConfigResponse extends ConfigData {
+  message?: string
+}
+
 export function useConfig() {
   const [config, setConfig] = useState<ConfigData | null>(null)
   const [loading, setLoading] = useState(false)
@@ -17,7 +21,7 @@ export function useConfig() {
   const loadConfig = useCallback(async () => {
     try {
       setLoading(true)
-      const response = await apiCall('/api/config')
+      const response = await apiCall<ConfigData>('/api/config')
       
       if (response.success && response.data) {
         setConfig(response.data)
@@ -35,7 +39,7 @@ export function useConfig() {
   }) => {
     try {
       setLoading(true)
-      const response = await apiCall('/api/config', {
+      const response = await apiCall<ConfigResponse>('/api/config', {
         method: 'PUT',
         body: JSON.stringify(updates)
       })

--- a/qce-v4-tool/hooks/use-resource-index.ts
+++ b/qce-v4-tool/hooks/use-resource-index.ts
@@ -184,7 +184,7 @@ export function useResourceIndex() {
         videoCount: 0,
         audioCount: 0,
         fileCount: 0,
-        exportCount: index?.exports?.length || 0
+        exportCount: 0
       };
     }
 

--- a/qce-v4-tool/hooks/use-theme-mode.ts
+++ b/qce-v4-tool/hooks/use-theme-mode.ts
@@ -70,10 +70,8 @@ export function useThemeMode() {
     }
 
     // Safari 老版本 fallback
-    // @ts-expect-error - legacy API
     mql.addListener(handler)
     return () => {
-      // @ts-expect-error - legacy API
       mql.removeListener(handler)
     }
   }, [])


### PR DESCRIPTION
## Summary
- add explicit API response types for config reads and updates
- remove unsupported dialog props and stale TypeScript suppressions
- simplify the empty resource-index statistics path

## Validation
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `git diff --check`