### PR TITLE
fix(release): 发布说明 Contributors 图与 README 保持一致（大图）

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -619,7 +619,7 @@ jobs:
           ### Contributors
 
           <a href="https://github.com/shuakami/qq-chat-exporter/graphs/contributors">
-            <img src="https://contrib.rocks/image?repo=shuakami/qq-chat-exporter&max=12&columns=12" width="125" />
+            <img src="https://contrib.rocks/image?repo=shuakami/qq-chat-exporter" alt="Contributors" />
           </a>
           EOF
           


### PR DESCRIPTION
发布说明底部的 contrib.rocks 图从 `max=12&columns=12 width=125` 的小图改为与 README 相同的默认大图。