### PR TITLE
perf(fetcher): batchSize 超时后连续成功回升，批间等待 100ms→20ms

### DIFF
--- a/qq-chat-export-server/src/fetcher/batch_fetcher.rs
+++ b/qq-chat-export-server/src/fetcher/batch_fetcher.rs
@@ -12,6 +12,12 @@ use crate::fetcher::chat_type::is_private_like_chat_type;
 /// issue #305 / #316：自适应缩小后的 batchSize 下限。
 const MIN_BATCH_SIZE_ON_TIMEOUT: i64 = 200;
 
+/// 缩小后的 batchSize 连续成功该次数后翻倍回升（不超过配置值）。
+const BATCH_SIZE_RECOVERY_SUCCESSES: u32 = 3;
+
+/// 分页批次之间的间隔（本地 IPC 调用，仅留出让路空隙）。
+const INTER_BATCH_DELAY_MS: u64 = 20;
+
 /// 聊天对象（对应 NapCat `Peer`）。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -189,6 +195,7 @@ pub enum FetchStrategy {
 #[derive(Debug)]
 struct FetcherState {
     batch_size: i64,
+    consecutive_successes: u32,
     stats: ApiCallStats,
     current_strategy: FetchStrategy,
 }
@@ -211,6 +218,7 @@ impl BatchMessageFetcher {
             config,
             state: Mutex::new(FetcherState {
                 batch_size,
+                consecutive_successes: 0,
                 stats: ApiCallStats::default(),
                 current_strategy: FetchStrategy::Hybrid,
             }),
@@ -330,7 +338,7 @@ impl BatchMessageFetcher {
                     return Ok(None);
                 }
                 // 避免过于频繁的 API 调用。
-                tokio::time::sleep(Duration::from_millis(100)).await;
+                tokio::time::sleep(Duration::from_millis(INTER_BATCH_DELAY_MS)).await;
             }
         }
         if self.is_cancelled() {
@@ -574,6 +582,22 @@ impl BatchMessageFetcher {
                     tracing::info!("[BatchMessageFetcher] API调用成功");
                     let mut state = self.state.lock().await;
                     state.stats.consecutive_failures = 0;
+                    // issue #305 / #316 的反向路径：缩小后的 batchSize 在连续成功后
+                    // 逐步翻倍回升，避免一次超时让整个任务全程使用小批次。
+                    if state.batch_size < self.config.batch_size {
+                        state.consecutive_successes += 1;
+                        if state.consecutive_successes >= BATCH_SIZE_RECOVERY_SUCCESSES {
+                            let previous = state.batch_size;
+                            let next = (previous * 2).min(self.config.batch_size);
+                            state.batch_size = next;
+                            state.consecutive_successes = 0;
+                            tracing::info!(
+                                "[BatchMessageFetcher] 连续成功，batchSize 回升: {previous} -> {next}"
+                            );
+                        }
+                    } else {
+                        state.consecutive_successes = 0;
+                    }
                     return Ok(value);
                 }
                 Ok(Err(message)) => FetchError::Api(message),
@@ -598,6 +622,7 @@ impl BatchMessageFetcher {
             // issue #305 / #316：超时类错误下次重试用更小的 batchSize。
             if result.is_timeout() {
                 let mut state = self.state.lock().await;
+                state.consecutive_successes = 0;
                 if state.batch_size > MIN_BATCH_SIZE_ON_TIMEOUT {
                     let previous = state.batch_size;
                     let next = (previous / 2).max(MIN_BATCH_SIZE_ON_TIMEOUT);
@@ -846,6 +871,71 @@ mod tests {
 
         assert_eq!(batch.actual_count, 1);
         assert_eq!(batch.next_message_id.as_deref(), Some("message-1"));
+    }
+
+    struct NoopApi;
+
+    #[async_trait]
+    impl MessageFetchApi for NoopApi {
+        async fn get_aio_first_view_latest_msgs(
+            &self,
+            _peer: &Peer,
+            _count: i64,
+        ) -> Result<Value, String> {
+            Ok(json!({ "msgList": [] }))
+        }
+
+        async fn get_msg_history(
+            &self,
+            _peer: &Peer,
+            _msg_id: &str,
+            _count: i64,
+        ) -> Result<Value, String> {
+            Ok(json!({ "msgList": [] }))
+        }
+
+        async fn get_msgs_by_seq_range(
+            &self,
+            _peer: &Peer,
+            _start_seq: &str,
+            _end_seq: &str,
+        ) -> Result<Value, String> {
+            Ok(json!({ "msgList": [] }))
+        }
+    }
+
+    #[tokio::test]
+    async fn shrunk_batch_size_recovers_after_consecutive_successes() {
+        let fetcher = BatchMessageFetcher::new(Arc::new(NoopApi), BatchFetchConfig::default());
+        {
+            let mut state = fetcher.state.lock().await;
+            state.batch_size = MIN_BATCH_SIZE_ON_TIMEOUT;
+        }
+
+        for _ in 0..BATCH_SIZE_RECOVERY_SUCCESSES {
+            fetcher
+                .call_with_retry(|_batch_size| async { Ok(json!({ "msgList": [] })) })
+                .await
+                .expect("call succeeds");
+        }
+        assert_eq!(
+            fetcher.state.lock().await.batch_size,
+            MIN_BATCH_SIZE_ON_TIMEOUT * 2
+        );
+
+        // 回升不超过配置上限。
+        {
+            let mut state = fetcher.state.lock().await;
+            state.batch_size = 4000;
+            state.consecutive_successes = 0;
+        }
+        for _ in 0..BATCH_SIZE_RECOVERY_SUCCESSES {
+            fetcher
+                .call_with_retry(|_batch_size| async { Ok(json!({ "msgList": [] })) })
+                .await
+                .expect("call succeeds");
+        }
+        assert_eq!(fetcher.state.lock().await.batch_size, 5000);
     }
 
     #[test]


### PR DESCRIPTION
## 摘要

消息分页抓取两处优化，均针对 NapCat 本地 IPC（无服务器频控）：

1. **超时后 batchSize 只降不升 → 加回升**：`call_with_retry` 超时时会把 batchSize 折半（下限 200），但此前永不恢复，一次网络抖动会让整个任务全程用小批次拖慢。现在连续成功 `BATCH_SIZE_RECOVERY_SUCCESSES`(3) 次后 batchSize 翻倍回升，上限为配置的 `batch_size`，超时会重置连续成功计数，避免振荡。
2. **批间固定 sleep 100ms → 20ms**：本地 loopback IPC 不存在腾讯服务器那种防洪节流需求，100ms 是保守值。改为 20ms 仅留出让路空隙。大群多批次导出可省下可观的累计等待。

## 变更

```
FetcherState { + consecutive_successes: u32 }

// call_with_retry 成功分支
if batch_size < config.batch_size {
    consecutive_successes += 1;
    if consecutive_successes >= 3 { batch_size = (batch_size*2).min(config.batch_size); reset; }
} else { consecutive_successes = 0; }

// 超时分支：consecutive_successes = 0（原折半逻辑不变）

fetch_next_batch: sleep 100ms -> INTER_BATCH_DELAY_MS(20ms)
```

新增测试 `shrunk_batch_size_recovers_after_consecutive_successes`：验证 200 连续成功 3 次回升到 400，且回升不越过配置上限 5000。

## 检查

- `cargo test`（fetcher 3 通过）
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`
- `rustfmt --edition 2021 --check src/fetcher/batch_fetcher.rs`
