### PR TITLE
fix: harden API security boundaries

### DIFF
--- a/qq-chat-export-server/src/api/middleware.rs
+++ b/qq-chat-export-server/src/api/middleware.rs
@@ -14,8 +14,11 @@ pub async fn request_id_middleware(mut request: Request<Body>, next: Next) -> Re
         .headers()
         .get("x-request-id")
         .and_then(|value| value.to_str().ok())
+        .filter(|value| value.len() <= 128)
         .map_or_else(response::generate_request_id, ToString::to_string);
-    request.extensions_mut().insert(RequestId(request_id.clone()));
+    request
+        .extensions_mut()
+        .insert(RequestId(request_id.clone()));
     let mut response = next.run(request).await;
     if let Ok(header_value) = HeaderValue::from_str(&request_id) {
         response.headers_mut().insert("x-request-id", header_value);
@@ -25,21 +28,6 @@ pub async fn request_id_middleware(mut request: Request<Body>, next: Next) -> Re
 
 /// 从请求中提取真实客户端 IP。
 pub fn client_ip(request: &Request<Body>) -> Option<String> {
-    let headers = request.headers();
-    if let Some(forwarded) = headers.get("x-forwarded-for").and_then(|v| v.to_str().ok()) {
-        if let Some(first) = forwarded.split(',').next() {
-            let trimmed = first.trim();
-            if !trimmed.is_empty() {
-                return Some(trimmed.to_string());
-            }
-        }
-    }
-    if let Some(real_ip) = headers.get("x-real-ip").and_then(|v| v.to_str().ok()) {
-        let trimmed = real_ip.trim();
-        if !trimmed.is_empty() {
-            return Some(trimmed.to_string());
-        }
-    }
     request
         .extensions()
         .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
@@ -75,8 +63,14 @@ fn map_verify_token_failure(
 
 /// 判断路径是否为公开路由（无需认证）。
 fn is_public_route(path: &str) -> bool {
-    const PUBLIC_ROUTES: [&str; 6] =
-        ["/", "/health", "/auth", "/auth/", "/security-status", "/qce"];
+    const PUBLIC_ROUTES: [&str; 6] = [
+        "/",
+        "/health",
+        "/auth",
+        "/auth/",
+        "/security-status",
+        "/qce",
+    ];
     const STATIC_EXTENSIONS: [&str; 11] = [
         ".png", ".jpg", ".jpeg", ".svg", ".gif", ".ico", ".css", ".js", ".woff", ".woff2", ".ttf",
     ];
@@ -95,6 +89,14 @@ fn is_public_route(path: &str) -> bool {
     // 注意：/api/download-file 需要认证（Issue #192 安全修复）
 }
 
+fn is_websocket_upgrade(request: &Request<Body>) -> bool {
+    request
+        .headers()
+        .get("upgrade")
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.eq_ignore_ascii_case("websocket"))
+}
+
 /// 安全认证中间件。
 pub async fn auth_middleware(
     State(state): State<SharedState>,
@@ -102,7 +104,8 @@ pub async fn auth_middleware(
     next: Next,
 ) -> Response {
     let path = request.uri().path().to_string();
-    if is_public_route(&path) {
+    let root_websocket_upgrade = path == "/" && is_websocket_upgrade(&request);
+    if is_public_route(&path) && !root_websocket_upgrade {
         return next.run(request).await;
     }
 
@@ -116,11 +119,13 @@ pub async fn auth_middleware(
         .headers()
         .get("authorization")
         .and_then(|value| value.to_str().ok())
-        .map(|value| value.trim_start_matches("Bearer ").to_string())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .map(ToString::to_string)
         .or_else(|| {
-            request.uri().query().and_then(|query| {
-                url_query_param(query, "token")
-            })
+            request
+                .uri()
+                .query()
+                .and_then(|query| url_query_param(query, "token"))
         })
         .or_else(|| {
             request
@@ -157,7 +162,9 @@ pub async fn auth_middleware(
 /// 从 query string 中提取参数（URL 解码）。
 fn url_query_param(query: &str, key: &str) -> Option<String> {
     for pair in query.split('&') {
-        let (k, v) = pair.split_once('=')?;
+        let Some((k, v)) = pair.split_once('=') else {
+            continue;
+        };
         if k == key {
             return percent_encoding::percent_decode_str(v)
                 .decode_utf8()
@@ -181,11 +188,48 @@ mod tests {
         assert!(!is_public_route("/api/exports/files"));
         assert!(!is_public_route("/api/exports/files/abc.html/preview"));
         assert!(!is_public_route("/api/exports/files/abc.html/info"));
-        assert!(!is_public_route("/api/exports/files/abc/resources/images/x.bin"));
-        assert!(!is_public_route("/api/exports/files/abc/resources/images/x.png"));
+        assert!(!is_public_route(
+            "/api/exports/files/abc/resources/images/x.bin"
+        ));
+        assert!(!is_public_route(
+            "/api/exports/files/abc/resources/images/x.png"
+        ));
         assert!(!is_public_route("/downloads/abc.html"));
         assert!(!is_public_route("/resources/avatar.png"));
         assert!(!is_public_route("/api/download-file"));
         assert!(!is_public_route("/api/groups"));
+    }
+
+    #[test]
+    fn root_websocket_upgrade_is_not_treated_as_public_http() {
+        let request = Request::builder()
+            .header("upgrade", "websocket")
+            .body(Body::empty())
+            .expect("request");
+        assert!(is_public_route("/"));
+        assert!(is_websocket_upgrade(&request));
+    }
+
+    #[test]
+    fn client_ip_ignores_forwarding_headers() {
+        let mut request = Request::builder()
+            .header("x-forwarded-for", "127.0.0.1")
+            .header("x-real-ip", "127.0.0.1")
+            .body(Body::empty())
+            .expect("request");
+        request.extensions_mut().insert(axum::extract::ConnectInfo(
+            "192.0.2.25:40653"
+                .parse::<std::net::SocketAddr>()
+                .expect("socket address"),
+        ));
+        assert_eq!(client_ip(&request).as_deref(), Some("192.0.2.25"));
+    }
+
+    #[test]
+    fn query_parser_skips_malformed_pairs() {
+        assert_eq!(
+            url_query_param("broken&token=abc%20123", "token").as_deref(),
+            Some("abc 123")
+        );
     }
 }

--- a/qq-chat-export-server/src/api/mod.rs
+++ b/qq-chat-export-server/src/api/mod.rs
@@ -1,5 +1,6 @@
 pub mod helpers;
 pub mod middleware;
+pub mod path_security;
 pub mod response;
 pub mod routes;
 pub mod state;

--- a/qq-chat-export-server/src/api/path_security.rs
+++ b/qq-chat-export-server/src/api/path_security.rs
@@ -1,0 +1,136 @@
+use std::ffi::OsString;
+use std::path::{Component, Path, PathBuf};
+
+fn has_unsafe_components(path: &Path) -> bool {
+    path.components()
+        .any(|component| matches!(component, Component::ParentDir | Component::CurDir))
+}
+
+fn canonical_roots(roots: &[PathBuf]) -> Vec<PathBuf> {
+    roots
+        .iter()
+        .filter_map(|root| root.canonicalize().ok())
+        .collect()
+}
+
+#[must_use]
+pub fn resolve_existing_within(path: &Path, roots: &[PathBuf]) -> Option<PathBuf> {
+    if !path.is_absolute() || has_unsafe_components(path) {
+        return None;
+    }
+    let resolved = path.canonicalize().ok()?;
+    canonical_roots(roots)
+        .iter()
+        .any(|root| resolved.starts_with(root))
+        .then_some(resolved)
+}
+
+#[must_use]
+pub fn resolve_existing_descendant_within(path: &Path, roots: &[PathBuf]) -> Option<PathBuf> {
+    let resolved = resolve_existing_within(path, roots)?;
+    canonical_roots(roots)
+        .iter()
+        .any(|root| resolved != *root && resolved.starts_with(root))
+        .then_some(resolved)
+}
+
+#[must_use]
+pub fn resolve_for_creation_within(path: &Path, roots: &[PathBuf]) -> Option<PathBuf> {
+    if !path.is_absolute() || has_unsafe_components(path) {
+        return None;
+    }
+    if path.exists() {
+        return resolve_existing_within(path, roots);
+    }
+
+    let mut cursor = path;
+    let mut missing: Vec<OsString> = Vec::new();
+    while !cursor.exists() {
+        missing.push(cursor.file_name()?.to_os_string());
+        cursor = cursor.parent()?;
+    }
+
+    let mut resolved = cursor.canonicalize().ok()?;
+    let canonical_roots = canonical_roots(roots);
+    if !canonical_roots
+        .iter()
+        .any(|root| resolved.starts_with(root))
+    {
+        return None;
+    }
+    for component in missing.into_iter().rev() {
+        resolved.push(component);
+    }
+    Some(resolved)
+}
+
+#[must_use]
+pub fn valid_relative_resource_path(raw: &str) -> bool {
+    !raw.is_empty()
+        && !raw.contains(['\\', '\0', ':'])
+        && raw
+            .split('/')
+            .all(|segment| !segment.is_empty() && segment != "." && segment != "..")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn relative_resource_paths_reject_cross_platform_escape_forms() {
+        assert!(valid_relative_resource_path("images/avatar.png"));
+        for invalid in [
+            "../secret.txt",
+            "images/../secret.txt",
+            "images\\secret.txt",
+            "C:/secret.txt",
+            "/absolute.txt",
+            "images//avatar.png",
+        ] {
+            assert!(!valid_relative_resource_path(invalid), "{invalid}");
+        }
+    }
+
+    #[test]
+    fn existing_paths_must_remain_inside_allowed_roots() {
+        let root = std::env::temp_dir().join(format!(
+            "qce-path-security-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock")
+                .as_nanos()
+        ));
+        let allowed = root.join("exports");
+        let outside = root.join("outside");
+        std::fs::create_dir_all(&allowed).expect("create allowed root");
+        std::fs::create_dir_all(&outside).expect("create outside root");
+        let inside_file = allowed.join("chat.json");
+        let outside_file = outside.join("secret.json");
+        std::fs::write(&inside_file, "{}").expect("write inside file");
+        std::fs::write(&outside_file, "{}").expect("write outside file");
+
+        assert!(resolve_existing_within(&inside_file, std::slice::from_ref(&allowed)).is_some());
+        assert!(resolve_existing_within(&outside_file, std::slice::from_ref(&allowed)).is_none());
+        assert!(
+            resolve_existing_descendant_within(&allowed, std::slice::from_ref(&allowed)).is_none()
+        );
+        assert!(
+            resolve_existing_descendant_within(&inside_file, std::slice::from_ref(&allowed))
+                .is_some()
+        );
+        assert!(resolve_for_creation_within(
+            &allowed.join("merged/new"),
+            std::slice::from_ref(&allowed)
+        )
+        .is_some());
+        assert!(resolve_for_creation_within(
+            &outside.join("merged/new"),
+            std::slice::from_ref(&allowed)
+        )
+        .is_none());
+
+        std::fs::remove_dir_all(root).expect("remove test root");
+    }
+}

--- a/qq-chat-export-server/src/api/routes/messages.rs
+++ b/qq-chat-export-server/src/api/routes/messages.rs
@@ -635,11 +635,20 @@ async fn prepare_export_request(
             .and_then(Value::as_str)
             .unwrap_or(""),
     );
-    let output_dir = if custom_output_dir.trim().is_empty() {
+    let requested_output_dir = if custom_output_dir.trim().is_empty() {
         state.path_manager.exports_dir()
     } else {
         PathBuf::from(&custom_output_dir)
     };
+    let output_roots = [
+        state.path_manager.exports_dir(),
+        state.path_manager.scheduled_exports_dir(),
+    ];
+    let output_dir = crate::api::path_security::resolve_for_creation_within(
+        &requested_output_dir,
+        &output_roots,
+    )
+    .ok_or_else(|| ApiError::validation("导出目录必须位于允许的导出目录内", "INVALID_PATH"))?;
 
     // 会话名：优先用户输入（issue #365）。
     let user_session_name = body

--- a/qq-chat-export-server/src/api/routes/resources.rs
+++ b/qq-chat-export-server/src/api/routes/resources.rs
@@ -13,12 +13,13 @@ use serde_json::{json, Value};
 use qce_exporter::modern_html_exporter::{HtmlExportOptions, ModernHtmlExporter};
 use qce_exporter::types::{ChatInfo, CleanMessage};
 
+use crate::api::path_security::{
+    resolve_existing_within, resolve_for_creation_within, valid_relative_resource_path,
+};
 use crate::api::response::{self, ApiError, ErrorType, RequestId};
 use crate::api::state::SharedState;
 
-
 // 通用小工具
-
 
 fn iso(time: std::time::SystemTime) -> String {
     DateTime::<Utc>::from(time).to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
@@ -126,7 +127,8 @@ fn resolve_export_file(state: &SharedState, file_name: &str) -> Option<ResolvedE
         if !candidate.is_file() {
             continue;
         }
-        let (Ok(path), Ok(canonical_base)) = (candidate.canonicalize(), base_dir.canonicalize()) else {
+        let (Ok(path), Ok(canonical_base)) = (candidate.canonicalize(), base_dir.canonicalize())
+        else {
             continue;
         };
         if path.starts_with(&canonical_base) {
@@ -140,9 +142,7 @@ fn resolve_export_file(state: &SharedState, file_name: &str) -> Option<ResolvedE
     None
 }
 
-
 // 导出文件名解析（Issue #216 新旧格式兼容）
-
 
 fn valid_qq_uin(value: &str) -> bool {
     value != "0" && !value.is_empty() && value.chars().all(|c| c.is_ascii_digit())
@@ -318,9 +318,7 @@ fn strip_suffix_ci<'a>(input: &'a str, suffix: &str) -> Option<&'a str> {
     }
 }
 
-
 // 导出文件元数据解析
-
 
 #[derive(Default)]
 struct FileMetadata {
@@ -470,9 +468,7 @@ async fn display_name_for_chat(
     }
 }
 
-
 // 目录扫描
-
 
 /// 高性能目录统计（递归文件数 + 总大小）。
 fn scan_directory_stats(dir: &FsPath) -> (i64, i64) {
@@ -610,9 +606,7 @@ async fn scan_export_dir(
     }
 }
 
-
 // GET /api/exports/files
-
 
 /// 获取导出文件列表（聊天记录索引页面）。
 pub async fn list_export_files(
@@ -639,9 +633,7 @@ pub async fn list_export_files(
     response::success(json!({ "files": files }), &request_id)
 }
 
-
 // GET /api/exports/files/:fileName/info
-
 
 /// 获取特定导出文件的详细信息。
 pub async fn export_file_info(
@@ -756,9 +748,7 @@ pub async fn export_file_info(
     response::success(result, &request_id)
 }
 
-
 // DELETE /api/exports/files/:fileName（Issue #32）
-
 
 /// 删除导出文件（HTML + JSON + 资源目录）。
 pub async fn delete_export_file(
@@ -796,9 +786,7 @@ pub async fn delete_export_file(
     )
 }
 
-
 // GET /api/exports/files/:fileName/preview
-
 
 fn escape_html(text: &str) -> String {
     text.replace('&', "&amp;")
@@ -912,10 +900,9 @@ pub async fn preview_export_file(
             .filter(|token| !token.is_empty())
             .map(|token| format!("?token={}", encode_uri_component(token)))
             .unwrap_or_default();
-        let resource_re = regex::Regex::new(
-            r#"(?P<attr>src|href)=\"(?:\./|\.\./)resources/(?P<path>[^\"]*)\""#,
-        )
-        .expect("valid resource URL regex");
+        let resource_re =
+            regex::Regex::new(r#"(?P<attr>src|href)=\"(?:\./|\.\./)resources/(?P<path>[^\"]*)\""#)
+                .expect("valid resource URL regex");
         content = resource_re
             .replace_all(&content, |captures: &regex::Captures<'_>| {
                 format!(
@@ -939,9 +926,7 @@ pub async fn preview_export_file(
         .into_response()
 }
 
-
 // GET /api/exports/files/:fileName/resources/*path
-
 
 /// 构建单个资源目录的文件名缓存（shortName → 实际文件名）。
 async fn build_resource_cache(state: &SharedState, dir_path: &str) -> HashMap<String, String> {
@@ -982,13 +967,8 @@ async fn find_resource_file(state: &SharedState, resource_path: &str) -> Option<
     let short_name = path.file_name().map(|n| n.to_string_lossy().into_owned())?;
     let cache = build_resource_cache(state, &dir_path).await;
     let actual = cache.get(&short_name)?;
-    Some(
-        state
-            .path_manager
-            .resources_dir()
-            .join(dir_path)
-            .join(actual),
-    )
+    let resources_dir = state.path_manager.resources_dir();
+    resolve_existing_within(&resources_dir.join(dir_path).join(actual), &[resources_dir])
 }
 
 /// HTML 预览页面的资源文件服务。
@@ -1005,10 +985,7 @@ pub async fn export_file_resource(
         let err = ApiError::validation("非法的导出文件名", "INVALID_FILENAME");
         return response::error(&err, &request_id);
     }
-    if resource_path.contains("..")
-        || resource_path.starts_with('/')
-        || resource_path.starts_with('\\')
-    {
+    if !valid_relative_resource_path(&resource_path) {
         let err = ApiError::validation("非法的资源路径", "INVALID_PATH");
         return response::error(&err, &request_id);
     }
@@ -1083,7 +1060,7 @@ async fn find_export_local_resource(
 
     let candidate = resource_dir.join(resource_path);
     if candidate.is_file() {
-        return Some(candidate);
+        return resolve_existing_within(&candidate, &[resource_dir.clone()]);
     }
 
     // 带 MD5 前缀匹配：目录下文件名为 `md5_originalName.ext`
@@ -1107,20 +1084,18 @@ async fn find_export_local_resource(
         }
         let file_name = entry.file_name().to_string_lossy().into_owned();
         if file_name == short_name {
-            return Some(entry.path());
+            return resolve_existing_within(&entry.path(), &[resource_dir.clone()]);
         }
         if let Some(idx) = file_name.find('_') {
             if idx > 0 && file_name[idx + 1..] == short_name {
-                return Some(entry.path());
+                return resolve_existing_within(&entry.path(), &[resource_dir.clone()]);
             }
         }
     }
     None
 }
 
-
 // GET /api/resources/index
-
 
 /// 构建完整的资源索引（全局资源目录 + ZIP + JSONL）。
 pub async fn resources_index(
@@ -1278,9 +1253,7 @@ pub async fn resources_index(
     )
 }
 
-
 // GET /api/resources/export/:fileName
-
 
 /// 获取特定导出文件的资源列表。
 pub async fn export_file_resources(
@@ -1349,9 +1322,7 @@ pub async fn export_file_resources(
     response::success(json!({ "resources": resources }), &request_id)
 }
 
-
 // GET /api/resources/files
-
 
 /// `nameSearch` 子串最大长度。
 const MAX_NAME_SEARCH_LENGTH: usize = 200;
@@ -1386,7 +1357,7 @@ pub async fn global_resource_files(
         .get("limit")
         .and_then(|l| l.parse::<usize>().ok())
         .unwrap_or(50)
-        .max(1);
+        .clamp(1, 200);
     let name_search = normalize_name_search(params.get("nameSearch").map(String::as_str));
 
     let resources_dir = state.path_manager.resources_dir();
@@ -1456,12 +1427,11 @@ pub async fn global_resource_files(
     )
 }
 
-
 // GET /api/download-file（Issue #192）
-
 
 /// 动态下载 API（自定义导出路径的文件下载，含路径安全校验）。
 pub async fn download_file(
+    State(state): State<SharedState>,
     Extension(RequestId(request_id)): Extension<RequestId>,
     Query(params): Query<HashMap<String, String>>,
 ) -> Response {
@@ -1482,15 +1452,6 @@ pub async fn download_file(
         );
     }
     let normalized = PathBuf::from(raw_path);
-    if normalized
-        .components()
-        .any(|c| matches!(c, std::path::Component::ParentDir))
-    {
-        return response::error(
-            &permission_err("非法的文件路径", "INVALID_PATH"),
-            &request_id,
-        );
-    }
 
     // 只允许下载导出文件扩展名。
     let ext = ext_of(raw_path);
@@ -1508,6 +1469,17 @@ pub async fn download_file(
             &request_id,
         );
     }
+
+    let roots = [
+        state.path_manager.exports_dir(),
+        state.path_manager.scheduled_exports_dir(),
+    ];
+    let Some(normalized) = resolve_existing_within(&normalized, &roots) else {
+        return response::error(
+            &permission_err("文件不在允许的导出目录内", "PATH_NOT_ALLOWED"),
+            &request_id,
+        );
+    };
 
     let Ok(meta) = std::fs::metadata(&normalized) else {
         let err = ApiError::new(ErrorType::FileSystem, "文件不存在", "FILE_NOT_FOUND")
@@ -1553,9 +1525,7 @@ pub async fn download_file(
         .into_response()
 }
 
-
 // POST /api/open-file-location / /api/open-export-directory
-
 
 fn extract_html_time_range(html: &str) -> Option<String> {
     static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
@@ -1615,6 +1585,7 @@ fn should_select_in_file_manager(target: &FsPath) -> bool {
 
 /// 打开文件所在位置（文件管理器中选中该文件）。
 pub async fn open_file_location(
+    State(state): State<SharedState>,
     Extension(RequestId(request_id)): Extension<RequestId>,
     Json(body): Json<Value>,
 ) -> Response {
@@ -1626,11 +1597,15 @@ pub async fn open_file_location(
         let err = ApiError::validation("缺少文件路径参数", "MISSING_FILE_PATH");
         return response::error(&err, &request_id);
     };
-    let path = PathBuf::from(file_path);
-    if !path.exists() {
-        let err = ApiError::validation("文件不存在", "FILE_NOT_FOUND");
+    let roots = [
+        state.path_manager.exports_dir(),
+        state.path_manager.scheduled_exports_dir(),
+        state.path_manager.resources_dir(),
+    ];
+    let Some(path) = resolve_existing_within(&PathBuf::from(file_path), &roots) else {
+        let err = ApiError::validation("文件不在允许的导出目录内", "PATH_NOT_ALLOWED");
         return response::error(&err, &request_id);
-    }
+    };
     open_in_file_manager(&path, should_select_in_file_manager(&path));
     response::success(json!({ "message": "已打开文件位置" }), &request_id)
 }
@@ -1643,15 +1618,10 @@ pub async fn open_export_directory(
     let export_dir = state.path_manager.exports_dir();
     let _ = std::fs::create_dir_all(&export_dir);
     open_in_file_manager(&export_dir, false);
-    response::success(
-        json!({ "message": "已打开导出目录", "path": export_dir.to_string_lossy() }),
-        &request_id,
-    )
+    response::success(json!({ "message": "已打开导出目录" }), &request_id)
 }
 
-
 // 手动导出文件名解析（Issue #163）
-
 
 /// 手动导出文件名解析结果。
 struct ManualExportInfo {
@@ -1695,9 +1665,7 @@ fn parse_manual_export_file_name(file_name: &str) -> Option<ManualExportInfo> {
     })
 }
 
-
 // GET /api/merge-resources/available-tasks
-
 
 /// 获取可用于合并的备份列表（定时备份 + 手动导出，按会话分组）。
 pub async fn merge_available_tasks(
@@ -1856,9 +1824,7 @@ pub async fn merge_available_tasks(
     )
 }
 
-
 // POST /api/merge-resources（ResourceMerger 移植）
-
 
 struct MergeSource {
     html_file: PathBuf,
@@ -1902,17 +1868,16 @@ fn validate_merge_sources(
     let re = RE.get_or_init(|| regex::Regex::new(r"\.(html|json)$").expect("valid regex"));
 
     for file_name in file_names {
-        let export_path = export_dir.join(file_name);
-        let scheduled_path = scheduled_dir.join(file_name);
-        let (found_path, task_dir) = if export_path.exists() {
-            (export_path, &export_dir)
-        } else if scheduled_path.exists() {
-            (scheduled_path, &scheduled_dir)
-        } else {
+        if !valid_export_file_name(file_name) {
+            return Err(format!("非法的导出文件名: {file_name}"));
+        }
+        let Some(resolved) = resolve_export_file(state, file_name) else {
             return Err(format!(
                 "未找到文件: {file_name}（已搜索exports和scheduled-exports目录）"
             ));
         };
+        let found_path = resolved.path;
+        let task_dir = resolved.base_dir;
 
         let base_name = re.replace(file_name, "").into_owned();
         let json_file = format!("{base_name}.json");
@@ -1926,10 +1891,17 @@ fn validate_merge_sources(
             None
         };
 
+        let resource_candidate = task_dir.join(format!("resources_{base_name}"));
+        let resource_dir = if resource_candidate.exists() {
+            resolve_existing_within(&resource_candidate, std::slice::from_ref(&task_dir))
+                .ok_or_else(|| format!("资源目录越过导出目录边界: {file_name}"))?
+        } else {
+            resource_candidate
+        };
         sources.push(MergeSource {
             html_file: found_path,
             json_file: json_path,
-            resource_dir: task_dir.join(format!("resources_{base_name}")),
+            resource_dir,
         });
     }
     Ok(sources)
@@ -2124,6 +2096,10 @@ pub async fn merge_resources(
                 .collect()
         })
         .unwrap_or_default();
+    if source_task_ids.len() > 100 {
+        let err = ApiError::validation("单次最多合并100个任务", "TOO_MANY_SOURCE_TASKS");
+        return response::error(&err, &request_id);
+    }
     if source_task_ids.len() < 2 {
         let err = ApiError::validation("至少需要选择2个任务进行合并", "INVALID_SOURCE_TASKS");
         return response::error(&err, &request_id);
@@ -2136,14 +2112,27 @@ pub async fn merge_resources(
         .get("deduplicateMessages")
         .and_then(Value::as_bool)
         .unwrap_or(true);
-    let output_path = body
+    let requested_output_path = body
         .get("outputPath")
         .and_then(Value::as_str)
         .filter(|p| !p.is_empty())
         .map_or_else(
-            || state.path_manager.default_base_dir().join("merged"),
+            || state.path_manager.exports_dir().join("merged"),
             PathBuf::from,
         );
+    let roots = [
+        state.path_manager.exports_dir(),
+        state.path_manager.scheduled_exports_dir(),
+    ];
+    let Some(output_path) = resolve_for_creation_within(&requested_output_path, &roots) else {
+        let err = ApiError::new(
+            ErrorType::Api,
+            "合并输出目录必须位于导出目录内",
+            "OUTPUT_PATH_NOT_ALLOWED",
+        )
+        .with_status(StatusCode::FORBIDDEN);
+        return response::error(&err, &request_id);
+    };
 
     let start_time = std::time::Instant::now();
     let merge_task_id = format!(

--- a/qq-chat-export-server/src/api/routes/security.rs
+++ b/qq-chat-export-server/src/api/routes/security.rs
@@ -30,35 +30,14 @@ fn server_addresses(state: &SharedState) -> Value {
 pub async fn security_status(
     State(state): State<SharedState>,
     Extension(RequestId(request_id)): Extension<RequestId>,
-    request: Request<Body>,
+    _request: Request<Body>,
 ) -> Response {
     let mut status = state.security_manager.security_status();
     if let Some(obj) = status.as_object_mut() {
         obj.insert("requiresAuth".to_string(), Value::Bool(true));
-        obj.insert(
-            "serverIP".to_string(),
-            state.security_manager.public_ip().map_or(Value::Null, Value::String),
-        );
-        obj.insert(
-            "isDocker".to_string(),
-            Value::Bool(state.security_manager.is_in_docker()),
-        );
-        obj.insert(
-            "ipWhitelistDisabled".to_string(),
-            Value::Bool(state.security_manager.is_ip_whitelist_disabled()),
-        );
-        obj.insert(
-            "allowedIPs".to_string(),
-            json!(state.security_manager.allowed_ips()),
-        );
-        obj.insert(
-            "currentClientIP".to_string(),
-            client_ip(&request).map_or(Value::Null, Value::String),
-        );
-        obj.insert(
-            "configPath".to_string(),
-            Value::String(state.security_manager.config_path().display().to_string()),
-        );
+        obj.remove("publicIP");
+        obj.remove("createdAt");
+        obj.remove("lastAccess");
     }
     response::success(status, &request_id)
 }
@@ -70,12 +49,16 @@ pub async fn auth(
     request: Request<Body>,
 ) -> Response {
     let ip = client_ip(&request);
-    let Ok(body_bytes) = axum::body::to_bytes(request.into_body(), 1024 * 1024).await else {
+    let Ok(body_bytes) = axum::body::to_bytes(request.into_body(), 4096).await else {
         let err = ApiError::validation("缺少访问令牌", "MISSING_TOKEN");
         return response::error(&err, &request_id);
     };
     let body: Value = serde_json::from_slice(&body_bytes).unwrap_or(Value::Null);
-    let Some(token) = body.get("token").and_then(Value::as_str).filter(|t| !t.is_empty()) else {
+    let Some(token) = body
+        .get("token")
+        .and_then(Value::as_str)
+        .filter(|t| !t.is_empty())
+    else {
         let err = ApiError::validation("缺少访问令牌", "MISSING_TOKEN");
         return response::error(&err, &request_id);
     };
@@ -114,16 +97,38 @@ pub async fn auth(
     }
 }
 
+fn valid_ip_rule(value: &str) -> bool {
+    if value == "*" || value == "0.0.0.0" {
+        return true;
+    }
+    if value.parse::<std::net::IpAddr>().is_ok() {
+        return true;
+    }
+    let Some((address, prefix)) = value.split_once('/') else {
+        return false;
+    };
+    address.parse::<std::net::Ipv4Addr>().is_ok()
+        && prefix.parse::<u8>().is_ok_and(|bits| bits <= 32)
+}
+
 /// `POST /api/server/host` — 更新服务器地址配置。
 pub async fn update_server_host(
     State(state): State<SharedState>,
     Extension(RequestId(request_id)): Extension<RequestId>,
     axum::Json(body): axum::Json<Value>,
 ) -> Response {
-    let Some(host) = body.get("host").and_then(Value::as_str).filter(|h| !h.is_empty()) else {
+    let Some(host) = body.get("host").and_then(Value::as_str).map(str::trim) else {
         let err = ApiError::validation("服务器地址不能为空", "INVALID_HOST");
         return response::error(&err, &request_id);
     };
+    let valid_host = !host.is_empty()
+        && host.len() <= 255
+        && !host.chars().any(char::is_control)
+        && !host.contains(['/', '\\', ':']);
+    if !valid_host {
+        let err = ApiError::validation("服务器地址格式无效", "INVALID_HOST");
+        return response::error(&err, &request_id);
+    }
     state.security_manager.update_server_host(host);
     response::success(
         json!({
@@ -145,7 +150,6 @@ pub async fn get_ip_whitelist(
             "allowedIPs": state.security_manager.allowed_ips(),
             "disabled": state.security_manager.is_ip_whitelist_disabled(),
             "isDocker": state.security_manager.is_in_docker(),
-            "configPath": state.security_manager.config_path().display().to_string(),
             "currentClientIP": client_ip(&request),
         }),
         &request_id,
@@ -158,10 +162,14 @@ pub async fn add_ip_whitelist(
     Extension(RequestId(request_id)): Extension<RequestId>,
     axum::Json(body): axum::Json<Value>,
 ) -> Response {
-    let Some(ip) = body.get("ip").and_then(Value::as_str).filter(|v| !v.is_empty()) else {
+    let Some(ip) = body.get("ip").and_then(Value::as_str).map(str::trim) else {
         let err = ApiError::validation("IP地址不能为空", "INVALID_IP");
         return response::error(&err, &request_id);
     };
+    if !valid_ip_rule(ip) {
+        let err = ApiError::validation("IP地址或CIDR格式无效", "INVALID_IP");
+        return response::error(&err, &request_id);
+    }
     state.security_manager.add_allowed_ip(ip);
     response::success(
         json!({
@@ -178,7 +186,11 @@ pub async fn remove_ip_whitelist(
     Extension(RequestId(request_id)): Extension<RequestId>,
     axum::Json(body): axum::Json<Value>,
 ) -> Response {
-    let Some(ip) = body.get("ip").and_then(Value::as_str).filter(|v| !v.is_empty()) else {
+    let Some(ip) = body
+        .get("ip")
+        .and_then(Value::as_str)
+        .filter(|v| !v.is_empty())
+    else {
         let err = ApiError::validation("IP地址不能为空", "INVALID_IP");
         return response::error(&err, &request_id);
     };
@@ -236,4 +248,19 @@ pub async fn add_current_ip(
         }),
         &request_id,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::valid_ip_rule;
+
+    #[test]
+    fn ip_rules_accept_supported_forms_and_reject_malformed_values() {
+        for valid in ["127.0.0.1", "::1", "10.0.0.0/8", "*"] {
+            assert!(valid_ip_rule(valid), "{valid}");
+        }
+        for invalid in ["", "999.1.1.1", "10.0.0.0/33", "not-an-ip", "10.0.0.0/x"] {
+            assert!(!valid_ip_rule(invalid), "{invalid}");
+        }
+    }
 }

--- a/qq-chat-export-server/src/api/routes/tasks.rs
+++ b/qq-chat-export-server/src/api/routes/tasks.rs
@@ -2,6 +2,7 @@ use axum::extract::{Extension, Path, State};
 use axum::response::Response;
 use serde_json::{json, Value};
 
+use crate::api::path_security::resolve_existing_descendant_within;
 use crate::api::response::{self, ApiError, ErrorType, RequestId};
 use crate::api::state::SharedState;
 
@@ -219,14 +220,16 @@ pub async fn delete_original_files(
         return response::error(&err, &request_id);
     };
 
-    let path = std::path::PathBuf::from(&original_dir);
-    // 安全约束：只允许删除导出目录内的路径。
-    let exports_dir = state.path_manager.exports_dir();
-    let scheduled_dir = state.path_manager.scheduled_exports_dir();
-    if !(path.starts_with(&exports_dir) || path.starts_with(&scheduled_dir)) {
+    let roots = [
+        state.path_manager.exports_dir(),
+        state.path_manager.scheduled_exports_dir(),
+    ];
+    let Some(path) =
+        resolve_existing_descendant_within(&std::path::PathBuf::from(&original_dir), &roots)
+    else {
         let err = ApiError::validation("路径不在导出目录内", "INVALID_PATH");
         return response::error(&err, &request_id);
-    }
+    };
 
     if path.exists() {
         if let Err(error) = tokio::fs::remove_dir_all(&path).await {

--- a/qq-chat-export-server/src/api/ws.rs
+++ b/qq-chat-export-server/src/api/ws.rs
@@ -205,7 +205,10 @@ async fn handle_stream_search(state: &SharedState, sender: WsSender, data: Value
         .get("searchQuery")
         .and_then(Value::as_str)
         .unwrap_or("")
-        .to_string();
+        .trim()
+        .chars()
+        .take(200)
+        .collect::<String>();
     let peer_value = data.get("peer").cloned().unwrap_or(Value::Null);
     let Ok(peer) = serde_json::from_value::<Peer>(peer_value) else {
         send_json(
@@ -218,7 +221,7 @@ async fn handle_stream_search(state: &SharedState, sender: WsSender, data: Value
         .await;
         return;
     };
-    if query.is_empty() {
+    if search_id.is_empty() || search_id.len() > 128 || query.is_empty() {
         send_json(
             &sender,
             &json!({
@@ -250,6 +253,17 @@ async fn handle_stream_search(state: &SharedState, sender: WsSender, data: Value
     let cancel_flag = Arc::new(AtomicBool::new(false));
     {
         let mut searches = active_searches().lock().await;
+        if searches.len() >= 64 || searches.contains_key(&search_id) {
+            send_json(
+                &sender,
+                &json!({
+                    "type": "search_error",
+                    "data": { "searchId": search_id, "message": "搜索任务数量已达上限或ID重复" },
+                }),
+            )
+            .await;
+            return;
+        }
         searches.insert(search_id.clone(), Arc::clone(&cancel_flag));
     }
 
@@ -280,7 +294,10 @@ async fn handle_stream_search(state: &SharedState, sender: WsSender, data: Value
                 .await;
                 break;
             }
-            let batch = match fetcher.fetch_next_batch(&peer, &filter, previous.as_ref()).await {
+            let batch = match fetcher
+                .fetch_next_batch(&peer, &filter, previous.as_ref())
+                .await
+            {
                 Ok(Some(batch)) => batch,
                 Ok(None) => {
                     send_json(

--- a/qq-chat-export-server/src/security/manager.rs
+++ b/qq-chat-export-server/src/security/manager.rs
@@ -138,7 +138,11 @@ fn ip_matches_cidr(ip: &str, cidr: &str) -> bool {
     let Some(ip_num) = ip_to_number(ip) else {
         return false;
     };
-    let mask: u32 = if mask_bits == 0 { 0 } else { u32::MAX << (32 - mask_bits) };
+    let mask: u32 = if mask_bits == 0 {
+        0
+    } else {
+        u32::MAX << (32 - mask_bits)
+    };
     (ip_num & mask) == (network & mask)
 }
 
@@ -220,10 +224,20 @@ impl SecurityManager {
     pub fn initialize(&self) {
         {
             let mut public_ip = self.public_ip.write().expect("public_ip 锁中毒");
-            *public_ip = Some(if self.is_docker { "0.0.0.0" } else { "127.0.0.1" }.to_string());
+            *public_ip = Some(
+                if self.is_docker {
+                    "0.0.0.0"
+                } else {
+                    "127.0.0.1"
+                }
+                .to_string(),
+            );
         }
 
-        tracing::info!("[QCE][SecurityManager] config: {}", self.config_path.display());
+        tracing::info!(
+            "[QCE][SecurityManager] config: {}",
+            self.config_path.display()
+        );
 
         if self.config_path.exists() {
             self.load_config();
@@ -416,6 +430,14 @@ impl SecurityManager {
             if std::fs::write(&self.config_path, data).is_err() {
                 tracing::warn!("[QCE][SecurityManager] security.json 写入失败");
             }
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let permissions = std::fs::Permissions::from_mode(0o600);
+                if std::fs::set_permissions(&self.config_path, permissions).is_err() {
+                    tracing::warn!("[QCE][SecurityManager] security.json 权限设置失败");
+                }
+            }
         }
         self.record_mtime();
     }
@@ -456,11 +478,12 @@ impl SecurityManager {
         if cfg.token_expired.is_some_and(|expiry| Utc::now() > expiry) {
             return Err(VerifyTokenReason::TokenExpired);
         }
-        if !cfg.disable_ip_whitelist.unwrap_or(false) {
-            if let Some(ip) = client_ip {
-                if !cfg.allowed_i_ps.is_empty() && !Self::check_ip_allowed(&cfg, ip) {
-                    return Err(VerifyTokenReason::IpNotAllowed);
-                }
+        if !cfg.disable_ip_whitelist.unwrap_or(false) && !cfg.allowed_i_ps.is_empty() {
+            let Some(ip) = client_ip else {
+                return Err(VerifyTokenReason::IpNotAllowed);
+            };
+            if !Self::check_ip_allowed(&cfg, ip) {
+                return Err(VerifyTokenReason::IpNotAllowed);
             }
         }
 
@@ -563,7 +586,10 @@ impl SecurityManager {
     /// 获取当前白名单列表。
     pub fn allowed_ips(&self) -> Vec<String> {
         let guard = self.config.read().expect("config 锁中毒");
-        guard.as_ref().map(|c| c.allowed_i_ps.clone()).unwrap_or_default()
+        guard
+            .as_ref()
+            .map(|c| c.allowed_i_ps.clone())
+            .unwrap_or_default()
     }
 
     /// 设置是否禁用 IP 白名单验证。


### PR DESCRIPTION
## Security audit scope

Audited every Rust HTTP/WebSocket route and the associated authentication, filesystem, process-launch, resource-serving, and user-controlled output paths on current master.

## Confirmed issues fixed

- Ignore untrusted proxy IP headers and use the TCP peer address for whitelist enforcement.
- Fail closed when the whitelist is enabled but the peer address is unavailable.
- Require authentication for the legacy WebSocket upgrade on /.
- Restrict download, open-location, merge output, custom export output, task cleanup, and resource serving to canonical managed roots.
- Reject cross-platform traversal forms and symlink escapes; prevent deletion of an export root itself.
- Remove sensitive public security metadata and local configuration paths.
- Validate security inputs and bound request IDs, auth bodies, WebSocket messages, active searches, pagination, and merge source counts.
- Set security.json to mode 