### PR TITLE
fix(ui): 任务向导选好目标后不再被会话列表异步刷新弹回选择页

### DIFF
--- a/qce-v4-tool/components/ui/task-wizard.tsx
+++ b/qce-v4-tool/components/ui/task-wizard.tsx
@@ -225,6 +225,9 @@ export function TaskWizard({
   const [showTargetSelector, setShowTargetSelector] = useState(false)
   const [filtersOpen, setFiltersOpen] = useState(false)
   const listRef = useRef<HTMLDivElement>(null)
+  // 每次打开只初始化一次目标视图，避免后台会话列表异步刷新导致 groups/friends
+  // 引用变化时把用户已选好的目标清空、弹回选择页（概率性返回上一步）。
+  const didInitTargetRef = useRef(false)
   
   // 手动输入 QQ 号 / 群号模式（Issue #226）：friend | group | null
   const [manualInputMode, setManualInputMode] = useState<'friend' | 'group' | null>(null)
@@ -283,7 +286,9 @@ export function TaskWizard({
   ])
 
   useEffect(() => {
-    if (prefilledData?.peerUid && isOpen) {
+    if (!isOpen || didInitTargetRef.current) return
+    if (prefilledData?.peerUid) {
+      // groups/friends 可能在打开后才异步加载完成，找到目标前允许本 effect 随列表更新重跑。
       const targetList = prefilledData.chatType === 2 ? groups : friends
       const found = targetList.find((t) => {
         if (prefilledData.chatType === 2) return "groupCode" in t && t.groupCode === prefilledData.peerUid
@@ -292,10 +297,12 @@ export function TaskWizard({
       if (found) {
         setSelectedTarget(found)
         setShowTargetSelector(false)
+        didInitTargetRef.current = true
       }
-    } else if (isOpen && !prefilledData?.peerUid) {
+    } else {
       setSelectedTarget(null)
       setShowTargetSelector(true)
+      didInitTargetRef.current = true
     }
   }, [prefilledData, groups, friends, isOpen])
 
@@ -329,6 +336,7 @@ export function TaskWizard({
     if (!isOpen) {
       if (preferencesReady) writeAdvancedPreferences(form)
       setPreferencesReady(false)
+      didInitTargetRef.current = false
       setSelectedTarget(null)
       setSearchTerm("")
       setShowTargetSelector(true)


### PR DESCRIPTION
## 问题

用户报告：选择导出目标后，在导出配置视图有概率被弹回上一步的目标选择页。

## 根因

`task-wizard.tsx` 里初始化目标视图的 effect 依赖 `groups` / `friends`。向导打开时会触发 `onLoadData()` 后台刷新会话列表；当刷新在用户已选好目标之后完成时，`groups`/`friends` 引用变化使 effect 重跑，无 `prefilledData` 分支执行 `setSelectedTarget(null)` + `setShowTargetSelector(true)`，把用户弹回选择页。是否复现取决于列表刷新与用户选择的时序，因此表现为"概率性"。

## 修复

- 新增 `didInitTargetRef`：每次打开向导只初始化一次目标视图，初始化完成后 effect 不再因列表刷新重跑清空选择。
- `prefilledData` 场景仍允许 effect 随列表加载重跑直到找到目标（列表可能晚于打开加载完成），找到后同样标记完成，避免后续刷新覆盖用户"更换目标"等操作。
- 关闭向导时重置该标记，保证下次打开重新初始化。

## 验证

- `pnpm install --frozen-lockfile && pnpm build` 通过（Next.js 静态导出成功）。
