### PR TITLE
fix: 修复导出文件未鉴权访问和路径遍历

### DIFF
--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -85,6 +85,7 @@ import {
 import type { CreateTaskForm, CreateScheduledExportForm } from "@/types/api"
 import { useQCE } from "@/hooks/use-qce"
 import { BUILD_VERSION, isNewerVersion } from "@/lib/version"
+import AuthManager from "@/lib/auth"
 import { useScheduledExports } from "@/hooks/use-scheduled-exports"
 import { useChatHistory } from "@/hooks/use-chat-history"
 import { useStickerPacks } from "@/hooks/use-sticker-packs"
@@ -3014,7 +3015,7 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
                         className="rounded-full text-[13px]"
                         onClick={() => {
                           const link = document.createElement('a')
-                          link.href = `/api/exports/files/${selectedFile.fileName}`
+                          link.href = `/api/download-file?path=${encodeURIComponent(selectedFile.filePath)}&token=${encodeURIComponent(AuthManager.getInstance().getToken() || "")}`
                           link.download = selectedFile.fileName
                           link.click()
                         }}
@@ -3031,7 +3032,7 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
                   </div>
                   <div className="flex-1 overflow-hidden">
                     <iframe
-                      src={`/api/exports/files/${selectedFile.fileName}/preview`}
+                      src={`/api/exports/files/${encodeURIComponent(selectedFile.fileName)}/preview?token=${encodeURIComponent(AuthManager.getInstance().getToken() || "")}`}
                       className="w-full h-full border-0"
                       title={`预览 ${selectedFile.sessionName}`}
                     />
@@ -3078,7 +3079,7 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
                         className="w-full rounded-xl"
                         onClick={() => {
                           const link = document.createElement('a')
-                          link.href = `/api/exports/files/${selectedFile.fileName}`
+                          link.href = `/api/download-file?path=${encodeURIComponent(selectedFile.filePath)}&token=${encodeURIComponent(AuthManager.getInstance().getToken() || "")}`
                           link.download = selectedFile.fileName
                           link.click()
                         }}

--- a/qce-v4-tool/hooks/use-chat-history.ts
+++ b/qce-v4-tool/hooks/use-chat-history.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import AuthManager from '@/lib/auth';
 
 export interface ExportFile {
   fileName: string;
@@ -107,7 +108,8 @@ export function useChatHistory() {
   const downloadFile = useCallback((file: ExportFile) => {
     // 创建下载链接
     const link = document.createElement('a');
-    link.href = file.relativePath;
+    const token = AuthManager.getInstance().getToken() || '';
+    link.href = `${file.relativePath}?token=${encodeURIComponent(token)}`;
     link.download = file.fileName;
     document.body.appendChild(link);
     link.click();

--- a/qq-chat-export-server/src/api/middleware.rs
+++ b/qq-chat-export-server/src/api/middleware.rs
@@ -82,31 +82,16 @@ fn is_public_route(path: &str) -> bool {
     ];
 
     let lower = path.to_lowercase();
-    let is_static_file = STATIC_EXTENSIONS.iter().any(|ext| lower.ends_with(ext));
-
-    let preview_like = || {
-        let Some(rest) = path.strip_prefix("/api/exports/files/") else {
-            return false;
-        };
-        if let Some((name, tail)) = rest.split_once('/') {
-            if name.is_empty() {
-                return false;
-            }
-            return tail == "preview" || tail == "info" || tail.starts_with("resources/");
-        }
-        false
-    };
+    let is_root_static_file = !path.starts_with("/api/")
+        && !path.starts_with("/resources/")
+        && !path.starts_with("/downloads/")
+        && !path.starts_with("/scheduled-downloads/")
+        && STATIC_EXTENSIONS.iter().any(|ext| lower.ends_with(ext));
 
     PUBLIC_ROUTES.contains(&path)
         || path.starts_with("/static/")
         || path.starts_with("/qce/")
-        || is_static_file
-        || path == "/api/exports/files"
-        || preview_like()
-        || path.starts_with("/resources/")
-        || path.starts_with("/downloads/")
-        || path.starts_with("/scheduled-downloads/")
-        || path == "/download"
+        || is_root_static_file
     // 注意：/api/download-file 需要认证（Issue #192 安全修复）
 }
 
@@ -193,10 +178,13 @@ mod tests {
         assert!(is_public_route("/health"));
         assert!(is_public_route("/qce/index.html"));
         assert!(is_public_route("/static/app.css"));
-        assert!(is_public_route("/api/exports/files"));
-        assert!(is_public_route("/api/exports/files/abc.html/preview"));
-        assert!(is_public_route("/api/exports/files/abc.html/info"));
-        assert!(is_public_route("/api/exports/files/abc/resources/images/x.bin"));
+        assert!(!is_public_route("/api/exports/files"));
+        assert!(!is_public_route("/api/exports/files/abc.html/preview"));
+        assert!(!is_public_route("/api/exports/files/abc.html/info"));
+        assert!(!is_public_route("/api/exports/files/abc/resources/images/x.bin"));
+        assert!(!is_public_route("/api/exports/files/abc/resources/images/x.png"));
+        assert!(!is_public_route("/downloads/abc.html"));
+        assert!(!is_public_route("/resources/avatar.png"));
         assert!(!is_public_route("/api/download-file"));
         assert!(!is_public_route("/api/groups"));
     }

--- a/qq-chat-export-server/src/api/routes/resources.rs
+++ b/qq-chat-export-server/src/api/routes/resources.rs
@@ -98,6 +98,47 @@ fn ext_of(name: &str) -> String {
         .unwrap_or_default()
 }
 
+fn valid_export_file_name(file_name: &str) -> bool {
+    let mut components = FsPath::new(file_name).components();
+    matches!(components.next(), Some(std::path::Component::Normal(_)))
+        && components.next().is_none()
+        && !file_name.contains('\0')
+}
+
+struct ResolvedExportFile {
+    path: PathBuf,
+    base_dir: PathBuf,
+    is_scheduled: bool,
+}
+
+/// Resolves an existing top-level export file without permitting traversal or symlink escape.
+fn resolve_export_file(state: &SharedState, file_name: &str) -> Option<ResolvedExportFile> {
+    if !valid_export_file_name(file_name) {
+        return None;
+    }
+
+    for (base_dir, is_scheduled) in [
+        (state.path_manager.exports_dir(), false),
+        (state.path_manager.scheduled_exports_dir(), true),
+    ] {
+        let candidate = base_dir.join(file_name);
+        if !candidate.is_file() {
+            continue;
+        }
+        let (Ok(path), Ok(canonical_base)) = (candidate.canonicalize(), base_dir.canonicalize()) else {
+            continue;
+        };
+        if path.starts_with(&canonical_base) {
+            return Some(ResolvedExportFile {
+                path,
+                base_dir,
+                is_scheduled,
+            });
+        }
+    }
+    None
+}
+
 
 // 导出文件名解析（Issue #216 新旧格式兼容）
 
@@ -607,19 +648,12 @@ pub async fn export_file_info(
     Extension(RequestId(request_id)): Extension<RequestId>,
     Path(file_name): Path<String>,
 ) -> Response {
-    let export_dir = state.path_manager.exports_dir();
-    let scheduled_dir = state.path_manager.scheduled_exports_dir();
-
-    let mut file_path = export_dir.join(&file_name);
-    let mut is_scheduled = false;
-    if !file_path.exists() {
-        file_path = scheduled_dir.join(&file_name);
-        is_scheduled = true;
-    }
-    if !file_path.exists() {
+    let Some(resolved) = resolve_export_file(&state, &file_name) else {
         let err = ApiError::validation("导出文件不存在", "FILE_NOT_FOUND");
         return response::error(&err, &request_id);
-    }
+    };
+    let file_path = resolved.path;
+    let is_scheduled = resolved.is_scheduled;
     let Some(basic_info) = parse_export_file_name(&file_name) else {
         let err = ApiError::validation("无效的文件名格式", "INVALID_FILENAME");
         return response::error(&err, &request_id);
@@ -731,19 +765,11 @@ pub async fn delete_export_file(
     Extension(RequestId(request_id)): Extension<RequestId>,
     Path(file_name): Path<String>,
 ) -> Response {
-    let export_dir = state.path_manager.exports_dir();
-    let scheduled_dir = state.path_manager.scheduled_exports_dir();
-
-    let mut target = export_dir.join(&file_name);
-    let mut base_dir = export_dir;
-    if !target.exists() {
-        target = scheduled_dir.join(&file_name);
-        base_dir = scheduled_dir;
-    }
-    if !target.exists() {
+    let Some(resolved) = resolve_export_file(&state, &file_name) else {
         let err = ApiError::validation("文件不存在", "FILE_NOT_FOUND");
         return response::error(&err, &request_id);
-    }
+    };
+    let base_dir = resolved.base_dir;
 
     static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
     let re = RE.get_or_init(|| regex::Regex::new(r"\.(html|json)$").expect("valid regex"));
@@ -827,17 +853,11 @@ pub async fn preview_export_file(
     Extension(RequestId(request_id)): Extension<RequestId>,
     Path(file_name): Path<String>,
 ) -> Response {
-    let export_dir = state.path_manager.exports_dir();
-    let scheduled_dir = state.path_manager.scheduled_exports_dir();
-
-    let mut file_path = export_dir.join(&file_name);
-    if !file_path.exists() {
-        file_path = scheduled_dir.join(&file_name);
-    }
-    if !file_path.exists() {
-        let err = ApiError::validation(format!("文件不存在: {file_name}"), "FILE_NOT_FOUND");
+    let Some(resolved) = resolve_export_file(&state, &file_name) else {
+        let err = ApiError::validation("导出文件不存在", "FILE_NOT_FOUND");
         return response::error(&err, &request_id);
-    }
+    };
+    let file_path = resolved.path;
 
     let is_json = ext_of(&file_name) == ".json";
     let html = if is_json {
@@ -971,6 +991,10 @@ pub async fn export_file_resource(
     Extension(RequestId(request_id)): Extension<RequestId>,
     Path((file_name, resource_path)): Path<(String, String)>,
 ) -> Response {
+    if !valid_export_file_name(&file_name) {
+        let err = ApiError::validation("非法的导出文件名", "INVALID_FILENAME");
+        return response::error(&err, &request_id);
+    }
     if resource_path.contains("..")
         || resource_path.starts_with('/')
         || resource_path.starts_with('\\')
@@ -1254,6 +1278,10 @@ pub async fn export_file_resources(
     Extension(RequestId(request_id)): Extension<RequestId>,
     Path(file_name): Path<String>,
 ) -> Response {
+    if !valid_export_file_name(&file_name) {
+        let err = ApiError::validation("非法的导出文件名", "INVALID_FILENAME");
+        return response::error(&err, &request_id);
+    }
     let exports_dir = state.path_manager.exports_dir();
     let scheduled_dir = state.path_manager.scheduled_exports_dir();
 
@@ -2194,7 +2222,7 @@ mod metadata_tests {
     use super::{
         apply_file_metadata, avatar_url, extract_html_time_range, parse_export_file_name,
         parse_manifest_metadata, parse_manual_export_file_name, should_select_in_file_manager,
-        windows_explorer_args,
+        valid_export_file_name, windows_explorer_args,
     };
     use serde_json::json;
     use std::fs;
@@ -2204,6 +2232,22 @@ mod metadata_tests {
         assert!(avatar_url("friend", "u_peer").is_none());
         assert!(avatar_url("friend", "0").is_none());
         assert!(avatar_url("friend", "1687657986").is_some());
+    }
+
+    #[test]
+    fn export_file_name_rejects_traversal_and_absolute_paths() {
+        assert!(valid_export_file_name("friend_123_20260713_002703.html"));
+        for invalid in [
+            "../etc/passwd",
+            "..\\Windows\\win.ini",
+            "/etc/passwd",
+            "C:\\Windows\\win.ini",
+            "nested/file.html",
+            "nested\\file.html",
+            "",
+        ] {
+            assert!(!valid_export_file_name(invalid), "{invalid}");
+        }
     }
 
     #[test]

--- a/qq-chat-export-server/src/api/routes/resources.rs
+++ b/qq-chat-export-server/src/api/routes/resources.rs
@@ -852,6 +852,7 @@ pub async fn preview_export_file(
     State(state): State<SharedState>,
     Extension(RequestId(request_id)): Extension<RequestId>,
     Path(file_name): Path<String>,
+    Query(params): Query<HashMap<String, String>>,
 ) -> Response {
     let Some(resolved) = resolve_export_file(&state, &file_name) else {
         let err = ApiError::validation("导出文件不存在", "FILE_NOT_FOUND");
@@ -905,15 +906,23 @@ pub async fn preview_export_file(
         let mut content = std::fs::read_to_string(&file_path).unwrap_or_default();
         let encoded = encode_uri_component(&file_name);
         let api_prefix = format!("/api/exports/files/{encoded}/resources/");
-        for pattern in [
-            "src=\"./resources/",
-            "href=\"./resources/",
-            "src=\"../resources/",
-            "href=\"../resources/",
-        ] {
-            let attr = &pattern[..=pattern.find('"').unwrap_or(0)];
-            content = content.replace(pattern, &format!("{attr}{api_prefix}"));
-        }
+        let token_suffix = params
+            .get("token")
+            .filter(|token| !token.is_empty())
+            .map(|token| format!("?token={}", encode_uri_component(token)))
+            .unwrap_or_default();
+        let resource_re = regex::Regex::new(
+            r#"(?P<attr>src|href)=\"(?:\./|\.\./)resources/(?P<path>[^\"]*)\""#,
+        )
+        .expect("valid resource URL regex");
+        content = resource_re
+            .replace_all(&content, |captures: &regex::Captures<'_>| {
+                format!(
+                    "{}=\"{api_prefix}{}{}\"",
+                    &captures["attr"], &captures["path"], token_suffix
+                )
+            })
+            .into_owned();
         content
     };
 

--- a/qq-chat-export-server/src/api/routes/resources.rs
+++ b/qq-chat-export-server/src/api/routes/resources.rs
@@ -102,6 +102,7 @@ fn valid_export_file_name(file_name: &str) -> bool {
     let mut components = FsPath::new(file_name).components();
     matches!(components.next(), Some(std::path::Component::Normal(_)))
         && components.next().is_none()
+        && !file_name.contains(['/', '\\'])
         && !file_name.contains('\0')
 }
 


### PR DESCRIPTION
qq-chat-exporter v6.0.6 以前的版本 (包括 NapCat 发行的 5.5.* 版本) 存在导出接口未授权与路径遍历，攻击者可以在未登录的情况下列举已有的导出文件，并在路径下实现任意文件读取。即使从5.5.*版本重构到6.0，此漏洞依然继承。由于项目的默认位置固定且通常以root权限进行，且此接口暴露在公网，访问限制形同虚设，因此危害极高。

## 修复内容

  - 收紧导出文件相关路由的认证要求，防止未携带访问令牌的文件枚举、预览、资源读取和下载。
  - 修复 /api/exports/files/:fileName/preview 的路径遍历/LFI 风险。
  - 文件名仅允许单层路径，并在 canonicalize 后确认目标仍位于受控的 exports 或 scheduled-exports 根目录内。
  - 同步保护详情、删除和资源关联接口，避免同类路径绕过。
  - 保持既有 token 参数键；iframe 预览、预览资源和下载链接均通过 ?token= 保持可用。
  - 不新增 cookie 或新的认证状态。