### PR TITLE
docs: 优化首页移动端堆叠卡片布局

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -134,10 +134,16 @@
         .card-chat iframe { width:600px; height:700px; }
 
         @media(max-width:900px){
-            .card-chat { display:none; }
+            .card-app {
+                width:92%; max-height:340px;
+            }
+            .card-chat {
+                left:auto; right:4%; width:min(230px,58%); height:250px;
+            }
         }
         @media(max-width:600px){
             .card-app { max-height:300px; }
+            .card-chat { height:220px; }
         }
     </style>
 </head>


### PR DESCRIPTION
移动端不再把 1633px 的桌面 demo 缩到不可读：小屏下会话卡片保持较大占宽（92%），聊天 demo 卡片缩小靠右前置叠放，保留桌面端的堆叠层次。