### PR TITLE
fix: harden external downloads and API limits

### DIFF
--- a/qq-chat-export-server/src/api/helpers.rs
+++ b/qq-chat-export-server/src/api/helpers.rs
@@ -1,6 +1,5 @@
-use std::time::Duration;
-
 use serde_json::{json, Value};
+use std::time::Duration;
 
 use qce_exporter::CleanMessage;
 
@@ -9,22 +8,6 @@ use crate::napcat::NapCatBridgeClient;
 
 /// 单步查询超时，单位为毫秒。
 const SESSION_NAME_TIMEOUT_MS: u64 = 2000;
-
-/// 下载 URL 到内存（30 秒超时，跟随重定向；失败返回 `None`）。
-pub async fn http_get_bytes(url: &str) -> Option<bytes::Bytes> {
-    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
-    let client = CLIENT.get_or_init(|| {
-        reqwest::Client::builder()
-            .timeout(Duration::from_secs(30))
-            .build()
-            .unwrap_or_default()
-    });
-    let response = client.get(url).send().await.ok()?;
-    if !response.status().is_success() {
-        return None;
-    }
-    response.bytes().await.ok()
-}
 
 /// 宽松转数字。
 fn to_number(value: Option<&Value>) -> i64 {
@@ -80,7 +63,10 @@ pub fn normalize_group_system_notify(raw: &Value) -> Value {
         .or_else(|| raw.get("InvitedRequest").and_then(Value::as_array))
         .unwrap_or(&empty);
 
-    let join_requests: Vec<Value> = join.iter().map(|item| map_notify_item(item, "join")).collect();
+    let join_requests: Vec<Value> = join
+        .iter()
+        .map(|item| map_notify_item(item, "join"))
+        .collect();
     let invited_requests: Vec<Value> = invited
         .iter()
         .map(|item| map_notify_item(item, "invited"))
@@ -196,9 +182,8 @@ pub fn resolve_peer_uin(
     self_uin: Option<&str>,
     messages: &[CleanMessage],
 ) -> Option<String> {
-    let valid_uin = |uin: &&str| {
-        !uin.is_empty() && uin.chars().all(|c| c.is_ascii_digit()) && *uin != "0"
-    };
+    let valid_uin =
+        |uin: &&str| !uin.is_empty() && uin.chars().all(|c| c.is_ascii_digit()) && *uin != "0";
     messages
         .iter()
         .find(|message| message.sender.uid == peer_uid)
@@ -318,7 +303,9 @@ mod tests {
     fn normalize_empty_payload() {
         let normalized = normalize_group_system_notify(&Value::Null);
         assert_eq!(normalized["totalCount"], 0);
-        assert!(normalized["joinRequests"].as_array().is_some_and(Vec::is_empty));
+        assert!(normalized["joinRequests"]
+            .as_array()
+            .is_some_and(Vec::is_empty));
     }
 
     #[test]

--- a/qq-chat-export-server/src/api/http_security.rs
+++ b/qq-chat-export-server/src/api/http_security.rs
@@ -1,0 +1,226 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::path::Path;
+use std::time::Duration;
+
+use bytes::{Bytes, BytesMut};
+use futures_util::StreamExt;
+use reqwest::header::LOCATION;
+use reqwest::{redirect::Policy, Response, Url};
+use tokio::io::AsyncWriteExt;
+
+const MAX_REDIRECTS: usize = 3;
+const DEFAULT_MEMORY_LIMIT: u64 = 32 * 1024 * 1024;
+
+#[must_use]
+fn is_public_ipv4(ip: Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    !(ip.is_private()
+        || ip.is_loopback()
+        || ip.is_link_local()
+        || ip.is_broadcast()
+        || ip.is_documentation()
+        || ip.is_unspecified()
+        || ip.is_multicast()
+        || octets[0] == 0
+        || octets[0] >= 240
+        || (octets[0] == 100 && (64..=127).contains(&octets[1]))
+        || (octets[0] == 192 && octets[1] == 0 && octets[2] == 0)
+        || (octets[0] == 198 && (octets[1] == 18 || octets[1] == 19)))
+}
+
+#[must_use]
+fn is_public_ipv6(ip: Ipv6Addr) -> bool {
+    let segments = ip.segments();
+    if let Some(mapped) = ip.to_ipv4_mapped() {
+        return is_public_ipv4(mapped);
+    }
+    !(ip.is_loopback()
+        || ip.is_unspecified()
+        || ip.is_multicast()
+        || (segments[0] & 0xfe00) == 0xfc00
+        || (segments[0] & 0xffc0) == 0xfe80
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8))
+}
+
+#[must_use]
+pub fn is_public_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => is_public_ipv4(ip),
+        IpAddr::V6(ip) => is_public_ipv6(ip),
+    }
+}
+
+fn validate_url(url: &Url) -> Option<(&str, u16)> {
+    if !matches!(url.scheme(), "http" | "https")
+        || !url.username().is_empty()
+        || url.password().is_some()
+    {
+        return None;
+    }
+    let host = url.host_str()?;
+    if host.eq_ignore_ascii_case("localhost") || host.ends_with(".localhost") {
+        return None;
+    }
+    Some((host, url.port_or_known_default()?))
+}
+
+async fn resolved_public_address(url: &Url) -> Option<(String, SocketAddr)> {
+    let (host, port) = validate_url(url)?;
+    let addresses: Vec<SocketAddr> = tokio::net::lookup_host((host, port)).await.ok()?.collect();
+    if addresses.is_empty() || addresses.iter().any(|address| !is_public_ip(address.ip())) {
+        return None;
+    }
+    Some((host.to_string(), addresses[0]))
+}
+
+async fn send_once(url: &Url) -> Option<Response> {
+    let (host, address) = resolved_public_address(url).await?;
+    let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
+        .redirect(Policy::none())
+        .no_proxy()
+        .resolve(&host, address)
+        .build()
+        .ok()?;
+    client.get(url.clone()).send().await.ok()
+}
+
+async fn safe_response(url: &str) -> Option<Response> {
+    let mut current = Url::parse(url).ok()?;
+    for redirect_count in 0..=MAX_REDIRECTS {
+        let response = send_once(&current).await?;
+        if response.status().is_redirection() {
+            if redirect_count == MAX_REDIRECTS {
+                return None;
+            }
+            let location = response.headers().get(LOCATION)?.to_str().ok()?;
+            current = current.join(location).ok()?;
+            continue;
+        }
+        return response.status().is_success().then_some(response);
+    }
+    None
+}
+
+async fn response_bytes(response: Response, max_bytes: u64) -> Option<Bytes> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > max_bytes)
+    {
+        return None;
+    }
+    let mut stream = response.bytes_stream();
+    let mut data = BytesMut::new();
+    let mut total = 0u64;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.ok()?;
+        total = total.checked_add(u64::try_from(chunk.len()).ok()?)?;
+        if total > max_bytes {
+            return None;
+        }
+        data.extend_from_slice(&chunk);
+    }
+    Some(data.freeze())
+}
+
+pub async fn http_get_bytes(url: &str) -> Option<Bytes> {
+    response_bytes(safe_response(url).await?, DEFAULT_MEMORY_LIMIT).await
+}
+
+pub async fn http_download_to_file(url: &str, destination: &Path, max_bytes: u64) -> bool {
+    let Some(response) = safe_response(url).await else {
+        return false;
+    };
+    if response
+        .content_length()
+        .is_some_and(|length| length > max_bytes)
+    {
+        return false;
+    }
+    let temporary = destination.with_extension(format!(
+        "{}.part-{}",
+        destination
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .unwrap_or("download"),
+        uuid::Uuid::new_v4().simple()
+    ));
+    let Ok(mut file) = tokio::fs::File::create(&temporary).await else {
+        return false;
+    };
+    let mut stream = response.bytes_stream();
+    let mut total = 0u64;
+    while let Some(chunk) = stream.next().await {
+        let Ok(chunk) = chunk else {
+            let _ = tokio::fs::remove_file(&temporary).await;
+            return false;
+        };
+        let Some(next_total) = total.checked_add(u64::try_from(chunk.len()).unwrap_or(u64::MAX))
+        else {
+            let _ = tokio::fs::remove_file(&temporary).await;
+            return false;
+        };
+        if next_total > max_bytes || file.write_all(&chunk).await.is_err() {
+            let _ = tokio::fs::remove_file(&temporary).await;
+            return false;
+        }
+        total = next_total;
+    }
+    if file.flush().await.is_err() || tokio::fs::rename(&temporary, destination).await.is_err() {
+        let _ = tokio::fs::remove_file(&temporary).await;
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_public_ip, validate_url};
+    use reqwest::Url;
+    use std::net::IpAddr;
+
+    #[test]
+    fn rejects_private_reserved_and_local_addresses() {
+        for address in [
+            "127.0.0.1",
+            "10.0.0.1",
+            "172.16.0.1",
+            "192.168.1.1",
+            "169.254.1.1",
+            "100.64.0.1",
+            "0.0.0.0",
+            "::1",
+            "fc00::1",
+            "fe80::1",
+            "2001:db8::1",
+            "::ffff:127.0.0.1",
+        ] {
+            assert!(
+                !is_public_ip(address.parse::<IpAddr>().expect("IP")),
+                "{address}"
+            );
+        }
+        for address in ["1.1.1.1", "8.8.8.8", "2606:4700:4700::1111"] {
+            assert!(
+                is_public_ip(address.parse::<IpAddr>().expect("IP")),
+                "{address}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_non_http_credentials_and_localhost_urls() {
+        for invalid in [
+            "file:///etc/passwd",
+            "http://localhost/test",
+            "http://sub.localhost/test",
+            "http://user:pass@example.com/test",
+        ] {
+            let url = Url::parse(invalid).expect("URL");
+            assert!(validate_url(&url).is_none(), "{invalid}");
+        }
+        let valid = Url::parse("https://example.com/image.png").expect("URL");
+        assert!(validate_url(&valid).is_some());
+    }
+}

--- a/qq-chat-export-server/src/api/mod.rs
+++ b/qq-chat-export-server/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod helpers;
+pub mod http_security;
 pub mod middleware;
 pub mod path_security;
 pub mod response;

--- a/qq-chat-export-server/src/api/routes/albums.rs
+++ b/qq-chat-export-server/src/api/routes/albums.rs
@@ -7,7 +7,7 @@ use axum::response::Response;
 use axum::Json;
 use serde_json::{json, Value};
 
-use crate::api::helpers::http_get_bytes;
+use crate::api::http_security::http_get_bytes;
 use crate::api::response::{self, ApiError, ErrorType, RequestId};
 use crate::api::state::SharedState;
 
@@ -75,7 +75,12 @@ async fn fetch_album_list(state: &SharedState, group_code: &str) -> Vec<Value> {
         return Vec::new();
     };
     let response_value = result.get("response").unwrap_or(&result);
-    if response_value.get("result").and_then(Value::as_i64).unwrap_or(-1) != 0 {
+    if response_value
+        .get("result")
+        .and_then(Value::as_i64)
+        .unwrap_or(-1)
+        != 0
+    {
         return Vec::new();
     }
     let empty: Vec<Value> = Vec::new();
@@ -89,7 +94,11 @@ async fn fetch_album_list(state: &SharedState, group_code: &str) -> Vec<Value> {
             let album_id = str_of(album, "album_id");
             let name = {
                 let n = str_of(album, "name");
-                if n.is_empty() { format!("相册_{album_id}") } else { n }
+                if n.is_empty() {
+                    format!("相册_{album_id}")
+                } else {
+                    n
+                }
             };
             json!({
                 "albumId": album_id,
@@ -141,8 +150,14 @@ fn normalize_media_item(item: &Value) -> Value {
     .into_iter()
     .find(|s| !s.is_empty())
     .unwrap_or_default();
-    let is_video = item.get("is_video").and_then(Value::as_bool).unwrap_or(false)
-        || item.get("isVideo").and_then(Value::as_bool).unwrap_or(false)
+    let is_video = item
+        .get("is_video")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        || item
+            .get("isVideo")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
         || media_data.get("type").and_then(Value::as_i64) == Some(1);
     json!({
         "id": id,
@@ -170,7 +185,12 @@ async fn fetch_album_media(state: &SharedState, group_code: &str, album_id: &str
         else {
             break;
         };
-        if response_value.get("result").and_then(Value::as_i64).unwrap_or(-1) != 0 {
+        if response_value
+            .get("result")
+            .and_then(Value::as_i64)
+            .unwrap_or(-1)
+            != 0
+        {
             break;
         }
         let empty: Vec<Value> = Vec::new();
@@ -251,7 +271,11 @@ pub async fn export_group_album(
     }
     let group_name = {
         let name = str_of(&body, "groupName");
-        if name.is_empty() { group_code.clone() } else { name }
+        if name.is_empty() {
+            group_code.clone()
+        } else {
+            name
+        }
     };
     let album_ids: Vec<String> = body
         .get("albumIds")
@@ -275,7 +299,11 @@ pub async fn export_group_album(
         chrono::Utc::now().timestamp_millis()
     ));
     if let Err(error) = tokio::fs::create_dir_all(&export_dir).await {
-        let err = ApiError::new(ErrorType::FileSystem, error.to_string(), "CREATE_DIR_FAILED");
+        let err = ApiError::new(
+            ErrorType::FileSystem,
+            error.to_string(),
+            "CREATE_DIR_FAILED",
+        );
         return response::error(&err, &request_id);
     }
 
@@ -319,7 +347,11 @@ pub async fn export_group_album(
 
         let mut album_media_data: Vec<Value> = Vec::new();
         for media in &media_items {
-            let ext = if str_of(media, "type") == "video" { ".mp4" } else { ".jpg" };
+            let ext = if str_of(media, "type") == "video" {
+                ".mp4"
+            } else {
+                ".jpg"
+            };
             let file_name = format!("{}{ext}", sanitize(&str_of(media, "id")));
             let file_path = album_dir.join(&file_name);
 
@@ -359,7 +391,11 @@ pub async fn export_group_album(
 
         let downloaded_in_album = album_media_data
             .iter()
-            .filter(|m| m.get("downloaded").and_then(Value::as_bool).unwrap_or(false))
+            .filter(|m| {
+                m.get("downloaded")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+            })
             .count();
         album_data.push(json!({
             "albumId": str_of(album, "albumId"),
@@ -427,7 +463,7 @@ pub async fn album_export_records(
         .get("limit")
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|l| *l >= 1)
-        .unwrap_or(50);
+        .map_or(50, |l| l.min(100));
     let mut records = load_records(&state).await;
     records.truncate(limit);
     response::success(

--- a/qq-chat-export-server/src/api/routes/files.rs
+++ b/qq-chat-export-server/src/api/routes/files.rs
@@ -7,7 +7,7 @@ use axum::response::Response;
 use axum::Json;
 use serde_json::{json, Value};
 
-use crate::api::helpers::http_get_bytes;
+use crate::api::http_security::http_download_to_file;
 use crate::api::response::{self, ApiError, ErrorType, RequestId};
 use crate::api::state::SharedState;
 
@@ -174,12 +174,20 @@ async fn fetch_all_files_recursive(
 /// 获取群文件下载链接。
 async fn file_download_url(state: &SharedState, group_code: &str, file_id: &str) -> Option<String> {
     let file_uuid = file_id.strip_prefix('/').unwrap_or(file_id);
-    let result = state.napcat.get_group_file_url(group_code, file_uuid).await.ok()?;
+    let result = state
+        .napcat
+        .get_group_file_url(group_code, file_uuid)
+        .await
+        .ok()?;
     match result {
         Value::String(url) if !url.is_empty() => Some(url),
         other => {
             let url = str_of(&other, "url");
-            if url.is_empty() { None } else { Some(url) }
+            if url.is_empty() {
+                None
+            } else {
+                Some(url)
+            }
         }
     }
 }
@@ -228,7 +236,11 @@ pub async fn group_file_count(
         let err = ApiError::validation("群号不能为空", "INVALID_GROUP_CODE");
         return response::error(&err, &request_id);
     }
-    let count = match state.napcat.get_group_file_count(vec![group_code.clone()]).await {
+    let count = match state
+        .napcat
+        .get_group_file_count(vec![group_code.clone()])
+        .await
+    {
         Ok(result) => result
             .get("groupFileCounts")
             .and_then(Value::as_array)
@@ -267,14 +279,23 @@ pub async fn download_group_file(
             &request_id,
         ),
         None => {
-            let err = ApiError::new(ErrorType::Api, "获取文件下载链接失败", "DOWNLOAD_URL_FAILED");
+            let err = ApiError::new(
+                ErrorType::Api,
+                "获取文件下载链接失败",
+                "DOWNLOAD_URL_FAILED",
+            );
             response::error(&err, &request_id)
         }
     }
 }
 
 /// 生成可读文件清单（Markdown）。
-fn build_readable_list(group_name: &str, files: &[Value], folders: &[Value], total_size: i64) -> String {
+fn build_readable_list(
+    group_name: &str,
+    files: &[Value],
+    folders: &[Value],
+    total_size: i64,
+) -> String {
     let mut text = format!("# {group_name} 群文件列表\n");
     text.push_str(&format!("导出时间: {}\n", now_iso()));
     text.push_str(&format!("文件总数: {}\n", files.len()));
@@ -332,7 +353,11 @@ pub async fn export_group_files_metadata(
     }
     let group_name = {
         let name = str_of(&body, "groupName");
-        if name.is_empty() { group_code.clone() } else { name }
+        if name.is_empty() {
+            group_code.clone()
+        } else {
+            name
+        }
     };
     let id = export_id();
     let export_dir = export_base_path(&state).join(format!(
@@ -342,7 +367,11 @@ pub async fn export_group_files_metadata(
         chrono::Utc::now().timestamp_millis()
     ));
     if let Err(error) = tokio::fs::create_dir_all(&export_dir).await {
-        let err = ApiError::new(ErrorType::FileSystem, error.to_string(), "CREATE_DIR_FAILED");
+        let err = ApiError::new(
+            ErrorType::FileSystem,
+            error.to_string(),
+            "CREATE_DIR_FAILED",
+        );
         return response::error(&err, &request_id);
     }
 
@@ -423,14 +452,16 @@ pub async fn export_group_files_metadata(
 }
 
 /// 下载单个群文件到指定路径（通过下载链接）。
-async fn download_file_to(state: &SharedState, group_code: &str, file_id: &str, dest: &FsPath) -> bool {
+async fn download_file_to(
+    state: &SharedState,
+    group_code: &str,
+    file_id: &str,
+    dest: &FsPath,
+) -> bool {
     let Some(url) = file_download_url(state, group_code, file_id).await else {
         return false;
     };
-    match http_get_bytes(&url).await {
-        Some(data) => tokio::fs::write(dest, data).await.is_ok(),
-        None => false,
-    }
+    http_download_to_file(&url, dest, 2 * 1024 * 1024 * 1024).await
 }
 
 /// `POST /api/groups/:groupCode/files/export-with-download` — 导出并下载群文件。
@@ -446,7 +477,11 @@ pub async fn export_group_files_with_download(
     }
     let group_name = {
         let name = str_of(&body, "groupName");
-        if name.is_empty() { group_code.clone() } else { name }
+        if name.is_empty() {
+            group_code.clone()
+        } else {
+            name
+        }
     };
     let id = export_id();
     let export_dir = export_base_path(&state).join(format!(
@@ -456,7 +491,11 @@ pub async fn export_group_files_with_download(
         chrono::Utc::now().timestamp_millis()
     ));
     if let Err(error) = tokio::fs::create_dir_all(&export_dir).await {
-        let err = ApiError::new(ErrorType::FileSystem, error.to_string(), "CREATE_DIR_FAILED");
+        let err = ApiError::new(
+            ErrorType::FileSystem,
+            error.to_string(),
+            "CREATE_DIR_FAILED",
+        );
         return response::error(&err, &request_id);
     }
 
@@ -469,7 +508,10 @@ pub async fn export_group_files_with_download(
     folder_paths.insert(String::new(), export_dir.clone());
     for folder in &folders {
         let parent = str_of(folder, "parentFolderId");
-        let parent_path = folder_paths.get(&parent).cloned().unwrap_or_else(|| export_dir.clone());
+        let parent_path = folder_paths
+            .get(&parent)
+            .cloned()
+            .unwrap_or_else(|| export_dir.clone());
         let folder_path = parent_path.join(sanitize(&str_of(folder, "folderName")));
         let _ = tokio::fs::create_dir_all(&folder_path).await;
         folder_paths.insert(str_of(folder, "folderId"), folder_path);
@@ -479,7 +521,10 @@ pub async fn export_group_files_with_download(
     let mut failed = 0usize;
     for (index, file) in files.iter().enumerate() {
         let parent = str_of(file, "parentFolderId");
-        let parent_path = folder_paths.get(&parent).cloned().unwrap_or_else(|| export_dir.clone());
+        let parent_path = folder_paths
+            .get(&parent)
+            .cloned()
+            .unwrap_or_else(|| export_dir.clone());
         let file_path = parent_path.join(sanitize(&str_of(file, "fileName")));
 
         state.broadcast_ws(&json!({

--- a/qq-chat-export-server/src/api/routes/friends.rs
+++ b/qq-chat-export-server/src/api/routes/friends.rs
@@ -15,12 +15,14 @@ fn page_and_limit(params: &HashMap<String, String>) -> (usize, usize) {
         .get("page")
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|p| *p >= 1)
-        .unwrap_or(1);
+        .unwrap_or(1)
+        .min(1_000_000);
     let limit = params
         .get("limit")
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|l| *l >= 1)
-        .unwrap_or(999);
+        .unwrap_or(999)
+        .min(2_000);
     (page, limit)
 }
 
@@ -266,15 +268,27 @@ fn map_friend(friend: &Value, category_id: &Value) -> Value {
     let uid = str_of(core, "uid");
     let uin = {
         let u = str_of(core, "uin");
-        if u.is_empty() { str_of(friend, "uin") } else { u }
+        if u.is_empty() {
+            str_of(friend, "uin")
+        } else {
+            u
+        }
     };
     let nick = {
         let n = str_of(core, "nick");
-        if n.is_empty() { str_of(friend, "nick") } else { n }
+        if n.is_empty() {
+            str_of(friend, "nick")
+        } else {
+            n
+        }
     };
     let remark = {
         let r = str_of(core, "remark");
-        if r.is_empty() { str_of(friend, "remark") } else { r }
+        if r.is_empty() {
+            str_of(friend, "remark")
+        } else {
+            r
+        }
     };
     let is_online = base
         .get("isOnline")
@@ -314,10 +328,7 @@ pub async fn list_friends(
     let cats = categories.as_array().unwrap_or(&empty);
     let mut friends: Vec<Value> = Vec::new();
     for cat in cats {
-        let category_id = cat
-            .get("categoryId")
-            .cloned()
-            .unwrap_or(Value::Null);
+        let category_id = cat.get("categoryId").cloned().unwrap_or(Value::Null);
         if let Some(list) = cat.get("buddyList").and_then(Value::as_array) {
             for friend in list {
                 friends.push(map_friend(friend, &category_id));
@@ -326,9 +337,14 @@ pub async fn list_friends(
     }
 
     let total = friends.len();
-    let start_index = (page - 1) * limit;
-    let end_index = start_index + limit;
-    let paginated: Vec<Value> = friends.iter().skip(start_index).take(limit).cloned().collect();
+    let start_index = (page - 1).saturating_mul(limit);
+    let end_index = start_index.saturating_add(limit);
+    let paginated: Vec<Value> = friends
+        .iter()
+        .skip(start_index)
+        .take(limit)
+        .cloned()
+        .collect();
 
     response::success(
         json!({

--- a/qq-chat-export-server/src/api/routes/group_files.rs
+++ b/qq-chat-export-server/src/api/routes/group_files.rs
@@ -19,7 +19,7 @@ pub async fn group_files_export_records(
         .get("limit")
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|l| *l >= 1)
-        .unwrap_or(50);
+        .map_or(50, |l| l.min(100));
     let mut records = load_records(&state).await;
     records.truncate(limit);
     response::success(

--- a/qq-chat-export-server/src/api/routes/groups.rs
+++ b/qq-chat-export-server/src/api/routes/groups.rs
@@ -20,12 +20,14 @@ fn page_and_limit(params: &HashMap<String, String>) -> (usize, usize) {
         .get("page")
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|p| *p >= 1)
-        .unwrap_or(1);
+        .unwrap_or(1)
+        .min(1_000_000);
     let limit = params
         .get("limit")
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|l| *l >= 1)
-        .unwrap_or(999);
+        .unwrap_or(999)
+        .min(2_000);
     (page, limit)
 }
 
@@ -59,9 +61,7 @@ pub fn sanitize_file_component(name: &str, max_len: usize) -> String {
         .chars()
         .take(max_len)
         .collect();
-    safe = safe
-        .trim_end_matches(['_', ' ', '.'])
-        .to_string();
+    safe = safe.trim_end_matches(['_', ' ', '.']).to_string();
     if matches!(
         safe.to_ascii_uppercase().as_str(),
         "CON"
@@ -197,8 +197,8 @@ pub async fn list_groups(
         .collect();
 
     let total = groups_with_avatars.len();
-    let start_index = (page - 1) * limit;
-    let end_index = start_index + limit;
+    let start_index = (page - 1).saturating_mul(limit);
+    let end_index = start_index.saturating_add(limit);
     let paginated: Vec<Value> = groups_with_avatars
         .iter()
         .skip(start_index)
@@ -905,23 +905,12 @@ mod member_list_tests {
         let name = "group_avatars_name_1_20260712_163632123.zip";
         std::fs::write(base.join(name), b"old").unwrap();
         let collision = reserve_unique_file_name(&base, name);
-        assert_eq!(
-            collision,
-            "group_avatars_name_1_20260712_163632123_2.zip"
-        );
+        assert_eq!(collision, "group_avatars_name_1_20260712_163632123_2.zip");
         release_group_export_path(&base.join(collision));
-        let first = reserve_unique_file_name(
-            &base,
-            "group_essence_name_1_20260712_163632123.html",
-        );
-        let second = reserve_unique_file_name(
-            &base,
-            "group_essence_name_1_20260712_163632123.html",
-        );
-        assert_eq!(
-            second,
-            "group_essence_name_1_20260712_163632123_2.html"
-        );
+        let first = reserve_unique_file_name(&base, "group_essence_name_1_20260712_163632123.html");
+        let second =
+            reserve_unique_file_name(&base, "group_essence_name_1_20260712_163632123.html");
+        assert_eq!(second, "group_essence_name_1_20260712_163632123_2.html");
         release_group_export_path(&base.join(first));
         release_group_export_path(&base.join(second));
         std::fs::remove_dir_all(base).unwrap();

--- a/qq-chat-export-server/src/api/routes/messages.rs
+++ b/qq-chat-export-server/src/api/routes/messages.rs
@@ -22,8 +22,12 @@ use qce_exporter::{ChatInfo, CleanMessage, ExportOptions};
 use crate::api::helpers::{
     chat_avatar_url, resolve_peer_uid, resolve_peer_uin, resolve_session_name,
 };
-use crate::api::response::{self, ApiError, RequestId};
+use crate::api::response::{self, ApiError, ErrorType, RequestId};
 use crate::api::state::{MessageCacheEntry, SharedState, CACHE_EXPIRE_TIME_MS};
+
+const MAX_ACTIVE_EXPORT_TASKS: usize = 32;
+const MAX_MESSAGE_CACHE_ENTRIES: usize = 64;
+const MAX_CACHED_MESSAGES_PER_ENTRY: usize = 20_000;
 use crate::export_debug::ExportDebugSession;
 use crate::fetcher::{
     chat_type_prefix, classify_chat_type_binary, BatchFetchConfig, BatchMessageFetcher,
@@ -422,9 +426,11 @@ pub async fn fetch_messages(
         return response::error(&err, &request_id);
     };
     let filter = body.get("filter").cloned().unwrap_or(Value::Null);
-    let batch_size = loose_i64(body.get("batchSize")).unwrap_or(5000);
-    let page = loose_i64(body.get("page")).unwrap_or(1).max(1);
-    let limit = loose_i64(body.get("limit")).unwrap_or(50).max(1);
+    let batch_size = loose_i64(body.get("batchSize"))
+        .unwrap_or(5000)
+        .clamp(1, 5000);
+    let page = loose_i64(body.get("page")).unwrap_or(1).clamp(1, 1_000_000);
+    let limit = loose_i64(body.get("limit")).unwrap_or(50).clamp(1, 2000);
 
     let start_time = loose_i64(filter.get("startTime"));
     let end_time = loose_i64(filter.get("endTime"));
@@ -462,8 +468,8 @@ pub async fn fetch_messages(
         has_more = entry.has_more;
     }
 
-    let start_index = usize::try_from((page - 1) * limit).unwrap_or(0);
-    let end_index = usize::try_from(page * limit).unwrap_or(usize::MAX);
+    let start_index = usize::try_from((page - 1).saturating_mul(limit)).unwrap_or(0);
+    let end_index = usize::try_from(page.saturating_mul(limit)).unwrap_or(usize::MAX);
 
     let paginate_response = |messages: &[Value], has_next: bool, hit: bool| -> Response {
         let total = messages.len();
@@ -562,8 +568,17 @@ pub async fn fetch_messages(
 
     let has_next = all_messages.len() > end_index || has_more;
     let paginated = paginate_response(&all_messages, has_next, cache_hit);
-    {
+    if all_messages.len() <= MAX_CACHED_MESSAGES_PER_ENTRY {
         let mut cache = state.message_cache.lock().await;
+        if cache.len() >= MAX_MESSAGE_CACHE_ENTRIES && !cache.contains_key(&cache_key) {
+            if let Some(oldest_key) = cache
+                .iter()
+                .min_by_key(|(_, entry)| entry.last_update)
+                .map(|(key, _)| key.clone())
+            {
+                cache.remove(&oldest_key);
+            }
+        }
         cache.insert(
             cache_key,
             MessageCacheEntry {
@@ -682,7 +697,7 @@ async fn prepare_export_request(
 }
 
 /// 创建任务记录、入表并持久化。
-async fn register_task(state: &SharedState, task: &Value) {
+async fn register_task(state: &SharedState, task: &Value) -> bool {
     let task_id = task
         .get("taskId")
         .and_then(Value::as_str)
@@ -690,11 +705,24 @@ async fn register_task(state: &SharedState, task: &Value) {
         .to_string();
     {
         let mut tasks = state.export_tasks.lock().await;
+        let active_count = tasks
+            .values()
+            .filter(|value| {
+                matches!(
+                    value.get("status").and_then(Value::as_str),
+                    Some("pending" | "running")
+                )
+            })
+            .count();
+        if active_count >= MAX_ACTIVE_EXPORT_TASKS {
+            return false;
+        }
         tasks.insert(task_id, task.clone());
     }
     if let Err(error) = state.db.save_task(task, task, true).await {
         tracing::warn!("[ApiServer] 保存新任务到数据库失败: {error}");
     }
+    true
 }
 
 /// `POST /api/messages/export` — 创建异步导出任务。
@@ -754,7 +782,15 @@ pub async fn export_messages(
         "filter": req.filter,
         "options": req.options,
     });
-    register_task(&state, &task).await;
+    if !register_task(&state, &task).await {
+        let err = ApiError::new(
+            ErrorType::Api,
+            "运行中的导出任务已达到上限",
+            "EXPORT_TASK_LIMIT_REACHED",
+        )
+        .with_status(axum::http::StatusCode::TOO_MANY_REQUESTS);
+        return response::error(&err, &request_id);
+    }
 
     let reply = json!({
         "taskId": task_id,
@@ -839,7 +875,15 @@ pub async fn export_streaming_zip(
         "filter": req.filter,
         "options": options,
     });
-    register_task(&state, &task).await;
+    if !register_task(&state, &task).await {
+        let err = ApiError::new(
+            ErrorType::Api,
+            "运行中的导出任务已达到上限",
+            "EXPORT_TASK_LIMIT_REACHED",
+        )
+        .with_status(axum::http::StatusCode::TOO_MANY_REQUESTS);
+        return response::error(&err, &request_id);
+    }
 
     let reply = json!({
         "taskId": task_id,
@@ -920,7 +964,15 @@ pub async fn export_streaming_jsonl(
         "filter": req.filter,
         "options": options,
     });
-    register_task(&state, &task).await;
+    if !register_task(&state, &task).await {
+        let err = ApiError::new(
+            ErrorType::Api,
+            "运行中的导出任务已达到上限",
+            "EXPORT_TASK_LIMIT_REACHED",
+        )
+        .with_status(axum::http::StatusCode::TOO_MANY_REQUESTS);
+        return response::error(&err, &request_id);
+    }
 
     let reply = json!({
         "taskId": task_id,

--- a/qq-chat-export-server/src/api/routes/resources.rs
+++ b/qq-chat-export-server/src/api/routes/resources.rs
@@ -956,6 +956,9 @@ async fn build_resource_cache(state: &SharedState, dir_path: &str) -> HashMap<St
     }
 
     let mut cache = state.resource_file_cache.lock().await;
+    if cache.len() >= 256 && !cache.contains_key(dir_path) {
+        cache.clear();
+    }
     cache.insert(dir_path.to_string(), map.clone());
     map
 }
@@ -1352,7 +1355,7 @@ pub async fn global_resource_files(
         .get("page")
         .and_then(|p| p.parse::<usize>().ok())
         .unwrap_or(1)
-        .max(1);
+        .clamp(1, 1_000_000);
     let limit = params
         .get("limit")
         .and_then(|l| l.parse::<usize>().ok())
@@ -1412,7 +1415,7 @@ pub async fn global_resource_files(
     });
 
     let total = files.len();
-    let start_index = (page - 1) * limit;
+    let start_index = (page - 1).saturating_mul(limit);
     let paginated: Vec<Value> = files.into_iter().skip(start_index).take(limit).collect();
 
     response::success(
@@ -1421,7 +1424,7 @@ pub async fn global_resource_files(
             "total": total,
             "page": page,
             "limit": limit,
-            "hasMore": start_index + limit < total,
+            "hasMore": start_index.saturating_add(limit) < total,
         }),
         &request_id,
     )

--- a/qq-chat-export-server/src/api/routes/scheduled.rs
+++ b/qq-chat-export-server/src/api/routes/scheduled.rs
@@ -5,11 +5,52 @@ use axum::response::Response;
 use axum::Json;
 use serde_json::{json, Value};
 
+use crate::api::path_security::resolve_for_creation_within;
 use crate::api::response::{self, ApiError, RequestId};
 use crate::api::state::SharedState;
 
+const MAX_SCHEDULED_EXPORTS: usize = 128;
+const MAX_NAME_LENGTH: usize = 128;
+const MAX_IDENTIFIER_LENGTH: usize = 256;
+
+fn validate_string_field(
+    body: &Value,
+    key: &str,
+    required: bool,
+    max_length: usize,
+) -> Result<(), ApiError> {
+    let Some(value) = body.get(key) else {
+        return if required {
+            Err(ApiError::validation(
+                format!("缺少必填字段: {key}"),
+                "MISSING_REQUIRED_FIELD",
+            ))
+        } else {
+            Ok(())
+        };
+    };
+    let Some(value) = value.as_str() else {
+        return Err(ApiError::validation(
+            format!("{key} 必须是字符串"),
+            "INVALID_FIELD_TYPE",
+        ));
+    };
+    let value = value.trim();
+    if value.is_empty() || value.chars().count() > max_length || value.chars().any(char::is_control)
+    {
+        return Err(ApiError::validation(
+            format!("{key} 无效"),
+            "INVALID_FIELD_VALUE",
+        ));
+    }
+    Ok(())
+}
+
 /// 校验创建 / 更新请求体的必填字段。
 fn validate_config(body: &Value, partial: bool) -> Result<(), ApiError> {
+    if !body.is_object() {
+        return Err(ApiError::validation("请求体必须是对象", "INVALID_BODY"));
+    }
     let required: [&str; 5] = ["name", "peer", "scheduleType", "timeRangeType", "format"];
     if !partial {
         for key in required {
@@ -20,10 +61,158 @@ fn validate_config(body: &Value, partial: bool) -> Result<(), ApiError> {
                 ));
             }
         }
-        let peer = body.get("peer").cloned().unwrap_or(Value::Null);
-        if peer.get("peerUid").and_then(Value::as_str).unwrap_or("").is_empty() {
-            return Err(ApiError::validation("peer.peerUid 不能为空", "INVALID_PEER"));
+    }
+
+    validate_string_field(body, "name", !partial, MAX_NAME_LENGTH)?;
+    validate_string_field(body, "scheduleType", !partial, 16)?;
+    validate_string_field(body, "timeRangeType", !partial, 32)?;
+    validate_string_field(body, "format", !partial, 16)?;
+
+    if let Some(schedule_type) = body.get("scheduleType").and_then(Value::as_str) {
+        if !matches!(schedule_type, "daily" | "weekly" | "monthly" | "custom") {
+            return Err(ApiError::validation(
+                "scheduleType 无效",
+                "INVALID_SCHEDULE_TYPE",
+            ));
         }
+        if schedule_type == "custom" {
+            validate_string_field(body, "cronExpression", true, 128)?;
+            let expression = body["cronExpression"].as_str().unwrap_or_default();
+            if expression.split_whitespace().count() != 5 {
+                return Err(ApiError::validation("cronExpression 无效", "INVALID_CRON"));
+            }
+        }
+    }
+    if body.get("cronExpression").is_some() {
+        validate_string_field(body, "cronExpression", true, 128)?;
+        if body["cronExpression"]
+            .as_str()
+            .unwrap_or_default()
+            .split_whitespace()
+            .count()
+            != 5
+        {
+            return Err(ApiError::validation("cronExpression 无效", "INVALID_CRON"));
+        }
+    }
+    if let Some(time_range_type) = body.get("timeRangeType").and_then(Value::as_str) {
+        if !matches!(
+            time_range_type,
+            "yesterday" | "last-week" | "last-month" | "last-7-days" | "last-30-days" | "custom"
+        ) {
+            return Err(ApiError::validation(
+                "timeRangeType 无效",
+                "INVALID_TIME_RANGE",
+            ));
+        }
+        if time_range_type == "custom" {
+            let range = body
+                .get("customTimeRange")
+                .and_then(Value::as_object)
+                .ok_or_else(|| {
+                    ApiError::validation("customTimeRange 无效", "INVALID_TIME_RANGE")
+                })?;
+            let start = range.get("startTime").and_then(Value::as_i64);
+            let end = range.get("endTime").and_then(Value::as_i64);
+            if !matches!((start, end), (Some(start), Some(end)) if start <= end) {
+                return Err(ApiError::validation(
+                    "customTimeRange 无效",
+                    "INVALID_TIME_RANGE",
+                ));
+            }
+        }
+    }
+    if body.get("customTimeRange").is_some() {
+        let range = body
+            .get("customTimeRange")
+            .and_then(Value::as_object)
+            .ok_or_else(|| ApiError::validation("customTimeRange 无效", "INVALID_TIME_RANGE"))?;
+        let start = range.get("startTime").and_then(Value::as_i64);
+        let end = range.get("endTime").and_then(Value::as_i64);
+        if !matches!((start, end), (Some(start), Some(end)) if start <= end) {
+            return Err(ApiError::validation(
+                "customTimeRange 无效",
+                "INVALID_TIME_RANGE",
+            ));
+        }
+    }
+    if let Some(format) = body.get("format").and_then(Value::as_str) {
+        if !matches!(
+            format.to_ascii_uppercase().as_str(),
+            "HTML" | "JSON" | "TXT" | "EXCEL"
+        ) {
+            return Err(ApiError::validation("format 无效", "INVALID_FORMAT"));
+        }
+    }
+    if let Some(execute_time) = body.get("executeTime") {
+        let valid = execute_time.as_str().is_some_and(|value| {
+            let mut parts = value.split(':');
+            matches!(
+                (parts.next(), parts.next(), parts.next()),
+                (Some(hour), Some(minute), None)
+                    if hour.len() == 2
+                        && minute.len() == 2
+                        && hour.parse::<u8>().is_ok_and(|value| value < 24)
+                        && minute.parse::<u8>().is_ok_and(|value| value < 60)
+            )
+        });
+        if !valid {
+            return Err(ApiError::validation(
+                "executeTime 无效",
+                "INVALID_EXECUTE_TIME",
+            ));
+        }
+    }
+    if let Some(peer) = body.get("peer") {
+        let peer = peer
+            .as_object()
+            .ok_or_else(|| ApiError::validation("peer 必须是对象", "INVALID_PEER"))?;
+        let peer_uid = peer.get("peerUid").and_then(Value::as_str).map(str::trim);
+        if peer_uid.is_none_or(|value| {
+            value.is_empty()
+                || value.chars().count() > MAX_IDENTIFIER_LENGTH
+                || value.chars().any(char::is_control)
+        }) {
+            return Err(ApiError::validation("peer.peerUid 无效", "INVALID_PEER"));
+        }
+        if peer.get("chatType").and_then(Value::as_i64).is_none() {
+            return Err(ApiError::validation("peer.chatType 无效", "INVALID_PEER"));
+        }
+    }
+    if let Some(options) = body.get("options") {
+        if !options.is_object() {
+            return Err(ApiError::validation(
+                "options 必须是对象",
+                "INVALID_OPTIONS",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_output_dir(state: &SharedState, body: &Value) -> Result<(), ApiError> {
+    let Some(output_dir) = body.get("outputDir") else {
+        return Ok(());
+    };
+    let Some(output_dir) = output_dir.as_str() else {
+        return Err(ApiError::validation(
+            "outputDir 必须是字符串",
+            "INVALID_PATH",
+        ));
+    };
+    let output_dir = output_dir.trim();
+    if output_dir.is_empty() {
+        return Ok(());
+    }
+    let roots = [
+        state.path_manager.exports_dir(),
+        state.path_manager.scheduled_exports_dir(),
+    ];
+    if resolve_for_creation_within(std::path::Path::new(output_dir), &roots).is_none() {
+        return Err(ApiError::validation(
+            "outputDir 必须位于允许的导出目录内",
+            "INVALID_PATH",
+        ));
     }
     Ok(())
 }
@@ -35,6 +224,19 @@ pub async fn create_scheduled_export(
     Json(body): Json<Value>,
 ) -> Response {
     if let Err(err) = validate_config(&body, false) {
+        return response::error(&err, &request_id);
+    }
+    if let Err(err) = validate_output_dir(&state, &body) {
+        return response::error(&err, &request_id);
+    }
+    if state
+        .scheduled_export_manager
+        .all_scheduled_exports()
+        .await
+        .len()
+        >= MAX_SCHEDULED_EXPORTS
+    {
+        let err = ApiError::validation("定时导出任务已达到上限", "SCHEDULE_LIMIT_REACHED");
         return response::error(&err, &request_id);
     }
     let config = state
@@ -108,6 +310,9 @@ pub async fn update_scheduled_export(
     if let Err(err) = validate_config(&body, true) {
         return response::error(&err, &request_id);
     }
+    if let Err(err) = validate_output_dir(&state, &body) {
+        return response::error(&err, &request_id);
+    }
     match state
         .scheduled_export_manager
         .update_scheduled_export(&id, body)
@@ -127,7 +332,11 @@ pub async fn delete_scheduled_export(
     Extension(RequestId(request_id)): Extension<RequestId>,
     Path(id): Path<String>,
 ) -> Response {
-    if state.scheduled_export_manager.delete_scheduled_export(&id).await {
+    if state
+        .scheduled_export_manager
+        .delete_scheduled_export(&id)
+        .await
+    {
         response::success(
             json!({
                 "message": "定时导出已删除",
@@ -147,7 +356,11 @@ pub async fn trigger_scheduled_export(
     Extension(RequestId(request_id)): Extension<RequestId>,
     Path(id): Path<String>,
 ) -> Response {
-    match state.scheduled_export_manager.trigger_scheduled_export(&id).await {
+    match state
+        .scheduled_export_manager
+        .trigger_scheduled_export(&id)
+        .await
+    {
         Some(result) => response::success(result, &request_id),
         None => {
             let err = ApiError::not_found("定时导出不存在", "SCHEDULED_EXPORT_NOT_FOUND");
@@ -167,7 +380,7 @@ pub async fn scheduled_export_history(
         .get("limit")
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|l| *l >= 1)
-        .unwrap_or(50);
+        .map_or(50, |l| l.min(100));
     let history = state
         .scheduled_export_manager
         .execution_history(&id, limit)
@@ -179,4 +392,44 @@ pub async fn scheduled_export_history(
         }),
         &request_id,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_config;
+    use serde_json::json;
+
+    fn valid_config() -> serde_json::Value {
+        json!({
+            "name": "daily export",
+            "peer": { "chatType": 2, "peerUid": "123" },
+            "scheduleType": "daily",
+            "executeTime": "02:00",
+            "timeRangeType": "yesterday",
+            "format": "HTML",
+            "options": {}
+        })
+    }
+
+    #[test]
+    fn accepts_valid_scheduled_export() {
+        assert!(validate_config(&valid_config(), false).is_ok());
+    }
+
+    #[test]
+    fn rejects_invalid_types_enums_and_ranges() {
+        let mut config = valid_config();
+        config["name"] = json!({});
+        assert!(validate_config(&config, false).is_err());
+
+        let mut config = valid_config();
+        config["scheduleType"] = json!("custom");
+        config["cronExpression"] = json!("* * *");
+        assert!(validate_config(&config, false).is_err());
+
+        let mut config = valid_config();
+        config["timeRangeType"] = json!("custom");
+        config["customTimeRange"] = json!({ "startTime": 10, "endTime": 1 });
+        assert!(validate_config(&config, false).is_err());
+    }
 }

--- a/qq-chat-export-server/src/api/routes/stickers.rs
+++ b/qq-chat-export-server/src/api/routes/stickers.rs
@@ -7,7 +7,7 @@ use axum::Json;
 use futures_util::{stream::FuturesUnordered, StreamExt};
 use serde_json::{json, Value};
 
-use crate::api::helpers::http_get_bytes;
+use crate::api::http_security::http_get_bytes;
 use crate::api::response::{self, ApiError, ErrorType, RequestId};
 use crate::api::state::SharedState;
 
@@ -830,7 +830,7 @@ pub async fn sticker_export_records(
         .get("limit")
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|l| *l >= 1)
-        .unwrap_or(50);
+        .map_or(50, |l| l.min(100));
     let mut records = load_records(&state).await;
     records.truncate(limit);
     response::success(

--- a/qq-chat-export-server/src/api/routes/system.rs
+++ b/qq-chat-export-server/src/api/routes/system.rs
@@ -8,6 +8,44 @@ use crate::api::state::SharedState;
 use crate::paths::PathManager;
 use crate::version::{APP_COPYRIGHT, APP_NAME, VERSION};
 
+const MAX_CONFIG_PATH_LENGTH: usize = 4096;
+
+#[derive(Debug, PartialEq, Eq)]
+enum ConfigPathUpdate {
+    Missing,
+    Clear,
+    Set(String),
+}
+
+fn parse_config_path(body: &Value, key: &str) -> Result<ConfigPathUpdate, ApiError> {
+    let Some(value) = body.get(key) else {
+        return Ok(ConfigPathUpdate::Missing);
+    };
+    if value.is_null() {
+        return Ok(ConfigPathUpdate::Clear);
+    }
+    let Some(value) = value.as_str() else {
+        return Err(ApiError::validation(
+            format!("{key} 必须是字符串或 null"),
+            "INVALID_PATH_TYPE",
+        ));
+    };
+    let sanitized = PathManager::sanitize_path(value);
+    if sanitized.is_empty() {
+        return Ok(ConfigPathUpdate::Clear);
+    }
+    if sanitized.chars().count() > MAX_CONFIG_PATH_LENGTH
+        || sanitized.chars().any(char::is_control)
+        || PathManager::validate_path(&sanitized).is_err()
+    {
+        return Err(ApiError::validation(
+            "禁止访问系统关键目录或使用无效路径",
+            "INVALID_PATH",
+        ));
+    }
+    Ok(ConfigPathUpdate::Set(sanitized))
+}
+
 /// `GET /` — API 信息。
 pub async fn root(
     State(state): State<SharedState>,
@@ -195,9 +233,9 @@ fn memory_usage() -> Value {
         true,
         sysinfo::ProcessRefreshKind::new().with_memory(),
     );
-    let (rss, virtual_mem) = system
-        .process(pid)
-        .map_or((0, 0), |process| (process.memory(), process.virtual_memory()));
+    let (rss, virtual_mem) = system.process(pid).map_or((0, 0), |process| {
+        (process.memory(), process.virtual_memory())
+    });
     json!({
         "rss": rss,
         "heapTotal": rss,
@@ -213,7 +251,10 @@ pub async fn get_config(
     State(state): State<SharedState>,
     Extension(RequestId(request_id)): Extension<RequestId>,
 ) -> Response {
-    let config_path = state.path_manager.default_base_dir().join("user-config.json");
+    let config_path = state
+        .path_manager
+        .default_base_dir()
+        .join("user-config.json");
     let config: Value = tokio::fs::read_to_string(&config_path)
         .await
         .ok()
@@ -237,7 +278,22 @@ pub async fn put_config(
     Extension(RequestId(request_id)): Extension<RequestId>,
     Json(body): Json<Value>,
 ) -> Response {
-    let config_path = state.path_manager.default_base_dir().join("user-config.json");
+    if !body.is_object() {
+        let err = ApiError::validation("请求体必须是对象", "INVALID_BODY");
+        return response::error(&err, &request_id);
+    }
+    let custom_output_dir = match parse_config_path(&body, "customOutputDir") {
+        Ok(value) => value,
+        Err(err) => return response::error(&err, &request_id),
+    };
+    let custom_scheduled_dir = match parse_config_path(&body, "customScheduledExportDir") {
+        Ok(value) => value,
+        Err(err) => return response::error(&err, &request_id),
+    };
+    let config_path = state
+        .path_manager
+        .default_base_dir()
+        .join("user-config.json");
     if let Some(parent) = config_path.parent() {
         if tokio::fs::create_dir_all(parent).await.is_err() {
             let err = ApiError::new(ErrorType::Config, "更新配置失败", "UPDATE_CONFIG_FAILED");
@@ -255,67 +311,79 @@ pub async fn put_config(
         return response::error(&err, &request_id);
     };
 
-    if let Some(custom_output_dir) = body.get("customOutputDir") {
-        match custom_output_dir.as_str().map(str::trim) {
-            None | Some("") => {
-                config_obj.insert("customOutputDir".to_string(), Value::Null);
-                if state.path_manager.set_custom_output_dir(None).is_err() {
-                    let err = ApiError::validation("路径验证失败", "INVALID_PATH");
-                    return response::error(&err, &request_id);
-                }
-            }
-            Some(dir) => {
-                let sanitized = PathManager::sanitize_path(dir);
-                if state
-                    .path_manager
-                    .set_custom_output_dir(Some(&sanitized))
-                    .is_err()
-                {
-                    let err = ApiError::validation("禁止访问系统关键目录", "INVALID_PATH");
-                    return response::error(&err, &request_id);
-                }
-                config_obj.insert("customOutputDir".to_string(), Value::String(sanitized));
-            }
+    match &custom_output_dir {
+        ConfigPathUpdate::Missing => {}
+        ConfigPathUpdate::Clear => {
+            config_obj.insert("customOutputDir".to_string(), Value::Null);
+        }
+        ConfigPathUpdate::Set(value) => {
+            config_obj.insert("customOutputDir".to_string(), Value::String(value.clone()));
         }
     }
 
-    if let Some(custom_scheduled_dir) = body.get("customScheduledExportDir") {
-        match custom_scheduled_dir.as_str().map(str::trim) {
-            None | Some("") => {
-                config_obj.insert("customScheduledExportDir".to_string(), Value::Null);
-                if state
-                    .path_manager
-                    .set_custom_scheduled_export_dir(None)
-                    .is_err()
-                {
-                    let err = ApiError::validation("路径验证失败", "INVALID_PATH");
-                    return response::error(&err, &request_id);
-                }
-            }
-            Some(dir) => {
-                let sanitized = PathManager::sanitize_path(dir);
-                if state
-                    .path_manager
-                    .set_custom_scheduled_export_dir(Some(&sanitized))
-                    .is_err()
-                {
-                    let err = ApiError::validation("禁止访问系统关键目录", "INVALID_PATH");
-                    return response::error(&err, &request_id);
-                }
-                config_obj.insert(
-                    "customScheduledExportDir".to_string(),
-                    Value::String(sanitized),
-                );
-            }
+    match &custom_scheduled_dir {
+        ConfigPathUpdate::Missing => {}
+        ConfigPathUpdate::Clear => {
+            config_obj.insert("customScheduledExportDir".to_string(), Value::Null);
+        }
+        ConfigPathUpdate::Set(value) => {
+            config_obj.insert(
+                "customScheduledExportDir".to_string(),
+                Value::String(value.clone()),
+            );
         }
     }
 
-    let serialized = serde_json::to_string_pretty(&config).unwrap_or_else(|_| "{}".to_string());
+    let Ok(serialized) = serde_json::to_string_pretty(&config) else {
+        let err = ApiError::new(ErrorType::Config, "更新配置失败", "UPDATE_CONFIG_FAILED");
+        return response::error(&err, &request_id);
+    };
     if tokio::fs::write(&config_path, serialized).await.is_err() {
         let err = ApiError::new(ErrorType::Config, "更新配置失败", "UPDATE_CONFIG_FAILED");
         return response::error(&err, &request_id);
     }
-    if state.path_manager.ensure_all_directories_exist().await.is_err() {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let permissions = std::fs::Permissions::from_mode(0o600);
+        if tokio::fs::set_permissions(&config_path, permissions)
+            .await
+            .is_err()
+        {
+            let err = ApiError::new(ErrorType::Config, "更新配置失败", "UPDATE_CONFIG_FAILED");
+            return response::error(&err, &request_id);
+        }
+    }
+    if !matches!(custom_output_dir, ConfigPathUpdate::Missing) {
+        let value = match &custom_output_dir {
+            ConfigPathUpdate::Set(value) => Some(value.as_str()),
+            ConfigPathUpdate::Missing | ConfigPathUpdate::Clear => None,
+        };
+        if state.path_manager.set_custom_output_dir(value).is_err() {
+            let err = ApiError::validation("路径验证失败", "INVALID_PATH");
+            return response::error(&err, &request_id);
+        }
+    }
+    if !matches!(custom_scheduled_dir, ConfigPathUpdate::Missing) {
+        let value = match &custom_scheduled_dir {
+            ConfigPathUpdate::Set(value) => Some(value.as_str()),
+            ConfigPathUpdate::Missing | ConfigPathUpdate::Clear => None,
+        };
+        if state
+            .path_manager
+            .set_custom_scheduled_export_dir(value)
+            .is_err()
+        {
+            let err = ApiError::validation("路径验证失败", "INVALID_PATH");
+            return response::error(&err, &request_id);
+        }
+    }
+    if state
+        .path_manager
+        .ensure_all_directories_exist()
+        .await
+        .is_err()
+    {
         let err = ApiError::new(ErrorType::Config, "更新配置失败", "UPDATE_CONFIG_FAILED");
         return response::error(&err, &request_id);
     }
@@ -330,4 +398,25 @@ pub async fn put_config(
         }),
         &request_id,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_config_path, ConfigPathUpdate};
+    use serde_json::json;
+
+    #[test]
+    fn config_paths_reject_type_confusion_and_control_characters() {
+        assert!(parse_config_path(&json!({ "customOutputDir": 123 }), "customOutputDir").is_err());
+        assert!(parse_config_path(
+            &json!({ "customOutputDir": "C:/exports\nother" }),
+            "customOutputDir"
+        )
+        .is_err());
+        assert_eq!(
+            parse_config_path(&json!({ "customOutputDir": null }), "customOutputDir")
+                .expect("null is valid"),
+            ConfigPathUpdate::Clear
+        );
+    }
 }

--- a/qq-chat-export-server/src/paths/mod.rs
+++ b/qq-chat-export-server/src/paths/mod.rs
@@ -53,7 +53,7 @@ impl PathManager {
     }
 
     /// 校验路径：只禁止系统关键目录，允许任意其他位置。
-    fn validate_path(input: &str) -> Result<PathBuf, PathError> {
+    pub(crate) fn validate_path(input: &str) -> Result<PathBuf, PathError> {
         let sanitized = Self::sanitize_path(input);
         let normalized_input = sanitized.replace('\\', "/").to_lowercase();
         let resolved = if Path::new(&sanitized).is_absolute() {

--- a/qq-chat-export-server/src/resource/handler.rs
+++ b/qq-chat-export-server/src/resource/handler.rs
@@ -1244,7 +1244,7 @@ async fn normalize_audio_file_extension(file_path: &str, resource: &mut Resource
         let _ = tokio::fs::remove_file(&new_path).await;
     }
     if let Err(error) = tokio::fs::rename(file_path, &new_path).await {
-        tracing::warn!("修正音频扩展名失败 {file_path} → {new_path}: {error}");
+        tracing::warn!("修正音频扩展名失败: {error}");
         return original;
     }
 

--- a/qq-chat-export-server/src/scheduled_executor.rs
+++ b/qq-chat-export-server/src/scheduled_executor.rs
@@ -13,6 +13,7 @@ use qce_exporter::types::MessageResource;
 use qce_exporter::{ChatInfo, CleanMessage, ExportOptions};
 
 use qce_server::api::helpers::{chat_avatar_url, resolve_peer_uin};
+use qce_server::api::path_security::resolve_for_creation_within;
 use qce_server::export_debug::ExportDebugSession;
 use qce_server::fetcher::{
     classify_chat_type_binary, BatchFetchConfig, BatchMessageFetcher, MessageFilter, Peer,
@@ -86,12 +87,18 @@ impl ScheduledExportExecutor for ApiScheduledExportExecutor {
             .unwrap_or("HTML")
             .to_uppercase();
         let options = task.get("options").cloned().unwrap_or(Value::Null);
-        let output_dir = task
+        let requested_output_dir = task
             .get("outputDir")
             .and_then(Value::as_str)
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .map_or_else(|| self.path_manager.scheduled_exports_dir(), PathBuf::from);
+        let output_roots = [
+            self.path_manager.exports_dir(),
+            self.path_manager.scheduled_exports_dir(),
+        ];
+        let output_dir = resolve_for_creation_within(&requested_output_dir, &output_roots)
+            .ok_or_else(|| "定时导出目录不在允许的导出目录内".to_string())?;
         let debug_session = if options.get("debugExport").and_then(Value::as_bool) == Some(true) {
             let export_name = format!(
                 "scheduled-{}-{}",


### PR DESCRIPTION
## Security audit scope

- harden all external HTTP downloads against SSRF, unsafe redirects, DNS rebinding, proxy bypass, and oversized responses
- stream group-file downloads to bounded temporary files instead of buffering entire responses
- enforce active export, cache, scheduled-task, history, pagination, and resource-cache limits
- validate scheduled-export schemas and restrict persisted output directories to managed export roots
- reject configuration path type confusion, prevalidate multi-field updates, and apply private Unix permissions
- remove sensitive filesystem paths from warning logs

## Validation

- cargo test --manifest-path qq-chat-export-server/Cargo.toml --lib --bins --no-fail-fast (81 passed)
- cargo clippy --manifest-path qq-chat-export-server/Cargo.toml --all-targets -- -D warnings
- cargo build --manifest-path qq-chat-export-server/Cargo.toml
- cargo audit --file qq-chat-export-server/Cargo.lock (no known vulnerabilities; existing yanked spin 0.9.8 warning)
- 
pm audit --omit=dev --audit-level=high in plugins/qq-chat-exporter (0 vulnerabilities)