### PR TITLE
fix(packaging): multi-source QQ discovery for Framework, standalone login URL, banner off release assets

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -634,22 +634,46 @@ jobs:
           VERSION="${GITHUB_REF#refs/tags/}"
           npm install --no-save --no-package-lock playwright@1.49.1
           npx playwright install --with-deps chromium
-          node scripts/generate-release-banner.mjs "$VERSION" CHANGELOG_RAW.txt "release-files/release-banner-${VERSION}.png"
+          node scripts/generate-release-banner.mjs "$VERSION" CHANGELOG_RAW.txt "release-banner-${VERSION}.png"
 
-      - name: "将 Banner 插入发布说明"
+      # Banner 通过 release-assets 孤儿分支托管（而不是作为 Release Asset 上传），
+      # 避免出现在 Release 的 Assets 列表里被误下载。
+      - name: "发布 Banner 到 release-assets 分支"
+        id: publish_banner
         if: steps.release_banner.outcome == 'success'
+        continue-on-error: true
         run: |
           VERSION="${GITHUB_REF#refs/tags/}"
-          if [ -f "release-files/release-banner-${VERSION}.png" ]; then
-            awk -v ver="$VERSION" '
-              $0 == "### " ver " 更新内容" { print "<details>"; print "<summary>完整更新内容</summary>"; inlist=1; next }
-              inlist && /^### / { print "</details>"; print ""; inlist=0 }
-              { print }
-            ' RELEASE_NOTES.md > RELEASE_NOTES.tmp
-            mv RELEASE_NOTES.tmp RELEASE_NOTES.md
-            printf '![%s](https://github.com/%s/releases/download/%s/release-banner-%s.png)\n\n' "$VERSION" "${GITHUB_REPOSITORY}" "$VERSION" "$VERSION" | cat - RELEASE_NOTES.md > RELEASE_NOTES.tmp
-            mv RELEASE_NOTES.tmp RELEASE_NOTES.md
+          [ -f "release-banner-${VERSION}.png" ] || exit 1
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          WORKTREE=$(mktemp -d)
+          if git fetch origin release-assets 2>/dev/null; then
+            git worktree add "$WORKTREE" -B release-assets origin/release-assets
+          else
+            git worktree add --detach "$WORKTREE"
+            git -C "$WORKTREE" checkout --orphan release-assets
+            git -C "$WORKTREE" rm -rf --quiet . || true
           fi
+          mkdir -p "$WORKTREE/banners"
+          cp "release-banner-${VERSION}.png" "$WORKTREE/banners/"
+          git -C "$WORKTREE" add "banners/release-banner-${VERSION}.png"
+          git -C "$WORKTREE" commit -m "chore: add release banner for ${VERSION}"
+          git -C "$WORKTREE" push origin release-assets
+          git worktree remove --force "$WORKTREE"
+
+      - name: "将 Banner 插入发布说明"
+        if: steps.publish_banner.outcome == 'success'
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          awk -v ver="$VERSION" '
+            $0 == "### " ver " 更新内容" { print "<details>"; print "<summary>完整更新内容</summary>"; inlist=1; next }
+            inlist && /^### / { print "</details>"; print ""; inlist=0 }
+            { print }
+          ' RELEASE_NOTES.md > RELEASE_NOTES.tmp
+          mv RELEASE_NOTES.tmp RELEASE_NOTES.md
+          printf '![%s](https://raw.githubusercontent.com/%s/release-assets/banners/release-banner-%s.png)\n\n' "$VERSION" "${GITHUB_REPOSITORY}" "$VERSION" | cat - RELEASE_NOTES.md > RELEASE_NOTES.tmp
+          mv RELEASE_NOTES.tmp RELEASE_NOTES.md
 
       - name: "创建 GitHub Release"
         uses: softprops/action-gh-release@v1
@@ -662,7 +686,6 @@ jobs:
             release-files/NapCat-Framework-QCE-${{ github.ref_name }}.zip
             release-files/napcat-plugin-qce.zip
             release-files/QQChatExporter-Installer-${{ github.ref_name }}.exe
-            release-files/release-banner-${{ github.ref_name }}.png
           draft: false
           prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
           generate_release_notes: false

--- a/plugins/qq-chat-exporter/__tests__/unit/standaloneLoginUrl.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/standaloneLoginUrl.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression test for issue #457: standalone mode gave users no way to see
+ * the access token, so the /auth page was an unpassable wall.
+ *
+ * The fix lives in the generated qce-standalone.mjs (scripts/quick-pack.py):
+ * after spawning qce-server it polls security.json (QCE_CONFIG_DIR or
+ * ~/.qq-chat-exporter) and prints the one-click login URL.
+ *
+ * The test extracts the embedded script from quick-pack.py, runs it against
+ * a fake qce-server that writes security.json, and asserts the login URL is
+ * printed with the URL-encoded token.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+import { createTempDir } from '../helpers/tempDir.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const QUICK_PACK = path.join(REPO_ROOT, 'scripts', 'quick-pack.py');
+
+function extractStandaloneScript(): string {
+    const source = fs.readFileSync(QUICK_PACK, 'utf8');
+    const match = source.match(/standalone_mjs = '''([\s\S]*?)'''/);
+    assert.ok(match, 'quick-pack.py should embed standalone_mjs');
+    return match[1].replace(/\r\n/g, '\n');
+}
+
+const posixOnly = process.platform !== 'win32'
+    ? null
+    : 'fake qce-server is a POSIX shell script';
+
+test('standalone script prints one-click login URL from security.json (issue #457)', { skip: posixOnly ?? false }, () => {
+    const tmp = createTempDir('qce-standalone-457-');
+    try {
+        const packDir = path.join(tmp.path, 'pack');
+        const configDir = path.join(tmp.path, 'config');
+        fs.mkdirSync(packDir, { recursive: true });
+        fs.mkdirSync(configDir, { recursive: true });
+
+        fs.writeFileSync(path.join(packDir, 'qce-standalone.mjs'), extractStandaloneScript());
+
+        // Fake qce-server: write security.json like SecurityManager does,
+        // stay alive long enough for the poll loop to observe it.
+        const token = 'abc123+/=TOKEN';
+        const fakeServer = path.join(packDir, 'qce-server');
+        fs.writeFileSync(
+            fakeServer,
+            `#!/bin/sh\ncat > "${configDir}/security.json" <<'EOF'\n{"accessToken":"${token}"}\nEOF\nsleep 3\n`,
+            { mode: 0o755 },
+        );
+
+        const result = spawnSync(
+            process.execPath,
+            [path.join(packDir, 'qce-standalone.mjs'), '23456'],
+            {
+                env: { ...process.env, QCE_CONFIG_DIR: configDir },
+                encoding: 'utf8',
+                timeout: 30_000,
+            },
+        );
+
+        assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+        assert.match(
+            result.stdout,
+            /\[QCE\] 一键登录: http:\/\/127\.0\.0\.1:23456\/qce\/auth\?token=/,
+        );
+        assert.ok(
+            result.stdout.includes(`token=${encodeURIComponent(token)}`),
+            `stdout should contain the URL-encoded token, got: ${result.stdout}`,
+        );
+    } finally {
+        tmp.cleanup();
+    }
+});

--- a/scripts/build-framework-plugin.py
+++ b/scripts/build-framework-plugin.py
@@ -14,7 +14,11 @@ import platform
 from pathlib import Path
 from urllib.request import urlretrieve, urlopen
 from datetime import datetime
-from plugin_runtime import copy_windows_server_binary, stage_plugin_runtime
+from plugin_runtime import (
+    copy_windows_server_binary,
+    stage_plugin_runtime,
+    write_find_qq_script,
+)
 
 SOURCE_PLUGIN_DIR = "plugins/qq-chat-exporter"
 RUNTIME_PLUGIN_ID = "napcat-plugin-qce"
@@ -65,6 +69,158 @@ def rewrite_runtime_plugin_package(plugin_dir):
     with open(package_json, "w", encoding="utf-8") as f:
         json.dump(package_data, f, indent=2, ensure_ascii=False)
         f.write("\n")
+
+# Enhanced napiLoader launchers (issue #589): the upstream NapCat.Framework
+# loaders only probe a single WOW6432Node uninstall key and abort with
+# "provided QQ path is invalid" when it is missing. We replace them with
+# launchers that reuse the saved path, run the multi-source find-qq.ps1 probe,
+# fall back to the direct registry query and common install paths, and offer a
+# manual QQ.exe picker with an actionable error message instead of dying.
+NAPILOADER_RESOLVE_LOGIC = '''
+:resolve_qq_path
+rem Priority 1: Command line argument
+if not "%~1"=="" if exist "%~1" (
+    set "QQPath=%~1"
+    goto :save_and_boot
+)
+
+rem Priority 2: Saved path from previous run
+if exist "%QQ_PATH_CONFIG%" (
+    set /p SavedPath=<"!QQ_PATH_CONFIG!"
+    if exist "!SavedPath!" (
+        set "QQPath=!SavedPath!"
+        echo [Info] Using saved QQ path: !SavedPath!
+        goto :napcat_boot
+    )
+)
+
+rem Priority 3: Multi-source probe (registry, App Paths, protocol handler,
+rem shortcuts) via find-qq.ps1 (issue #589)
+if exist "%cd%\\find-qq.ps1" (
+    for /f "usebackq delims=" %%i in (`powershell -NoProfile -ExecutionPolicy Bypass -File "%cd%\\find-qq.ps1" 2^>nul`) do set "QQPath=%%i"
+    if not "!QQPath!"=="" if exist "!QQPath!" goto :save_and_boot
+)
+
+rem Priority 3b: Direct registry query (fallback when PowerShell is unavailable)
+for /f "tokens=2*" %%a in ('reg query "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\QQ" /v "UninstallString" 2^>nul') do (
+    set "RetString=%%~b"
+    for %%x in ("!RetString!") do set "pathWithoutUninstall=%%~dpx"
+    set "QQPath=!pathWithoutUninstall!QQ.exe"
+    if exist "!QQPath!" goto :save_and_boot
+)
+
+rem Priority 4: Common installation paths
+rem Hoist %ProgramFiles(x86)% out of the for-list so the literal `(x86)` does
+rem not collide with the surrounding `for ... in (...)` parentheses (#291).
+set "PFX86=%ProgramFiles(x86)%"
+for %%p in (
+    "%ProgramFiles%\\Tencent\\QQNT\\QQ.exe"
+    "!PFX86!\\Tencent\\QQNT\\QQ.exe"
+    "%LocalAppData%\\Programs\\Tencent\\QQNT\\QQ.exe"
+    "C:\\Program Files\\Tencent\\QQNT\\QQ.exe"
+    "D:\\Program Files\\Tencent\\QQNT\\QQ.exe"
+) do (
+    if exist %%p (
+        set "QQPath=%%~p"
+        goto :save_and_boot
+    )
+)
+
+:manual_select
+echo.
+echo ============================================
+echo   QQ Installation Not Found
+echo ============================================
+echo.
+echo Could not detect QQ installation automatically.
+echo This may happen if you are using a portable/green version of QQ.
+echo.
+echo If QQ ^(QQNT^) is not installed yet, download it first:
+echo   https://im.qq.com/
+echo.
+echo Options:
+echo   [1] Browse for QQ.exe (GUI file picker)
+echo   [2] Enter path manually
+echo   [3] Exit
+echo.
+set /p choice="Select option (1/2/3): "
+
+if "%choice%"=="1" goto :gui_select
+if "%choice%"=="2" goto :text_input
+if "%choice%"=="3" exit /b 1
+goto :manual_select
+
+:gui_select
+echo.
+echo [Info] Opening file picker...
+for /f "delims=" %%i in ('powershell -Command "Add-Type -AssemblyName System.Windows.Forms; $f = New-Object System.Windows.Forms.OpenFileDialog; $f.Filter = 'QQ Executable (QQ.exe)|QQ.exe|All Files (*.*)|*.*'; $f.Title = 'Select QQ.exe'; $f.InitialDirectory = 'C:\\Program Files'; if ($f.ShowDialog() -eq 'OK') { $f.FileName } else { '' }"') do set "QQPath=%%i"
+
+if "%QQPath%"=="" (
+    echo [Error] No file selected.
+    goto :manual_select
+)
+goto :validate_path
+
+:text_input
+echo.
+set /p "QQPath=Enter full path to QQ.exe: "
+
+:validate_path
+if not exist "!QQPath!" (
+    echo [Error] File not found: !QQPath!
+    goto :manual_select
+)
+
+for %%f in ("!QQPath!") do set "filename=%%~nxf"
+if /i not "%filename%"=="QQ.exe" (
+    echo [Warning] Selected file is not QQ.exe, continue anyway? (Y/N)
+    set /p confirm="Confirm: "
+    if /i not "!confirm!"=="Y" goto :manual_select
+)
+
+:save_and_boot
+if not exist "%cd%\\config" mkdir "%cd%\\config"
+echo !QQPath!>"%QQ_PATH_CONFIG%"
+echo [Info] QQ path saved to config\\qq_path.txt
+
+:napcat_boot
+echo.
+echo [Info] Using QQ: "!QQPath!"
+
+set NAPCAT_MAIN_PATH=%NAPCAT_MAIN_PATH:\\=/%
+'''
+
+NAPILOADER_HEADER = '''@echo off
+chcp 65001 >nul
+setlocal enabledelayedexpansion
+cd /d "%~dp0"
+
+set NAPCAT_INJECT_PATH=%cd%\\napiloader.dll
+set NAPCAT_LAUNCHER_PATH=%cd%\\napimain.exe
+set NAPCAT_MAIN_PATH=%cd%\\nativeLoader.cjs
+set QQ_PATH_CONFIG=%cd%\\config\\qq_path.txt
+'''
+
+NAPILOADER_BAT = NAPILOADER_HEADER + NAPILOADER_RESOLVE_LOGIC + '''
+start "" "%NAPCAT_LAUNCHER_PATH%" "!QQPath!" "%NAPCAT_INJECT_PATH%" "%NAPCAT_MAIN_PATH%"
+'''
+
+NAPILOADER_DEBUG_BAT = NAPILOADER_HEADER + '''set NAPCAT_DEBUG_CONSOLE=1
+''' + NAPILOADER_RESOLVE_LOGIC + '''
+"%NAPCAT_LAUNCHER_PATH%" "!QQPath!" "%NAPCAT_INJECT_PATH%" "%NAPCAT_MAIN_PATH%"
+
+pause
+'''
+
+def write_enhanced_napiloaders(output_dir):
+    """Replace upstream napiLoader launchers with multi-source QQ discovery."""
+    for name, content in (
+        ("napiLoader.bat", NAPILOADER_BAT),
+        ("napiLoader-debug.bat", NAPILOADER_DEBUG_BAT),
+    ):
+        with open(os.path.join(output_dir, name), "w", encoding="utf-8", newline="\r\n") as f:
+            f.write(content)
+    write_find_qq_script(Path(output_dir))
 
 def download_file(url, dest):
     """Download file"""
@@ -124,6 +280,13 @@ def main():
     print("[3/8] Extracting NapCat.Framework...")
     with zipfile.ZipFile("NapCat.Framework.zip", 'r') as zf:
         zf.extractall(output_dir)
+    print("[x] Done")
+    print()
+
+    # Replace upstream napiLoader launchers with multi-source QQ discovery
+    # and a manual-selection fallback (issue #589).
+    print("[3.5/8] Writing enhanced napiLoader launchers...")
+    write_enhanced_napiloaders(output_dir)
     print("[x] Done")
     print()
     

--- a/scripts/plugin_runtime.py
+++ b/scripts/plugin_runtime.py
@@ -142,3 +142,85 @@ def copy_store_server_binaries(destination: Path) -> None:
     shutil.copy2(linux_binary, linux_target)
     ensure_executable(linux_target)
     shutil.copy2(windows_binary, windows_dir / "qce-server.exe")
+
+
+# find-qq.ps1: multi-source QQNT discovery for Windows launchers (issue #589).
+# Probes uninstall registry entries (64-bit / 32-bit / per-user), App Paths,
+# the tencent:// protocol handler and QQ shortcuts, then prints the first
+# QQ.exe that actually exists on disk.
+FIND_QQ_PS1 = r"""$ErrorActionPreference = 'SilentlyContinue'
+
+$candidates = New-Object System.Collections.Generic.List[string]
+
+function Add-Candidate([string]$path) {
+    if ($path) { $script:candidates.Add($path.Trim('"').Trim()) }
+}
+
+# 1) Uninstall registry entries (64-bit, 32-bit and per-user installs)
+foreach ($key in @(
+    'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\QQ',
+    'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\QQ',
+    'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\QQ'
+)) {
+    $props = Get-ItemProperty -LiteralPath $key
+    if (-not $props) { continue }
+    if ($props.DisplayIcon) { Add-Candidate ($props.DisplayIcon -replace ',\d+$', '') }
+    if ($props.UninstallString) {
+        $dir = Split-Path -Parent ($props.UninstallString.Trim('"'))
+        if ($dir) { Add-Candidate (Join-Path $dir 'QQ.exe') }
+    }
+    if ($props.InstallLocation) { Add-Candidate (Join-Path $props.InstallLocation 'QQ.exe') }
+}
+
+# 2) App Paths
+foreach ($key in @(
+    'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\QQ.exe',
+    'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\QQ.exe'
+)) {
+    Add-Candidate (Get-ItemProperty -LiteralPath $key).'(default)'
+}
+
+# 3) tencent:// protocol handler: points inside versions\<ver>\resources\app,
+#    so walk up the directory tree probing for QQ.exe at each level.
+$proto = (Get-ItemProperty -LiteralPath 'Registry::HKEY_CLASSES_ROOT\Tencent\shell\open\command').'(default)'
+if ($proto -match '"([^"]+)"') {
+    $dir = Split-Path -Parent $Matches[1]
+    for ($i = 0; $i -lt 6 -and $dir; $i++) {
+        Add-Candidate (Join-Path $dir 'QQ.exe')
+        $dir = Split-Path -Parent $dir
+    }
+}
+
+# 4) Start menu and desktop shortcuts
+$shell = New-Object -ComObject WScript.Shell
+foreach ($root in @(
+    "$env:APPDATA\Microsoft\Windows\Start Menu\Programs",
+    "$env:ProgramData\Microsoft\Windows\Start Menu\Programs",
+    "$env:USERPROFILE\Desktop",
+    "$env:PUBLIC\Desktop"
+)) {
+    Get-ChildItem -LiteralPath $root -Filter '*QQ*.lnk' -Recurse -Depth 2 |
+        ForEach-Object { Add-Candidate $shell.CreateShortcut($_.FullName).TargetPath }
+}
+
+# 5) Common installation directories
+foreach ($base in @($env:ProgramFiles, ${env:ProgramFiles(x86)}, "$env:LocalAppData\Programs", 'D:\Program Files')) {
+    if ($base) { Add-Candidate (Join-Path $base 'Tencent\QQNT\QQ.exe') }
+}
+
+foreach ($candidate in $candidates) {
+    if ((Split-Path -Leaf $candidate) -ieq 'QQ.exe' -and (Test-Path -LiteralPath $candidate)) {
+        Write-Output $candidate
+        exit 0
+    }
+}
+"""
+
+
+def write_find_qq_script(destination: Path) -> Path:
+    """Write find-qq.ps1 next to the Windows launchers."""
+    destination.mkdir(parents=True, exist_ok=True)
+    target = destination / "find-qq.ps1"
+    with open(target, "w", encoding="utf-8", newline="\r\n") as f:
+        f.write(FIND_QQ_PS1)
+    return target

--- a/scripts/quick-pack.py
+++ b/scripts/quick-pack.py
@@ -12,7 +12,7 @@ import tarfile
 from pathlib import Path
 from urllib.request import urlretrieve, urlopen
 from datetime import datetime
-from plugin_runtime import copy_native_server_binary, stage_plugin_runtime
+from plugin_runtime import FIND_QQ_PS1, copy_native_server_binary, stage_plugin_runtime
 
 def get_qce_version():
     """Get QCE version from package.json or environment variable"""
@@ -344,6 +344,9 @@ echo.
 echo Could not detect QQ installation automatically.
 echo This may happen if you are using a portable/green version of QQ.
 echo.
+echo If QQ ^(QQNT^) is not installed yet, download it first:
+echo   https://im.qq.com/
+echo.
 echo Options:
 echo   [1] Browse for QQ.exe (GUI file picker)
 echo   [2] Enter path manually
@@ -571,78 +574,6 @@ pause
 exit /b
 '''
 
-    # find-qq.ps1: multi-source QQNT discovery for the launcher (issue #589).
-    # Probes uninstall registry entries (64-bit / 32-bit / per-user),
-    # App Paths, the tencent:// protocol handler and QQ shortcuts, then
-    # prints the first QQ.exe that actually exists on disk.
-    find_qq_ps1 = '''$ErrorActionPreference = 'SilentlyContinue'
-
-$candidates = New-Object System.Collections.Generic.List[string]
-
-function Add-Candidate([string]$path) {
-    if ($path) { $script:candidates.Add($path.Trim('"').Trim()) }
-}
-
-# 1) Uninstall registry entries (64-bit, 32-bit and per-user installs)
-foreach ($key in @(
-    'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\QQ',
-    'HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\QQ',
-    'HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\QQ'
-)) {
-    $props = Get-ItemProperty -LiteralPath $key
-    if (-not $props) { continue }
-    if ($props.DisplayIcon) { Add-Candidate ($props.DisplayIcon -replace ',\\d+$', '') }
-    if ($props.UninstallString) {
-        $dir = Split-Path -Parent ($props.UninstallString.Trim('"'))
-        if ($dir) { Add-Candidate (Join-Path $dir 'QQ.exe') }
-    }
-    if ($props.InstallLocation) { Add-Candidate (Join-Path $props.InstallLocation 'QQ.exe') }
-}
-
-# 2) App Paths
-foreach ($key in @(
-    'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\QQ.exe',
-    'HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\QQ.exe'
-)) {
-    Add-Candidate (Get-ItemProperty -LiteralPath $key).'(default)'
-}
-
-# 3) tencent:// protocol handler: points inside versions\\<ver>\\resources\\app,
-#    so walk up the directory tree probing for QQ.exe at each level.
-$proto = (Get-ItemProperty -LiteralPath 'Registry::HKEY_CLASSES_ROOT\\Tencent\\shell\\open\\command').'(default)'
-if ($proto -match '"([^"]+)"') {
-    $dir = Split-Path -Parent $Matches[1]
-    for ($i = 0; $i -lt 6 -and $dir; $i++) {
-        Add-Candidate (Join-Path $dir 'QQ.exe')
-        $dir = Split-Path -Parent $dir
-    }
-}
-
-# 4) Start menu and desktop shortcuts
-$shell = New-Object -ComObject WScript.Shell
-foreach ($root in @(
-    "$env:APPDATA\\Microsoft\\Windows\\Start Menu\\Programs",
-    "$env:ProgramData\\Microsoft\\Windows\\Start Menu\\Programs",
-    "$env:USERPROFILE\\Desktop",
-    "$env:PUBLIC\\Desktop"
-)) {
-    Get-ChildItem -LiteralPath $root -Filter '*QQ*.lnk' -Recurse -Depth 2 |
-        ForEach-Object { Add-Candidate $shell.CreateShortcut($_.FullName).TargetPath }
-}
-
-# 5) Common installation directories
-foreach ($base in @($env:ProgramFiles, ${env:ProgramFiles(x86)}, "$env:LocalAppData\\Programs", 'D:\\Program Files')) {
-    if ($base) { Add-Candidate (Join-Path $base 'Tencent\\QQNT\\QQ.exe') }
-}
-
-foreach ($candidate in $candidates) {
-    if ((Split-Path -Leaf $candidate) -ieq 'QQ.exe' -and (Test-Path -LiteralPath $candidate)) {
-        Write-Output $candidate
-        exit 0
-    }
-}
-'''
-
     # reset-qq-path.bat
     reset_qq_path_bat = '''@echo off
 chcp 65001 >nul
@@ -684,7 +615,7 @@ pause
         "launcher-win10.bat": launcher_win10_bat,
         "launcher-win10-user.bat": launcher_win10_user_bat,
         "reset-qq-path.bat": reset_qq_path_bat,
-        "find-qq.ps1": find_qq_ps1
+        "find-qq.ps1": FIND_QQ_PS1
     }
 
     # Only emit the Windows .bat launchers in Windows packages — they are pure
@@ -892,8 +823,38 @@ extern "C" void qq_magic_napi_register(void *m) {
  * 无需 NapCat 登录即可运行，用于浏览已导出的聊天记录和资源
  */
 import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+function securityConfigPath() {
+    const override = (process.env.QCE_CONFIG_DIR || '').trim();
+    const dir = override || path.join(os.homedir(), '.qq-chat-exporter');
+    return path.join(dir, 'security.json');
+}
+
+// Issue #457: surface the one-click login URL so standalone users are not
+// stuck on the token prompt with no token in sight.
+async function printLoginUrl(port) {
+    const configFile = securityConfigPath();
+    for (let attempt = 0; attempt < 30; attempt++) {
+        try {
+            const config = JSON.parse(await readFile(configFile, 'utf8'));
+            if (config.accessToken) {
+                console.log('');
+                console.log(`[QCE] 一键登录: http://127.0.0.1:${port}/qce/auth?token=${encodeURIComponent(config.accessToken)}`);
+                console.log('[QCE] 此链接包含访问令牌，请勿分享给他人');
+                console.log('');
+                return;
+            }
+        } catch {
+            // security.json not written yet; keep polling.
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    console.log(`[QCE] 未能读取访问令牌，请打开 ${configFile} 查看 accessToken 字段`);
+}
 
 async function main() {
     const port = parseInt(process.argv[2]) || 40653;
@@ -919,6 +880,7 @@ async function main() {
     const stop = () => child.kill();
     process.on('SIGINT', stop);
     process.on('SIGTERM', stop);
+    printLoginUrl(port);
 }
 
 main();


### PR DESCRIPTION
## Summary

Follow-ups to the packaging/release work (issues #589, #457, and the release banner asset complaint):

### Framework package: multi-source QQ discovery (issue #589 follow-up)
The upstream `NapCat.Framework` launchers (`napiLoader.bat` / `napiLoader-debug.bat`) only probe the single `WOW6432Node` uninstall registry key and abort with a cryptic error when it is missing. `build-framework-plugin.py` now replaces them with enhanced launchers that:
- reuse a saved path (`config\qq_path.txt`) and accept a path argument
- run the shared multi-source `find-qq.ps1` probe (uninstall keys x3, App Paths, `tencent://` protocol handler, Start Menu/Desktop shortcuts, common install dirs)
- fall back to a direct `reg query` when PowerShell is unavailable, then common paths
- on failure, show an actionable message (install QQNT hint + GUI file picker / manual path entry) instead of dying

`find-qq.ps1` now lives once in `scripts/plugin_runtime.py` (`FIND_QQ_PS1` / `write_find_qq_script`) and is shared by `quick-pack.py` (Shell packages) and `build-framework-plugin.py` (Framework package).

### Standalone mode: print the one-click login URL (fixes #457)
`start-standalone.bat` started the server, but users had no way to see the access token and were stuck on the `/auth` page. The generated `qce-standalone.mjs` now polls `security.json` (respecting `QCE_CONFIG_DIR`) after `qce-server` starts and prints:

```
[QCE] 一键登录: http://127.0.0.1:<port>/qce/auth?token=...
```

with a fallback hint pointing at `security.json` if the token cannot be read. Regression test: `plugins/qq-chat-exporter/__tests__/unit/standaloneLoginUrl.test.ts` runs the extracted script against a fake `qce-server` and asserts the URL-encoded token is printed.

### Release workflow: banner no longer uploaded as a Release asset
People kept downloading the banner PNG instead of the packages. The banner is now committed to the `release-assets` orphan branch and embedded via `raw.githubusercontent.com`; it is removed from the release `files:` list. If banner generation or publishing fails, the release proceeds without it (no broken image link).

## Testing
- `python3 -m py_compile` on `quick-pack.py`, `build-framework-plugin.py`, `plugin_runtime.py`
- Generated Framework launchers + `find-qq.ps1` locally (CRLF, batch structure verified); `find-qq.ps1` content identical to the previously merged Shell version
- `node --check` on the generated `qce-standalone.mjs`
- Plugin tests: `npm run typecheck`, `npm run test:unit` (39 pass, incl. new #457 regression test)
- Workflow YAML parses; `git diff --check` clean (CRLF files preserved)
