### PR TITLE
fix: inject release version into frontend build

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -50,7 +50,7 @@ jobs:
       - name: "Build frontend"
         run: |
           pnpm install --no-frozen-lockfile
-          pnpm run build
+          QCE_VERSION="${GITHUB_REF_NAME#v}" pnpm run build
         working-directory: qce-v4-tool
 
       - name: "Upload frontend artifact"


### PR DESCRIPTION
## Summary

Inject the release tag version into the static frontend build so `BuildFooter` renders the actual release client version instead of the stale package.json fallback.

```sh
QCE_VERSION="${GITHUB_REF_NAME#v}" pnpm run build
```

The existing `GITHUB_SHA` path continues to provide the dynamic build hash.

## Verification

- Built with `GITHUB_REF_NAME=v6.0.0-beta.64`
- Confirmed generated footer contains `Client v6.0.0-beta.64`
- Confirmed no `vv6.0.0-beta.64` output
- Workflow YAML parsed successfully