### PR TITLE
docs: 首页移动端隐藏 QCE 标识，文档站品牌改为斜杠分隔

### DIFF
--- a/public/docs/contributing.html
+++ b/public/docs/contributing.html
@@ -27,7 +27,7 @@
 </head>
 <body>
 <header class="topbar">
-  <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">文档</span></a>
+  <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">/ 文档</span></a>
   <span class="right">
     <a href="https://github.com/shuakami/qq-chat-exporter/releases" target="_blank">下载</a>
     <a href="https://github.com/shuakami/qq-chat-exporter" target="_blank">GitHub</a>
@@ -38,7 +38,7 @@
 </header>
 <div class="mnav" aria-hidden="true">
   <div class="mnav-head">
-    <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">文档</span></a>
+    <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">/ 文档</span></a>
     <button class="mnav-close" aria-label="关闭" onclick="document.body.classList.remove('nav-open')">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg>
     </button>

--- a/public/docs/docker-napcat-deployment.html
+++ b/public/docs/docker-napcat-deployment.html
@@ -27,7 +27,7 @@
 </head>
 <body>
 <header class="topbar">
-  <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">文档</span></a>
+  <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">/ 文档</span></a>
   <span class="right">
     <a href="https://github.com/shuakami/qq-chat-exporter/releases" target="_blank">下载</a>
     <a href="https://github.com/shuakami/qq-chat-exporter" target="_blank">GitHub</a>
@@ -38,7 +38,7 @@
 </header>
 <div class="mnav" aria-hidden="true">
   <div class="mnav-head">
-    <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">文档</span></a>
+    <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">/ 文档</span></a>
     <button class="mnav-close" aria-label="关闭" onclick="document.body.classList.remove('nav-open')">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg>
     </button>

--- a/public/docs/feedback.html
+++ b/public/docs/feedback.html
@@ -27,7 +27,7 @@
 </head>
 <body>
 <header class="topbar">
-  <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">文档</span></a>
+  <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">/ 文档</span></a>
   <span class="right">
     <a href="https://github.com/shuakami/qq-chat-exporter/releases" target="_blank">下载</a>
     <a href="https://github.com/shuakami/qq-chat-exporter" target="_blank">GitHub</a>
@@ -38,7 +38,7 @@
 </header>
 <div class="mnav" aria-hidden="true">
   <div class="mnav-head">
-    <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">文档</span></a>
+    <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">/ 文档</span></a>
     <button class="mnav-close" aria-label="关闭" onclick="document.body.classList.remove('nav-open')">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg>
     </button>

--- a/public/docs/guide.html
+++ b/public/docs/guide.html
@@ -27,7 +27,7 @@
 </head>
 <body>
 <header class="topbar">
-  <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">文档</span></a>
+  <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">/ 文档</span></a>
   <span class="right">
     <a href="https://github.com/shuakami/qq-chat-exporter/releases" target="_blank">下载</a>
     <a href="https://github.com/shuakami/qq-chat-exporter" target="_blank">GitHub</a>
@@ -38,7 +38,7 @@
 </header>
 <div class="mnav" aria-hidden="true">
   <div class="mnav-head">
-    <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">文档</span></a>
+    <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">/ 文档</span></a>
     <button class="mnav-close" aria-label="关闭" onclick="document.body.classList.remove('nav-open')">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg>
     </button>

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
 <header class="topbar">
-  <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">文档</span></a>
+  <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">/ 文档</span></a>
   <span class="right">
     <a href="https://github.com/shuakami/qq-chat-exporter/releases" target="_blank">下载</a>
     <a href="https://github.com/shuakami/qq-chat-exporter" target="_blank">GitHub</a>
@@ -38,7 +38,7 @@
 </header>
 <div class="mnav" aria-hidden="true">
   <div class="mnav-head">
-    <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">文档</span></a>
+    <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">/ 文档</span></a>
     <button class="mnav-close" aria-label="关闭" onclick="document.body.classList.remove('nav-open')">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg>
     </button>

--- a/public/docs/linux-deploy.html
+++ b/public/docs/linux-deploy.html
@@ -27,7 +27,7 @@
 </head>
 <body>
 <header class="topbar">
-  <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">文档</span></a>
+  <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">/ 文档</span></a>
   <span class="right">
     <a href="https://github.com/shuakami/qq-chat-exporter/releases" target="_blank">下载</a>
     <a href="https://github.com/shuakami/qq-chat-exporter" target="_blank">GitHub</a>
@@ -38,7 +38,7 @@
 </header>
 <div class="mnav" aria-hidden="true">
   <div class="mnav-head">
-    <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">文档</span></a>
+    <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">/ 文档</span></a>
     <button class="mnav-close" aria-label="关闭" onclick="document.body.classList.remove('nav-open')">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg>
     </button>

--- a/public/index.html
+++ b/public/index.html
@@ -134,6 +134,7 @@
         .card-chat iframe { width:600px; height:700px; }
 
         @media(max-width:900px){
+            nav .brand .pkg { display:none; }
             .card-app {
                 width:92%; max-height:340px;
             }

--- a/scripts/build-docs-site.py
+++ b/scripts/build-docs-site.py
@@ -246,7 +246,7 @@ TEMPLATE = '''<!doctype html>
 </head>
 <body>
 <header class="topbar">
-  <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">文档</span></a>
+  <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">/ 文档</span></a>
   <span class="right">
     <a href="https://github.com/shuakami/qq-chat-exporter/releases" target="_blank">下载</a>
     <a href="https://github.com/shuakami/qq-chat-exporter" target="_blank">GitHub</a>
@@ -257,7 +257,7 @@ TEMPLATE = '''<!doctype html>
 </header>
 <div class="mnav" aria-hidden="true">
   <div class="mnav-head">
-    <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">文档</span></a>
+    <a class="brand" href="../index.html">QQ Chat Exporter<span class="doc">/ 文档</span></a>
     <button class="mnav-close" aria-label="关闭" onclick="document.body.classList.remove('nav-open')">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg>
     </button>


### PR DESCRIPTION
首页移动端导航不再显示 QCE 小字；文档站顶栏与移动端导航品牌改为「QQ Chat Exporter / 文档」。