### PR TITLE
fix(ui): keep sticker list visible during export and surface updates

### DIFF
--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -36,6 +36,7 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu"
 import {
   Download,
@@ -82,6 +83,7 @@ import {
 } from "lucide-react"
 import type { CreateTaskForm, CreateScheduledExportForm } from "@/types/api"
 import { useQCE } from "@/hooks/use-qce"
+import { BUILD_VERSION, isNewerVersion } from "@/lib/version"
 import { useScheduledExports } from "@/hooks/use-scheduled-exports"
 import { useChatHistory } from "@/hooks/use-chat-history"
 import { useStickerPacks } from "@/hooks/use-sticker-packs"
@@ -199,6 +201,7 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
   
   // GitHub stars
   const [githubStars, setGithubStars] = useState<number | null>(null)
+  const [updateInfo, setUpdateInfo] = useState<{ tag: string; url: string } | null>(null)
   
   // 定时导出筛选状态
   const [scheduledFilter, setScheduledFilter] = useState<'all' | 'enabled' | 'disabled'>('all')
@@ -422,6 +425,30 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
     openTaskFileLocation,
   } = useQCE({ onNotification: handleQceNotification })
 
+  useEffect(() => {
+    const currentVersion = systemInfo?.version || BUILD_VERSION
+    if (!currentVersion || currentVersion === 'unknown') return
+
+    const checkUpdate = async () => {
+      try {
+        const res = await fetch('https://api.github.com/repos/shuakami/qq-chat-exporter/releases?per_page=1')
+        if (!res.ok) return
+
+        const releases = await res.json()
+        const latest = releases?.[0]
+        if (latest?.tag_name && latest?.html_url && isNewerVersion(latest.tag_name, currentVersion)) {
+          setUpdateInfo({ tag: latest.tag_name, url: latest.html_url })
+        } else {
+          setUpdateInfo(null)
+        }
+      } catch {
+        // 静默失败
+      }
+    }
+
+    checkUpdate()
+  }, [systemInfo?.version])
+
   // 打开群精华消息模态框
   const handleOpenEssenceModal = useCallback((groupCode: string, groupName: string) => {
     setEssenceGroup({ groupCode, groupName })
@@ -549,6 +576,7 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
     packs: stickerPacks,
     exportRecords: stickerExportRecords,
     loading: stickerPacksLoading,
+    exporting: stickerPacksExporting,
     error: stickerPacksError,
     loadStickerPacks,
     loadExportRecords: loadStickerExportRecords,
@@ -657,9 +685,7 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
           ] : undefined,
           0
         )
-        stickerPacksLoadedRef.current = false
-        await Promise.all([loadStickerPacks(), loadStickerExportRecords()])
-        stickerPacksLoadedRef.current = true
+        await loadStickerExportRecords()
       } else {
         addNotification('error', '导出失败', `表情包"${packName}"导出失败`)
       }
@@ -691,9 +717,7 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
           ] : undefined,
           0
         )
-        stickerPacksLoadedRef.current = false
-        await Promise.all([loadStickerPacks(), loadStickerExportRecords()])
-        stickerPacksLoadedRef.current = true
+        await loadStickerExportRecords()
       } else {
         addNotification('error', '导出失败', '表情包导出失败')
       }
@@ -1441,11 +1465,36 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
                     {/* Help dropdown (docs) */}
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <button className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-black/[0.04] dark:hover:bg-white/[0.04] transition-colors">
+                        <button
+                          className="relative inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-black/[0.04] dark:hover:bg-white/[0.04] transition-colors"
+                          aria-label={updateInfo ? `帮助，有新版本 ${updateInfo.tag}` : '帮助'}
+                        >
                           <HelpCircle className="w-4 h-4" />
+                          {updateInfo && (
+                            <span className="absolute right-1 top-1 h-2 w-2 rounded-full bg-red-500 ring-2 ring-card" />
+                          )}
                         </button>
                       </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end" className="rounded-xl border-black/[0.06] dark:border-white/[0.08] shadow-xl min-w-[140px]">
+                      <DropdownMenuContent align="end" className="rounded-xl border-black/[0.06] dark:border-white/[0.08] shadow-xl min-w-[220px]">
+                        {updateInfo && (
+                          <>
+                            <DropdownMenuItem asChild>
+                              <a
+                                href={updateInfo.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="flex cursor-pointer flex-col items-start gap-0.5 py-2"
+                              >
+                                <span className="text-[13px] font-medium text-foreground">发现新版本</span>
+                                <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                                  <span>{updateInfo.tag}</span>
+                                  <span>查看更新内容</span>
+                                </span>
+                              </a>
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                          </>
+                        )}
                         <DropdownMenuItem asChild>
                           <a
                             href="https://shuakami.github.io/qq-chat-exporter/"
@@ -1639,7 +1688,7 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
                       stickerPacksLoadedRef.current = false
                     }
                   }}
-                  disabled={stickerPacksLoading}
+                  disabled={stickerPacksLoading || stickerPacksExporting}
                 >
                   {stickerPacksLoading ? <Loader size={16} /> : <RefreshCw className="w-4 h-4" />}
                 </Button>
@@ -1647,7 +1696,7 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
                   size="sm"
                   className="h-8 text-[13px] rounded-full px-2.5"
                   onClick={handleExportAllStickerPacks}
-                  disabled={stickerPacksLoading || stickerPacks.length === 0}
+                  disabled={stickerPacksLoading || stickerPacksExporting || stickerPacks.length === 0}
                 >
                   导出所有
                 </Button>
@@ -2717,7 +2766,7 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
                           <button
                             className="text-[11px] text-muted-foreground/40 hover:text-foreground transition-colors flex-shrink-0 ml-4 opacity-0 group-hover:opacity-100"
                             onClick={() => handleExportStickerPack(pack.packId, pack.packName)}
-                            disabled={stickerPacksLoading}
+                            disabled={stickerPacksLoading || stickerPacksExporting}
                           >
                             导出
                           </button>

--- a/qce-v4-tool/e2e/ui-smoke.spec.ts
+++ b/qce-v4-tool/e2e/ui-smoke.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import { test, expect } from '@playwright/test';
+import { isNewerVersion } from '../lib/version';
 
 const TOKEN = process.env.QCE_MOCK_TOKEN ?? 'qce_mock_token_for_tests';
 const FRONTEND_BASE = process.env.E2E_FRONTEND_URL ?? 'http://localhost:40653';
@@ -136,6 +137,55 @@ test.describe('Auth flow', () => {
         // The URL the browser would record in history (after replaceState)
         // must no longer contain the token.
         expect(page.url()).not.toContain('token=');
+    });
+});
+
+test.describe('Version updates', () => {
+    test('compares prerelease and stable versions in release order', () => {
+        expect(isNewerVersion('v6.0.0-beta.65', '6.0.0-beta.64')).toBe(true);
+        expect(isNewerVersion('v6.0.0', '6.0.0-rc.2')).toBe(true);
+        expect(isNewerVersion('v6.0.0-beta.66', '6.0.0')).toBe(false);
+        expect(isNewerVersion('v6.0.1-beta.1', '6.0.0')).toBe(true);
+        expect(isNewerVersion('latest', '6.0.0')).toBe(false);
+    });
+
+    test('shows a red help indicator and update entry for a newer release', async ({ page }) => {
+        await clearLocalStorage(page);
+        await page.evaluate((value) => {
+            localStorage.setItem('qce_access_token', value);
+        }, TOKEN);
+        await page.route(
+            'https://api.github.com/repos/shuakami/qq-chat-exporter/releases?**',
+            async (route) => {
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify([{
+                        tag_name: 'v6.0.0',
+                        html_url: 'https://github.com/shuakami/qq-chat-exporter/releases/tag/v6.0.0',
+                    }]),
+                });
+            }
+        );
+
+        const response = await page
+            .goto(`${FRONTEND_BASE}${SHELL_PATH}`)
+            .catch(() => null);
+        test.skip(
+            !response || response.status() >= 500,
+            `frontend not reachable at ${FRONTEND_BASE}`
+        );
+
+        const helpButton = page.getByRole('button', { name: '帮助，有新版本 v6.0.0' });
+        await expect(helpButton).toBeVisible({ timeout: 15_000 });
+        const skipBtn = page.getByRole('button', { name: '跳过' }).first();
+        if (await skipBtn.isVisible({ timeout: 1500 }).catch(() => false)) {
+            await skipBtn.click();
+        }
+        await helpButton.click();
+        await expect(page.getByText('发现新版本', { exact: true })).toBeVisible();
+        await expect(page.getByText('v6.0.0', { exact: true })).toBeVisible();
+        await expect(page.getByText('查看更新内容', { exact: true })).toBeVisible();
     });
 });
 
@@ -304,6 +354,111 @@ test.describe('Session list — QQ lookup (issue #204)', () => {
 
         // mock 的 getUidByUinV2 对未登记 uin 返 undefined，落到 found=false。
         await expect(page.getByText(/未在本机 NTQQ 数据中找到/)).toBeVisible({ timeout: 10_000 });
+    });
+});
+
+test.describe('Sticker exports', () => {
+    test('exporting keeps the loaded sticker list visible', async ({ page }) => {
+        await clearLocalStorage(page);
+        await page.evaluate((value) => {
+            localStorage.setItem('qce_access_token', value);
+        }, TOKEN);
+
+        let releaseExport!: () => void;
+        const exportGate = new Promise<void>((resolve) => {
+            releaseExport = resolve;
+        });
+        let markExportStarted!: () => void;
+        const exportStarted = new Promise<void>((resolve) => {
+            markExportStarted = resolve;
+        });
+
+        await page.route('**/api/sticker-packs**', async (route, request) => {
+            const url = new URL(request.url());
+            if (request.method() === 'GET' && url.pathname.endsWith('/export-records')) {
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        success: true,
+                        data: { records: [], totalCount: 0 },
+                    }),
+                });
+                return;
+            }
+            if (request.method() === 'GET') {
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        success: true,
+                        data: {
+                            packs: [{
+                                packId: 'regression-pack',
+                                packName: '回归测试表情包',
+                                packType: 'favorite_emoji',
+                                stickerCount: 1,
+                                stickers: [],
+                            }],
+                            stats: {
+                                favorite_emoji: 1,
+                                market_pack: 0,
+                                system_pack: 0,
+                            },
+                            totalCount: 1,
+                            totalStickers: 1,
+                        },
+                    }),
+                });
+                return;
+            }
+            if (request.method() === 'POST' && url.pathname.endsWith('/export')) {
+                markExportStarted();
+                await exportGate;
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        success: true,
+                        data: {
+                            success: true,
+                            packCount: 1,
+                            stickerCount: 1,
+                            exportPath: '/tmp/sticker-export',
+                        },
+                    }),
+                });
+                return;
+            }
+            await route.continue();
+        });
+
+        const response = await page
+            .goto(`${FRONTEND_BASE}/qce/stickers`)
+            .catch(() => null);
+        test.skip(
+            !response || response.status() >= 500,
+            `frontend not reachable at ${FRONTEND_BASE}`
+        );
+
+        const packName = page.getByText('回归测试表情包', { exact: true });
+        await expect(packName).toBeVisible({ timeout: 15_000 });
+        const skipBtn = page.getByRole('button', { name: '跳过' }).first();
+        if (await skipBtn.isVisible({ timeout: 1500 }).catch(() => false)) {
+            await skipBtn.click();
+        }
+        const packRow = packName.locator('xpath=ancestor::div[contains(@class,"group")]');
+        await packRow.hover();
+        await packRow.getByRole('button', { name: '导出', exact: true }).click();
+        await exportStarted;
+
+        await expect(packName).toBeVisible();
+        await expect(page.getByText('正在加载表情包...')).toBeHidden();
+
+        releaseExport();
+        await expect(page.getByText('表情包“回归测试表情包”已导出')).toBeVisible({
+            timeout: 15_000,
+        });
     });
 });
 

--- a/qce-v4-tool/hooks/use-sticker-packs.ts
+++ b/qce-v4-tool/hooks/use-sticker-packs.ts
@@ -58,6 +58,7 @@ export function useStickerPacks() {
   })
   const [exportRecords, setExportRecords] = useState<ExportRecord[]>([])
   const [loading, setLoading] = useState(false)
+  const [exporting, setExporting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   // 加载表情包列表
@@ -93,7 +94,7 @@ export function useStickerPacks() {
 
   // 导出指定表情包
   const exportStickerPack = useCallback(async (packId: string): Promise<ExportResult | null> => {
-    setLoading(true)
+    setExporting(true)
     setError(null)
     
     try {
@@ -113,13 +114,13 @@ export function useStickerPacks() {
       console.error('[useStickerPacks] 导出失败:', err)
       return null
     } finally {
-      setLoading(false)
+      setExporting(false)
     }
   }, [api])
 
   // 导出所有表情包
   const exportAllStickerPacks = useCallback(async (): Promise<ExportResult | null> => {
-    setLoading(true)
+    setExporting(true)
     setError(null)
     
     try {
@@ -139,13 +140,12 @@ export function useStickerPacks() {
       console.error('[useStickerPacks] 导出所有失败:', err)
       return null
     } finally {
-      setLoading(false)
+      setExporting(false)
     }
   }, [api])
 
   // 加载导出记录
   const loadExportRecords = useCallback(async (limit: number = 50) => {
-    setLoading(true)
     setError(null)
 
     try {
@@ -165,8 +165,6 @@ export function useStickerPacks() {
       const errorMessage = err instanceof Error ? err.message : '加载导出记录失败'
       setError(errorMessage)
       console.error('[useStickerPacks] 加载导出记录失败:', err)
-    } finally {
-      setLoading(false)
     }
   }, [api])
 
@@ -184,6 +182,7 @@ export function useStickerPacks() {
     stats,
     exportRecords,
     loading,
+    exporting,
     error,
     loadStickerPacks,
     loadExportRecords,
@@ -193,4 +192,3 @@ export function useStickerPacks() {
     setError
   }
 }
-

--- a/qce-v4-tool/lib/version.ts
+++ b/qce-v4-tool/lib/version.ts
@@ -19,6 +19,43 @@ export function getVersionDisplay(apiVersion?: string): string {
     return BUILD_VERSION;
 }
 
+function parseVersion(version: string): number[] | null {
+    const match = version
+        .trim()
+        .replace(/^v/i, '')
+        .match(/^(\d+)\.(\d+)\.(\d+)(?:-(alpha|beta|rc)\.(\d+))?$/i);
+    if (!match) {
+        return null;
+    }
+
+    const channel = match[4]?.toLowerCase();
+    const channelRank = channel
+        ? { alpha: 0, beta: 1, rc: 2 }[channel as 'alpha' | 'beta' | 'rc']
+        : 3;
+    return [
+        Number(match[1]),
+        Number(match[2]),
+        Number(match[3]),
+        channelRank,
+        match[5] ? Number(match[5]) : 0,
+    ];
+}
+
+export function isNewerVersion(latest: string, current: string): boolean {
+    const latestParts = parseVersion(latest);
+    const currentParts = parseVersion(current);
+    if (!latestParts || !currentParts) {
+        return false;
+    }
+
+    for (let index = 0; index < latestParts.length; index += 1) {
+        if (latestParts[index] !== currentParts[index]) {
+            return latestParts[index] > currentParts[index];
+        }
+    }
+    return false;
+}
+
 /** 检查版本是否匹配 */
 export function checkVersionMatch(apiVersion?: string): {
     match: boolean;


### PR DESCRIPTION
## Summary
- Separate sticker-list loading from export activity so exporting one or all packs keeps the loaded list visible.
- Refresh only export history after a successful export while disabling duplicate export and refresh actions during the active export.
- Add semantic release comparison and a user-approved help-menu update indicator linking to newer GitHub releases.

## Verification
- `npx -y pnpm@9.15.9 run build`
- `npx -y tsc --noEmit --pretty false`
- `E2E_FRONTEND_URL=http://localhost:40653 npx -y pnpm@9.15.9 exec playwright test` (19 passed)