### PR TITLE
feat(release): 发版时自动生成 Update banner 并插入发布说明

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -492,6 +492,7 @@ jobs:
           else
             CHANGELOG="- 首次发布完整集成包"
           fi
+          printf '%s\n' "$CHANGELOG" | sed 's/^ *//' > CHANGELOG_RAW.txt
           
           # 判断是否为预发布版本
           PRERELEASE_NOTE=""
@@ -603,7 +604,25 @@ jobs:
           # 移除每行开头的空格
           sed -i 's/^          //' RELEASE_NOTES.md
           echo "已为版本 ${VERSION} 生成发布说明"
-      
+
+      - name: "生成 Release Banner"
+        id: release_banner
+        continue-on-error: true
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          npm install --no-save --no-package-lock playwright@1.49.1
+          npx playwright install --with-deps chromium
+          node scripts/generate-release-banner.mjs "$VERSION" CHANGELOG_RAW.txt "release-files/release-banner-${VERSION}.png"
+
+      - name: "将 Banner 插入发布说明"
+        if: steps.release_banner.outcome == 'success'
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          if [ -f "release-files/release-banner-${VERSION}.png" ]; then
+            printf '![%s](https://github.com/%s/releases/download/%s/release-banner-%s.png)\n\n' "$VERSION" "${GITHUB_REPOSITORY}" "$VERSION" "$VERSION" | cat - RELEASE_NOTES.md > RELEASE_NOTES.tmp
+            mv RELEASE_NOTES.tmp RELEASE_NOTES.md
+          fi
+
       - name: "创建 GitHub Release"
         uses: softprops/action-gh-release@v1
         with:
@@ -615,6 +634,7 @@ jobs:
             release-files/NapCat-Framework-QCE-${{ github.ref_name }}.zip
             release-files/napcat-plugin-qce.zip
             release-files/QQChatExporter-Installer-${{ github.ref_name }}.exe
+            release-files/release-banner-${{ github.ref_name }}.png
           draft: false
           prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
           generate_release_notes: false

--- a/scripts/generate-release-banner.mjs
+++ b/scripts/generate-release-banner.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * 生成 Release Update Banner。
+ *
+ * 用法: node scripts/generate-release-banner.mjs <version> <changelog.txt> <output.png>
+ * changelog.txt 为每行一条的 commit subject 列表。
+ */
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { chromium } from 'playwright';
+
+const [version, changelogPath, outputPath] = process.argv.slice(2);
+if (!version || !changelogPath || !outputPath) {
+  console.error('usage: generate-release-banner.mjs <version> <changelog.txt> <output.png>');
+  process.exit(1);
+}
+
+const MAX_ITEMS = 6;
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const escapeHtml = (s) => s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+
+const seen = new Set();
+const items = [];
+for (const line of readFileSync(changelogPath, 'utf8').split('\n')) {
+  const t = line.replace(/^-\s*/, '').replace(/\s*\(#\d+\)\s*$/, '').trim();
+  if (t && !seen.has(t)) { seen.add(t); items.push(t); }
+}
+
+function renderItem(t) {
+  const m = t.match(/^(feat|fix|perf|docs|test|chore|refactor|style|build|ci)(\(([^)]+)\))?\s*:\s*(.*)$/);
+  if (!m) return `<li><span>${escapeHtml(t)}</span></li>`;
+  const [, typ, , scope, rest] = m;
+  const cls = ['feat', 'fix', 'perf', 'docs'].includes(typ) ? typ : 'other';
+  const label = escapeHtml(typ) + (scope ? `<span class="scope"> ${escapeHtml(scope)}</span>` : '');
+  return `<li><span class="ct ct-${cls}">${label}</span><span>${escapeHtml(rest)}</span></li>`;
+}
+
+let lis = items.slice(0, MAX_ITEMS).map(renderItem).join('');
+if (items.length > MAX_ITEMS) {
+  lis += `<li class="more">…以及另外 ${items.length - MAX_ITEMS} 项改进</li>`;
+}
+
+const template = readFileSync(join(repoRoot, 'scripts', 'release-banner-template.html'), 'utf8');
+const html = template
+  .replace('{{VERSION_MARK}}', 'Update')
+  .replace('{{TAG}}', escapeHtml(version))
+  .replace('{{ITEMS}}', lis)
+  .replace('{{UI_URL}}', pathToFileURL(join(repoRoot, 'public', 'assets', 'home', 'app', 'index.html')).href)
+  .replace('{{SHADER_URL}}', pathToFileURL(join(repoRoot, 'public', 'assets', 'vendor', 'paper-shaders-0.0.77.js')).href);
+
+const htmlPath = join(mkdtempSync(join(tmpdir(), 'qce-banner-')), 'banner.html');
+writeFileSync(htmlPath, html);
+
+const browser = await chromium.launch({ args: ['--allow-file-access-from-files'] });
+const page = await (await browser.newContext({
+  viewport: { width: 1700, height: 900 },
+  deviceScaleFactor: 2,
+})).newPage();
+await page.goto(pathToFileURL(htmlPath).href);
+await page.waitForFunction('window.__shaderReady === true', null, { timeout: 30000 }).catch(() => {});
+await page.waitForTimeout(3000);
+await page.locator('.banner').screenshot({ path: outputPath });
+await browser.close();
+console.log(outputPath);

--- a/scripts/release-banner-template.html
+++ b/scripts/release-banner-template.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8" />
+<title>QCE Release Banner</title>
+<link rel="preconnect" href="https://fonts.loli.net">
+<link href="https://fonts.loli.net/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Noto+Sans+SC:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; padding:0; box-sizing:border-box; }
+  html,body { background:transparent; }
+  body { font-family: Inter, "Noto Sans SC", system-ui, sans-serif; color:#18181b; -webkit-font-smoothing:antialiased; }
+  .banner { position:relative; width:1600px; height:800px; overflow:hidden; }
+  .frame {
+    position:absolute; inset:0; border-radius:12px; overflow:hidden;
+    border:1px solid rgba(24,24,27,0.10); background:#ffffff;
+  }
+  #shader { position:absolute; inset:0; }
+  .wordmark {
+    position:absolute; left:0; right:0; top:64px; z-index:1;
+    text-align:center; font-weight:700; letter-spacing:-0.04em; line-height:1; white-space:nowrap;
+    font-size:150px; user-select:none; pointer-events:none;
+        background:linear-gradient(to bottom, rgba(49,124,254,0.13), rgba(49,124,254,0.02));
+    -webkit-background-clip:text; background-clip:text; color:transparent;
+  }
+  .copy { position:absolute; left:84px; top:200px; z-index:3; max-width:600px; }
+  h1 { font-size:52px; font-weight:700; letter-spacing:-0.04em; line-height:1.12; }
+  ul { list-style:none; margin-top:26px; }
+  ul li {
+    display:flex; align-items:baseline; gap:10px; margin:12px 0;
+    font-size:16px; line-height:1.5; color:#3f3f46;
+  }
+  ul li.more { color:#a1a1aa; }
+  .ct {
+    flex:none; font-family:"JetBrains Mono",monospace; font-size:11.5px; font-weight:500;
+    padding:2.5px 8px; border-radius:6px; letter-spacing:0;
+    position:relative; top:-2px;
+  }
+  .ct-feat { background:rgba(49,124,254,0.10); color:#1d4ed8; }
+  .ct-fix { background:rgba(234,88,12,0.10); color:#c2410c; }
+  .ct-perf { background:rgba(147,51,234,0.10); color:#7e22ce; }
+  .ct-docs { background:rgba(24,24,27,0.06); color:#52525b; }
+  .ct-other { background:rgba(24,24,27,0.06); color:#52525b; }
+  .scope { color:inherit; opacity:0.65; }
+  ul li code { font-family:"JetBrains Mono",monospace; font-size:0.86em; background:rgba(24,24,27,0.05); border-radius:5px; padding:2px 6px; }
+  .shot {
+    position:absolute; left:760px; top:236px; right:-80px; bottom:-2px; z-index:2;
+    border-radius:16px 0 0 0; overflow:hidden;
+    border:1px solid rgba(24,24,27,0.08); border-right:none; border-bottom:none;
+    box-shadow:
+      0 2px 4px rgba(24,24,27,0.04),
+      0 16px 32px -8px rgba(24,24,27,0.10),
+      0 56px 112px -28px rgba(24,124,254,0.16);
+    background:#fff;
+  }
+  .shot iframe { border:0; display:block; width:1633px; height:952px; transform-origin:0 0; pointer-events:none; background:#fff; }
+</style>
+</head>
+<body>
+<div class="banner">
+  <div class="frame">
+    <div id="shader"></div>
+    <div class="wordmark">{{VERSION_MARK}}</div>
+    <div class="copy">
+      <h1>{{TAG}}</h1>
+      <ul>{{ITEMS}}</ul>
+    </div>
+    <div class="shot"><iframe src="{{UI_URL}}"></iframe></div>
+  </div>
+</div>
+<script>
+  (function(){
+    function fit(){
+      var el = document.querySelector('.shot');
+      var f = el.querySelector('iframe');
+      var s = el.clientWidth / 1633;
+      f.style.transform = 'scale(' + s + ')';
+      f.style.height = (el.clientHeight / s) + 'px';
+    }
+    window.addEventListener('load', fit); fit();
+  })();
+</script>
+<script type="module">
+  var m = await import('{{SHADER_URL}}');
+  var s = m.defaultObjectSizing;
+  var host = document.getElementById('shader');
+  var tex = m.getShaderNoiseTexture();
+  if (tex && !(tex.complete && tex.naturalWidth)) {
+    await new Promise(function(r){ tex.onload = r; tex.onerror = r; });
+  }
+  new m.ShaderMount(host, m.grainGradientFragmentShader, {
+    u_colorBack: m.getShaderColorFromString('#00000000'),
+    u_colors: ['#f0f5ff', '#d9e6ff', '#317cfe10'].map(m.getShaderColorFromString),
+    u_colorsCount: 3,
+    u_softness: 1, u_intensity: 0.38, u_noise: 0.1,
+    u_shape: m.GrainGradientShapes.corners,
+    u_noiseTexture: tex,
+    u_fit: m.ShaderFitOptions[s.fit], u_scale: s.scale, u_rotation: s.rotation,
+    u_offsetX: s.offsetX, u_offsetY: s.offsetY,
+    u_originX: s.originX, u_originY: s.originY,
+    u_worldWidth: s.worldWidth, u_worldHeight: s.worldHeight
+  }, undefined, 0.4, 0, 1, 1920 * 1080);
+  requestAnimationFrame(function(){ requestAnimationFrame(function(){ window.__shaderReady = true; }); });
+</script>
+</body>
+</html>


### PR DESCRIPTION
发版时在 create-release 作业中自动生成 Update banner：

- 新增 `scripts/release-banner-template.html` 与 `scripts/generate-release-banner.mjs`：解析 changelog（去重、识别 feat/fix/docs/perf 等前缀渲染彩色标签，最多 6 条 + 汇总行），shader 背景 + 实时渲染当前 UI demo，Playwright 截图输出 PNG
- `release-plugin.yml`：生成 `CHANGELOG_RAW.txt`，新增「生成 Release Banner」步骤（`continue-on-error`，失败不阻塞发版），成功时把 banner 图插入发布说明顶部并作为 release asset 上传