### PR TITLE
fix(export): 系统消息不再输出占位发送者 "0"，statistics.senders 排除系统消息

### DIFF
--- a/qq-chat-export-core/src/stats.rs
+++ b/qq-chat-export-core/src/stats.rs
@@ -95,15 +95,19 @@ impl StatsAccumulator {
         };
         *self.by_type.entry(type_key.to_owned()).or_insert(0) += 1;
 
-        let sender_key = if m.sender.uid.is_empty() {
-            "unknown".to_owned()
-        } else {
-            m.sender.uid.clone()
-        };
-        let entry = self.by_sender.entry(sender_key).or_insert((None, 0));
-        entry.1 += 1;
-        if entry.0.is_none() && !m.sender.name.is_empty() {
-            entry.0 = Some(m.sender.name.clone());
+        // 系统灰条消息没有真实发送者，不计入发送者统计，避免第三方导入工具
+        // 把它当成一个真实成员。
+        if !m.system {
+            let sender_key = if m.sender.uid.is_empty() {
+                "unknown".to_owned()
+            } else {
+                m.sender.uid.clone()
+            };
+            let entry = self.by_sender.entry(sender_key).or_insert((None, 0));
+            entry.1 += 1;
+            if entry.0.is_none() && !m.sender.name.is_empty() {
+                entry.0 = Some(m.sender.name.clone());
+            }
         }
 
         for r in &m.content.resources {
@@ -165,5 +169,53 @@ impl StatsAccumulator {
                 total_size: self.res_total_size,
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StatsAccumulator;
+    use crate::types::{CleanMessage, MessageContent, Sender};
+
+    fn message(uid: &str, name: &str, system: bool) -> CleanMessage {
+        CleanMessage {
+            id: "1".to_owned(),
+            seq: "1".to_owned(),
+            timestamp: 1_700_000_000_000,
+            time: String::new(),
+            sender: Sender {
+                uid: uid.to_owned(),
+                uin: None,
+                name: name.to_owned(),
+                nickname: None,
+                group_card: None,
+                remark: None,
+                title: None,
+                avatar_base64: None,
+            },
+            message_type: if system { "system" } else { "text" }.to_owned(),
+            content: MessageContent {
+                text: String::new(),
+                html: None,
+                elements: Vec::new(),
+                resources: Vec::new(),
+                mentions: Vec::new(),
+            },
+            recalled: false,
+            system,
+            raw_message: None,
+        }
+    }
+
+    #[test]
+    fn system_messages_are_counted_but_excluded_from_senders() {
+        let mut acc = StatsAccumulator::new();
+        acc.consume(&message("u_alice", "Alice", false));
+        acc.consume(&message("未知", "系统消息", true));
+
+        let stats = acc.finalize();
+        assert_eq!(stats.total_messages, 2);
+        assert_eq!(stats.senders.len(), 1);
+        assert_eq!(stats.senders[0].uid, "u_alice");
     }
 }

--- a/qq-chat-export-server/src/parser/simple_parser.rs
+++ b/qq-chat-export-server/src/parser/simple_parser.rs
@@ -487,6 +487,38 @@ mod reply_target_tests {
         assert_eq!(reply_data(&parsed[3])["referencedMessageId"], "first");
         assert_eq!(reply_data(&parsed[4])["referencedMessageId"], "second");
     }
+
+    #[tokio::test]
+    async fn anonymous_system_message_gets_system_sender_placeholder() {
+        let system = json!({
+            "msgId": "sys-1",
+            "msgSeq": "10",
+            "msgTime": 1_758_025_100,
+            "msgType": 5,
+            "chatType": 1,
+            "peerUid": "u_peer",
+            "senderUid": "",
+            "senderUin": "0",
+            "elements": [{ "elementType": 8, "grayTipElement": {} }]
+        });
+        let normal = raw_message(
+            "text-1",
+            "11",
+            1_758_025_200,
+            "1687657986",
+            json!([{ "elementType": 1, "textElement": { "content": "hi" } }]),
+        );
+
+        let mut parser = SimpleMessageParser::new(SimpleParserOptions::standard());
+        let parsed = parser.parse_messages(&[system, normal]).await;
+
+        assert!(parsed[0].system);
+        assert_eq!(parsed[0].sender.uid, "未知");
+        assert_eq!(parsed[0].sender.uin, None);
+        assert_eq!(parsed[0].sender.name, "系统消息");
+        assert_eq!(parsed[1].sender.uin.as_deref(), Some("1687657986"));
+        assert_eq!(parsed[1].sender.name, "笨蛋Darf v2");
+    }
 }
 
 #[cfg(test)]
@@ -925,16 +957,28 @@ impl SimpleMessageParser {
         let content = self.parse_message_content(message, 0).await;
         let msg_type = v_i64(message, "msgType").unwrap_or(0);
 
-        CleanMessage {
-            id: trimmed_field(message, "msgId").unwrap_or_default(),
-            seq: trimmed_field(message, "msgSeq").unwrap_or_default(),
-            timestamp,
-            time: rfc3339_from_millis(timestamp),
-            sender: Sender {
-                uid: v_str(message, "senderUid")
-                    .filter(|s| !s.is_empty())
-                    .unwrap_or("未知")
-                    .to_string(),
+        // 系统灰条消息（撤回提示等）没有真实发送者：NapCat 给出的
+        // senderUid 为空、senderUin 为 "0"，若原样导出会被第三方导入工具
+        // 当成一个名叫 "0" 的用户，这里归一化成明确的系统占位。
+        let sender_uid = trimmed_field(message, "senderUid");
+        let sender_uin = trimmed_field(message, "senderUin");
+        let anonymous_system =
+            msg_type == 5 && sender_uid.is_none() && sender_uin.as_deref().is_none_or(|u| u == "0");
+
+        let sender = if anonymous_system {
+            Sender {
+                uid: "未知".to_string(),
+                uin: None,
+                name: "系统消息".to_string(),
+                nickname: None,
+                group_card: None,
+                remark: None,
+                title: None,
+                avatar_base64: None,
+            }
+        } else {
+            Sender {
+                uid: sender_uid.unwrap_or_else(|| "未知".to_string()),
                 uin: v_str(message, "senderUin").map(str::to_string),
                 name: sender_info.name,
                 nickname: sender_info.nickname,
@@ -942,7 +986,15 @@ impl SimpleMessageParser {
                 remark: sender_info.remark,
                 title: self.resolve_sender_title(message),
                 avatar_base64: None,
-            },
+            }
+        };
+
+        CleanMessage {
+            id: trimmed_field(message, "msgId").unwrap_or_default(),
+            seq: trimmed_field(message, "msgSeq").unwrap_or_default(),
+            timestamp,
+            time: rfc3339_from_millis(timestamp),
+            sender,
             message_type: Self::get_message_type_string(msg_type),
             content,
             recalled: v_get(message, "recallTime")


### PR DESCRIPTION
## 背景

QQ 私聊导出 JSON 导入 ChatLab 时被识别成群聊，且出现一个名为 "0" 的用户。根因之一在 QCE 侧：系统灰条消息（撤回提示等，msgType 5）没有真实发送者，NapCat 给出的 senderUid 为空、senderUin 为 "0"，导出后：

- 消息 sender 变成 `{uid:"未知", uin:"0", name:"0"}`，被第三方导入工具当成真实用户 "0"；
- `statistics.senders` 多出这个占位条目（真实 2 人 + 占位 1 = 3），ChatLab 按 senders 数量 > 2 判定为群聊。

## 修改

- `qq-chat-export-server/src/parser/simple_parser.rs`：msgType 5 且无真实发送者（senderUid 空、senderUin 为空或 "0"）时，sender 归一化为 `{uid:"未知", uin:null, name:"系统消息"}`，不再输出 `uin:"0"` / `name:"0"`。
- `qq-chat-export-core/src/stats.rs`：`StatsAccumulator::consume` 对 `system:true` 的消息不计入 `senders` 统计（总数、类型统计不变）。

## 测试

- 新增 parser 回归测试：匿名系统消息得到系统占位 sender，普通消息不受影响。
- 新增 stats 回归测试：系统消息计入 totalMessages 但不出现在 senders。

## 检查

- core / server：`cargo test`、`cargo clippy --all-targets -- -D warnings`、`cargo build` 全绿
- `rustfmt --edition 2021 --check` 触及改动行无 diff（stats.rs 存在一处历史遗留格式差异，未改动）
- `git diff --check` 通过
