### PR TITLE
docs: fix repository license link

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,15 @@ updates:
       - "/uninstaller"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
+    open-pull-requests-limit: 2
+    groups:
+      npm-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ docker logs -f napcat-qce
 [releases-link]: https://github.com/shuakami/qq-chat-exporter/releases
 [issues-link]: https://github.com/shuakami/qq-chat-exporter/issues
 [stars-link]: https://github.com/shuakami/qq-chat-exporter/stargazers
-[license-link]: https://github.com/shuakami/qq-chat-exporter/blob/main/LICENSE
+[license-link]: LICENSE
 [docker-doc]: https://shuakami.github.io/qq-chat-exporter/docs/docker-napcat-deployment.html
 [github-release-shield]: https://img.shields.io/github/v/release/shuakami/qq-chat-exporter?color=317cfe&labelColor=black&logo=github&style=flat-square
 [github-downloads-shield]: https://img.shields.io/github/downloads/shuakami/qq-chat-exporter/total?color=317cfe&labelColor=black&style=flat-square


### PR DESCRIPTION
## Summary
- Point the README license reference at the repository-relative `LICENSE` file instead of the nonexistent `main` branch.
- Group Dependabot minor/patch updates across the real JavaScript packages, cap concurrent update PRs, and ignore automatic major-version jumps.
- Remove the newly enabled GitHub Actions update stream to avoid unrelated repository-maintenance PR noise.

## Verification
- `LICENSE` exists on `master` through the GitHub contents API.
- Dependabot YAML parses successfully with one grouped npm policy and a two-PR cap.
- `git diff --check` passed.

The ungrouped Dependabot PRs generated immediately after #556 are superseded and will be closed. No release tag is created.