### PR TITLE
fix(launcher): probe more registry sources and shortcuts to locate QQ

### DIFF
--- a/installer/src-tauri/src/service.rs
+++ b/installer/src-tauri/src/service.rs
@@ -187,39 +187,106 @@ pub fn shutdown(state: &AppState) {
     kill_napcat_only();
 }
 
-/// Best-effort discovery of the desktop QQ executable via the registry.
+/// Best-effort discovery of the desktop QQ executable via the registry,
+/// App Paths, the tencent:// protocol handler and common install dirs.
 #[cfg(windows)]
 fn detect_qq_path() -> Option<String> {
-    use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE};
+    use winreg::enums::{HKEY_CLASSES_ROOT, HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE};
     use winreg::RegKey;
 
-    // QQNT records its install dir under the uninstall key.
-    const UNINSTALL: &str =
-        r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\QQ";
-    for hive in [HKEY_LOCAL_MACHINE, HKEY_CURRENT_USER] {
-        let root = RegKey::predef(hive);
-        if let Ok(key) = root.open_subkey(UNINSTALL) {
-            if let Ok(dir) = key.get_value::<String, _>("UninstallString") {
-                // UninstallString points at Uninstall.exe in the QQ dir.
-                if let Some(parent) = std::path::Path::new(&dir).parent() {
-                    let exe = parent.join("QQ.exe");
-                    if exe.exists() {
-                        return Some(exe.to_string_lossy().into_owned());
-                    }
+    fn existing(path: &std::path::Path) -> Option<String> {
+        path.exists().then(|| path.to_string_lossy().into_owned())
+    }
+
+    // QQNT records its install dir under the uninstall key
+    // (64-bit view, 32-bit WOW6432Node view and per-user installs).
+    const UNINSTALL_KEYS: [(&str, isize); 3] = [
+        (r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\QQ", 0),
+        (
+            r"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\QQ",
+            0,
+        ),
+        (r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\QQ", 1),
+    ];
+    for (subkey, hive) in UNINSTALL_KEYS {
+        let root = RegKey::predef(if hive == 0 {
+            HKEY_LOCAL_MACHINE
+        } else {
+            HKEY_CURRENT_USER
+        });
+        let Ok(key) = root.open_subkey(subkey) else {
+            continue;
+        };
+        if let Ok(icon) = key.get_value::<String, _>("DisplayIcon") {
+            // DisplayIcon may carry an icon index suffix like `...\QQ.exe,0`.
+            let path = icon.split(',').next().unwrap_or(&icon).trim_matches('"');
+            if let Some(found) = existing(std::path::Path::new(path)) {
+                return Some(found);
+            }
+        }
+        if let Ok(uninst) = key.get_value::<String, _>("UninstallString") {
+            // UninstallString points at Uninstall.exe in the QQ dir.
+            let uninst = uninst.trim_matches('"');
+            if let Some(parent) = std::path::Path::new(uninst).parent() {
+                if let Some(found) = existing(&parent.join("QQ.exe")) {
+                    return Some(found);
                 }
             }
-            if let Ok(dir) = key.get_value::<String, _>("DisplayIcon") {
-                let p = std::path::Path::new(&dir);
-                if p.exists() {
-                    return Some(p.to_string_lossy().into_owned());
+        }
+        if let Ok(dir) = key.get_value::<String, _>("InstallLocation") {
+            if let Some(found) = existing(&std::path::Path::new(&dir).join("QQ.exe")) {
+                return Some(found);
+            }
+        }
+    }
+
+    // App Paths registration.
+    const APP_PATHS: &str = r"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\QQ.exe";
+    for hive in [HKEY_LOCAL_MACHINE, HKEY_CURRENT_USER] {
+        if let Ok(key) = RegKey::predef(hive).open_subkey(APP_PATHS) {
+            if let Ok(path) = key.get_value::<String, _>("") {
+                if let Some(found) = existing(std::path::Path::new(path.trim_matches('"'))) {
+                    return Some(found);
                 }
             }
         }
     }
-    // Common default location.
-    let candidate = r"C:\Program Files\Tencent\QQNT\QQ.exe";
-    if std::path::Path::new(candidate).exists() {
-        return Some(candidate.to_string());
+
+    // tencent:// protocol handler: points inside versions\<ver>\resources\app,
+    // so walk up the directory tree probing for QQ.exe at each level.
+    if let Ok(key) = RegKey::predef(HKEY_CLASSES_ROOT).open_subkey(r"Tencent\shell\open\command") {
+        if let Ok(command) = key.get_value::<String, _>("") {
+            let exe = command
+                .split('"')
+                .nth(1)
+                .unwrap_or(command.trim())
+                .to_string();
+            let mut dir = std::path::Path::new(&exe).parent();
+            for _ in 0..6 {
+                let Some(current) = dir else { break };
+                if let Some(found) = existing(&current.join("QQ.exe")) {
+                    return Some(found);
+                }
+                dir = current.parent();
+            }
+        }
     }
-    None
+
+    // Common default locations.
+    let mut candidates: Vec<std::path::PathBuf> = Vec::new();
+    for var in ["ProgramFiles", "ProgramFiles(x86)"] {
+        if let Ok(base) = std::env::var(var) {
+            candidates.push(std::path::Path::new(&base).join(r"Tencent\QQNT\QQ.exe"));
+        }
+    }
+    if let Ok(base) = std::env::var("LocalAppData") {
+        candidates.push(std::path::Path::new(&base).join(r"Programs\Tencent\QQNT\QQ.exe"));
+    }
+    candidates.push(std::path::PathBuf::from(
+        r"C:\Program Files\Tencent\QQNT\QQ.exe",
+    ));
+    candidates.push(std::path::PathBuf::from(
+        r"D:\Program Files\Tencent\QQNT\QQ.exe",
+    ));
+    candidates.into_iter().find_map(|p| existing(&p))
 }

--- a/scripts/quick-pack.py
+++ b/scripts/quick-pack.py
@@ -302,7 +302,14 @@ if exist "%QQ_PATH_CONFIG%" (
 )
 
 :try_registry
-rem Priority 4: Registry query
+rem Priority 4: Multi-source probe (registry, App Paths, protocol handler,
+rem shortcuts) via find-qq.ps1 (issue #589)
+if exist "%cd%\\find-qq.ps1" (
+    for /f "usebackq delims=" %%i in (`powershell -NoProfile -ExecutionPolicy Bypass -File "%cd%\\find-qq.ps1" 2^>nul`) do set "QQPath=%%i"
+    if not "!QQPath!"=="" if exist "!QQPath!" goto :save_and_boot
+)
+
+rem Priority 4b: Direct registry query (fallback when PowerShell is unavailable)
 for /f "tokens=2*" %%a in ('reg query "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\QQ" /v "UninstallString" 2^>nul') do (
     set "RetString=%%~b"
     for %%x in ("!RetString!") do set "pathWithoutUninstall=%%~dpx"
@@ -564,6 +571,78 @@ pause
 exit /b
 '''
 
+    # find-qq.ps1: multi-source QQNT discovery for the launcher (issue #589).
+    # Probes uninstall registry entries (64-bit / 32-bit / per-user),
+    # App Paths, the tencent:// protocol handler and QQ shortcuts, then
+    # prints the first QQ.exe that actually exists on disk.
+    find_qq_ps1 = '''$ErrorActionPreference = 'SilentlyContinue'
+
+$candidates = New-Object System.Collections.Generic.List[string]
+
+function Add-Candidate([string]$path) {
+    if ($path) { $script:candidates.Add($path.Trim('"').Trim()) }
+}
+
+# 1) Uninstall registry entries (64-bit, 32-bit and per-user installs)
+foreach ($key in @(
+    'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\QQ',
+    'HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\QQ',
+    'HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\QQ'
+)) {
+    $props = Get-ItemProperty -LiteralPath $key
+    if (-not $props) { continue }
+    if ($props.DisplayIcon) { Add-Candidate ($props.DisplayIcon -replace ',\\d+$', '') }
+    if ($props.UninstallString) {
+        $dir = Split-Path -Parent ($props.UninstallString.Trim('"'))
+        if ($dir) { Add-Candidate (Join-Path $dir 'QQ.exe') }
+    }
+    if ($props.InstallLocation) { Add-Candidate (Join-Path $props.InstallLocation 'QQ.exe') }
+}
+
+# 2) App Paths
+foreach ($key in @(
+    'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\QQ.exe',
+    'HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\QQ.exe'
+)) {
+    Add-Candidate (Get-ItemProperty -LiteralPath $key).'(default)'
+}
+
+# 3) tencent:// protocol handler: points inside versions\\<ver>\\resources\\app,
+#    so walk up the directory tree probing for QQ.exe at each level.
+$proto = (Get-ItemProperty -LiteralPath 'Registry::HKEY_CLASSES_ROOT\\Tencent\\shell\\open\\command').'(default)'
+if ($proto -match '"([^"]+)"') {
+    $dir = Split-Path -Parent $Matches[1]
+    for ($i = 0; $i -lt 6 -and $dir; $i++) {
+        Add-Candidate (Join-Path $dir 'QQ.exe')
+        $dir = Split-Path -Parent $dir
+    }
+}
+
+# 4) Start menu and desktop shortcuts
+$shell = New-Object -ComObject WScript.Shell
+foreach ($root in @(
+    "$env:APPDATA\\Microsoft\\Windows\\Start Menu\\Programs",
+    "$env:ProgramData\\Microsoft\\Windows\\Start Menu\\Programs",
+    "$env:USERPROFILE\\Desktop",
+    "$env:PUBLIC\\Desktop"
+)) {
+    Get-ChildItem -LiteralPath $root -Filter '*QQ*.lnk' -Recurse -Depth 2 |
+        ForEach-Object { Add-Candidate $shell.CreateShortcut($_.FullName).TargetPath }
+}
+
+# 5) Common installation directories
+foreach ($base in @($env:ProgramFiles, ${env:ProgramFiles(x86)}, "$env:LocalAppData\\Programs", 'D:\\Program Files')) {
+    if ($base) { Add-Candidate (Join-Path $base 'Tencent\\QQNT\\QQ.exe') }
+}
+
+foreach ($candidate in $candidates) {
+    if ((Split-Path -Leaf $candidate) -ieq 'QQ.exe' -and (Test-Path -LiteralPath $candidate)) {
+        Write-Output $candidate
+        exit 0
+    }
+}
+'''
+
     # reset-qq-path.bat
     reset_qq_path_bat = '''@echo off
 chcp 65001 >nul
@@ -604,7 +683,8 @@ pause
         "launcher-user.bat": launcher_user_bat,
         "launcher-win10.bat": launcher_win10_bat,
         "launcher-win10-user.bat": launcher_win10_user_bat,
-        "reset-qq-path.bat": reset_qq_path_bat
+        "reset-qq-path.bat": reset_qq_path_bat,
+        "find-qq.ps1": find_qq_ps1
     }
 
     # Only emit the Windows .bat launchers in Windows packages — they are pure


### PR DESCRIPTION
## Summary
Fixes #589.

Users on some Windows setups report that the one-click package cannot locate QQ via the registry (framework fails with "无法获取QQ注册表"). The launcher previously probed only a single registry key (`HKLM\SOFTWARE\WOW6432Node\...\Uninstall\QQ` → `UninstallString`), so per-user installs, 64-bit-view registrations, and other setups fell straight through to the manual picker.

### Launcher (`scripts/quick-pack.py`)
- New `find-qq.ps1` shipped alongside the `.bat` launchers; the `:try_registry` step now runs it first and falls back to the old direct `reg query` when PowerShell is unavailable
- `find-qq.ps1` probes, in order, and returns the first `QQ.exe` that exists on disk:
  1. Uninstall entries in HKLM 64-bit, HKLM WOW6432Node, and HKCU (`DisplayIcon` with `,N` icon-index stripping, `UninstallString` parent dir, `InstallLocation`)
  2. `App Paths\QQ.exe` (HKLM + HKCU)
  3. `HKCR\Tencent\shell\open\command` protocol handler, walking up from the deep `versions\<ver>\resources\app` target
  4. Start-menu / desktop `*QQ*.lnk` shortcut targets
  5. Common install dirs (`%ProgramFiles%`, `%ProgramFiles(x86)%`, `%LocalAppData%\Programs`, `D:\Program Files`)
- No dependency on QQ running or any indexing tool (Everything etc.); a found path is still saved to `config\qq_path.txt` as before

### Installer (`installer/src-tauri/src/service.rs`)
- `detect_qq_path` extended with the same sources (was: HKLM/HKCU uninstall key + one hardcoded path): WOW6432Node view, `,N` suffix stripping for `DisplayIcon`, `InstallLocation`, App Paths, Tencent protocol handler walk-up, and env-derived common dirs

## Testing
- `python3 -m py_compile scripts/quick-pack.py`
- `cargo check` / `cargo clippy --all-targets -- -D warnings` for the installer crate against `x86_64-pc-windows-gnu` (the changed code is `#[cfg(windows)]`)
- `rustfmt --check` on the changed file (remaining diffs at lines 80/124/136 are pre-existing)
