### PR TITLE
docs: 相关项目卡片去掉表格边框，改为并排图片

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,14 @@ docker logs -f napcat-qce
 
 [![ChatLab](docs/images/bento-chatlab.png)](https://chatlab.fun/cn)
 
-<table>
-  <tr>
-    <td width="50%"><a href="https://github.com/Ruoan-486/QCE2Chatlab"><img src="docs/images/bento-qce2chatlab.png" alt="QCE2ChatLab"></a></td>
-    <td width="50%"><a href="https://github.com/CutrelyAlex/QQChatAnalyzer"><img src="docs/images/bento-qqchatanalyzer.png" alt="QQChatAnalyzer"></a></td>
-  </tr>
-  <tr>
-    <td width="50%"><a href="https://github.com/JUSTMONIKA2022/QQ-Chat-AI-Analyzer"><img src="docs/images/bento-qq-chat-ai-analyzer.png" alt="QQ-Chat-AI-Analyzer"></a></td>
-    <td width="50%"><a href="https://github.com/streetartist/napcat-qce-python"><img src="docs/images/bento-napcat-qce-python.png" alt="napcat-qce-python"></a></td>
-  </tr>
-</table>
+<p>
+  <a href="https://github.com/Ruoan-486/QCE2Chatlab"><img src="docs/images/bento-qce2chatlab.png" alt="QCE2ChatLab" width="49.4%"></a>
+  <a href="https://github.com/CutrelyAlex/QQChatAnalyzer"><img src="docs/images/bento-qqchatanalyzer.png" alt="QQChatAnalyzer" width="49.4%"></a>
+</p>
+<p>
+  <a href="https://github.com/JUSTMONIKA2022/QQ-Chat-AI-Analyzer"><img src="docs/images/bento-qq-chat-ai-analyzer.png" alt="QQ-Chat-AI-Analyzer" width="49.4%"></a>
+  <a href="https://github.com/streetartist/napcat-qce-python"><img src="docs/images/bento-napcat-qce-python.png" alt="napcat-qce-python" width="49.4%"></a>
+</p>
 
 我们非常欢迎和 QCE 有关的社区项目！如果需要展示您的项目，可以在[这里](https://github.com/shuakami/qq-chat-exporter/issues/new)提一个 issue。
 


### PR DESCRIPTION
GitHub 渲染 table 会带边框，把 2x2 卡片改为 <p> 内并排 <img width="49.4%">，视觉更干净。