### PR TITLE
feat(release): 正式版自动聚合全部预发布更新日志，banner 优先展示 feat/fix

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -478,21 +478,43 @@ jobs:
           VERSION="${GITHUB_REF#refs/tags/}"
           NAPCAT_VERSION="${{ needs.get-napcat-version.outputs.version }}"
           
-          # 获取上一个 tag
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          # 获取上一个 tag：正式版对比上一个正式版（跳过 alpha/beta/rc，聚合全部预发布的更新）
+          if [[ "$VERSION" == *"alpha"* ]] || [[ "$VERSION" == *"beta"* ]] || [[ "$VERSION" == *"rc"* ]]; then
+            PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          else
+            PREV_TAG=$(git tag --merged HEAD^ --sort=-v:refname | grep -vE -- '-(alpha|beta|rc)' | head -n 1 || echo "")
+          fi
           
           # 生成更新内容
+          NL=$'\n'
           CHANGELOG=""
           if [ -n "$PREV_TAG" ]; then
-            while IFS= read -r commit; do
-              subject=$(git log -1 --format="%s" "$commit")
-              CHANGELOG="${CHANGELOG}- ${subject}
-          "
-            done < <(git log ${PREV_TAG}..HEAD --format="%H" --reverse)
+            git log "${PREV_TAG}..HEAD" --format="- %s" --reverse > CHANGELOG_RAW.txt
+            if [[ "$VERSION" == *"alpha"* ]] || [[ "$VERSION" == *"beta"* ]] || [[ "$VERSION" == *"rc"* ]]; then
+              CHANGELOG=$(cat CHANGELOG_RAW.txt)
+            else
+              # 正式版：按预发布 tag 分段聚合全部更新日志
+              SEG_TAGS=$(git tag --merged HEAD --no-merged "$PREV_TAG" --sort=v:refname | grep -v "^${VERSION}\$" || true)
+              seg_prev="$PREV_TAG"
+              for seg_tag in $SEG_TAGS; do
+                body=$(git log "${seg_prev}..${seg_tag}" --format="- %s" --reverse)
+                if [ -n "$body" ]; then
+                  CHANGELOG="${CHANGELOG}#### ${seg_tag}${NL}${NL}${body}${NL}${NL}"
+                fi
+                seg_prev="$seg_tag"
+              done
+              body=$(git log "${seg_prev}..HEAD" --format="- %s" --reverse)
+              if [ -n "$body" ]; then
+                CHANGELOG="${CHANGELOG}#### ${VERSION}${NL}${NL}${body}${NL}"
+              fi
+              if [ -z "$CHANGELOG" ]; then
+                CHANGELOG=$(cat CHANGELOG_RAW.txt)
+              fi
+            fi
           else
             CHANGELOG="- 首次发布完整集成包"
+            printf '%s\n' "$CHANGELOG" > CHANGELOG_RAW.txt
           fi
-          printf '%s\n' "$CHANGELOG" | sed 's/^ *//' > CHANGELOG_RAW.txt
           
           # 判断是否为预发布版本
           PRERELEASE_NOTE=""

--- a/scripts/generate-release-banner.mjs
+++ b/scripts/generate-release-banner.mjs
@@ -38,7 +38,23 @@ function renderItem(t) {
   return `<li><span class="ct ct-${cls}">${label}</span><span>${escapeHtml(rest)}</span></li>`;
 }
 
-let lis = items.slice(0, MAX_ITEMS).map(renderItem).join('');
+const PRIORITY = { feat: 0, fix: 1, perf: 2 };
+function rank(t) {
+  const m = t.match(/^(\w+)(\([^)]+\))?\s*:/);
+  return m && m[1] in PRIORITY ? PRIORITY[m[1]] : 3;
+}
+
+let selected = items;
+if (items.length > MAX_ITEMS) {
+  selected = items
+    .map((t, i) => ({ t, i, r: rank(t) }))
+    .sort((a, b) => a.r - b.r || a.i - b.i)
+    .slice(0, MAX_ITEMS)
+    .sort((a, b) => a.i - b.i)
+    .map((x) => x.t);
+}
+
+let lis = selected.map(renderItem).join('');
 if (items.length > MAX_ITEMS) {
   lis += `<li class="more">…以及另外 ${items.length - MAX_ITEMS} 项改进</li>`;
 }


### PR DESCRIPTION
## 说明

正式版（无 alpha/beta/rc 后缀）发版时，更新日志此前只对比上一个 tag（通常是最后一个 beta），导致所有 beta 期间的更新丢失。

- `release-plugin.yml`：正式版的 `PREV_TAG` 改为上一个正式版 tag（跳过全部预发布 tag），完整聚合期间所有提交；发布说明中按各预发布 tag 分组（`#### v6.0.0-beta.x` 小标题），全部完整列出并折叠在「完整更新内容」里。
- `generate-release-banner.mjs`：changelog 条目超过 6 条时优先展示 feat > fix > perf，避免正式版 banner 被 chore/docs 占满。
