### PR TITLE
docs: correct contribution base branch

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -101,7 +101,7 @@ npm test
 我们非常欢迎社区提交 Pull Request 来共同完善项目！以下是一些教程：
 
 1. 将本仓库 Fork 到你个人的 GitHub 账号下。
-2. 从你的 Fork 仓库中基于 `main` 分支切出一个语义明确的新特性或修复分支（例如 `feat/stream-export` 或 `fix/token-refresh`）。
+2. 从你的 Fork 仓库中基于 `master` 分支切出一个语义明确的新特性或修复分支（例如 `feat/stream-export` 或 `fix/token-refresh`）。
 3. 进行代码编写与本地完整验证。
 4. 提交 Commit 时，请严格遵循 Angular 规范，使用标准的约定式提交格式（Conventional Commits）：
     * `feat: 添加了某项新功能`

--- a/public/docs/contributing.html
+++ b/public/docs/contributing.html
@@ -174,7 +174,7 @@ npm<span class="w"> </span><span class="nb">test</span>
 <p>我们非常欢迎社区提交 Pull Request 来共同完善项目！以下是一些教程：</p>
 <ol>
 <li>将本仓库 Fork 到你个人的 GitHub 账号下。</li>
-<li>从你的 Fork 仓库中基于 <code>main</code> 分支切出一个语义明确的新特性或修复分支（例如 <code>feat/stream-export</code> 或 <code>fix/token-refresh</code>）。</li>
+<li>从你的 Fork 仓库中基于 <code>master</code> 分支切出一个语义明确的新特性或修复分支（例如 <code>feat/stream-export</code> 或 <code>fix/token-refresh</code>）。</li>
 <li>进行代码编写与本地完整验证。</li>
 <li>提交 Commit 时，请严格遵循 Angular 规范，使用标准的约定式提交格式（Conventional Commits）：<ul>
 <li><code>feat: 添加了某项新功能</code></li>


### PR DESCRIPTION
## Summary

- Correct the contribution base branch from `main` to `master`
- Keep the Markdown source and generated HTML documentation consistent

## Changes

- Update `docs/contributing.md`
- Update `public/docs/contributing.html`

## Testing

- Documentation-only change
- Verified the staged diff with `git diff --cached --check`