### PR TITLE
docs: 修复相关项目卡片在移动端纵向堆叠的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,8 @@ docker logs -f napcat-qce
 
 [![ChatLab](docs/images/bento-chatlab.png)](https://chatlab.fun/cn)
 
-<p>
-  <a href="https://github.com/Ruoan-486/QCE2Chatlab"><img src="docs/images/bento-qce2chatlab.png" alt="QCE2ChatLab" width="49.4%"></a>
-  <a href="https://github.com/CutrelyAlex/QQChatAnalyzer"><img src="docs/images/bento-qqchatanalyzer.png" alt="QQChatAnalyzer" width="49.4%"></a>
-</p>
-<p>
-  <a href="https://github.com/JUSTMONIKA2022/QQ-Chat-AI-Analyzer"><img src="docs/images/bento-qq-chat-ai-analyzer.png" alt="QQ-Chat-AI-Analyzer" width="49.4%"></a>
-  <a href="https://github.com/streetartist/napcat-qce-python"><img src="docs/images/bento-napcat-qce-python.png" alt="napcat-qce-python" width="49.4%"></a>
-</p>
+<p><a href="https://github.com/Ruoan-486/QCE2Chatlab"><img src="docs/images/bento-qce2chatlab.png" alt="QCE2ChatLab" width="49%"></a><a href="https://github.com/CutrelyAlex/QQChatAnalyzer"><img src="docs/images/bento-qqchatanalyzer.png" alt="QQChatAnalyzer" width="49%" align="right"></a></p>
+<p><a href="https://github.com/JUSTMONIKA2022/QQ-Chat-AI-Analyzer"><img src="docs/images/bento-qq-chat-ai-analyzer.png" alt="QQ-Chat-AI-Analyzer" width="49%"></a><a href="https://github.com/streetartist/napcat-qce-python"><img src="docs/images/bento-napcat-qce-python.png" alt="napcat-qce-python" width="49%" align="right"></a></p>
 
 我们非常欢迎和 QCE 有关的社区项目！如果需要展示您的项目，可以在[这里](https://github.com/shuakami/qq-chat-exporter/issues/new)提一个 issue。
 


### PR DESCRIPTION
移动端上两张 49% 图片之间的换行空白被渲染成空格，总宽超过 100% 导致换行堆叠。去掉图片间空白并给右图加 align="right"，两列布局在窄屏也能保持。