### PR TITLE
perf(resource): 资源下载默认并发从 2 提升到 8

### DIFF
--- a/qq-chat-export-server/src/resource/handler.rs
+++ b/qq-chat-export-server/src/resource/handler.rs
@@ -53,7 +53,7 @@ impl Default for ResourceHandlerConfig {
         Self {
             storage_root: home.join(".qq-chat-exporter").join("resources"),
             download_timeout_ms: 30000,
-            max_concurrent_downloads: 2,
+            max_concurrent_downloads: 8,
             max_retries: 5,
             circuit_breaker_threshold: 20,
             circuit_breaker_recovery_time_ms: 60000,


### PR DESCRIPTION
## 摘要

资源下载默认并发 `max_concurrent_downloads` 从 2 提升到 8。

媒体较多的导出任务中，资源下载阶段是主要耗时点：下载走 loopback bridge 的 `FileApi.downloadMedia`（NT 本地缓存/CDN 直链），并发 2 时 Semaphore 排队严重。提升到 8 后媒体阶段吞吐约 4 倍，熔断器（阈值 20）与指数退避重试逻辑不变，失败风暴时仍会熔断保护。

## 变更

- `qq-chat-export-server/src/resource/handler.rs`：`ResourceHandlerConfig::default().max_concurrent_downloads` 2 → 8

## 检查

- `cargo test`（62 通过）
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`
- `rustfmt --edition 2021 --check src/resource/handler.rs`
