### PR TITLE
fix: complete API security audit hardening

### DIFF
--- a/qq-chat-export-server/src/api/http_security.rs
+++ b/qq-chat-export-server/src/api/http_security.rs
@@ -25,6 +25,7 @@ fn is_public_ipv4(ip: Ipv4Addr) -> bool {
         || octets[0] >= 240
         || (octets[0] == 100 && (64..=127).contains(&octets[1]))
         || (octets[0] == 192 && octets[1] == 0 && octets[2] == 0)
+        || (octets[0] == 192 && octets[1] == 88 && octets[2] == 99)
         || (octets[0] == 198 && (octets[1] == 18 || octets[1] == 19)))
 }
 
@@ -39,7 +40,14 @@ fn is_public_ipv6(ip: Ipv6Addr) -> bool {
         || ip.is_multicast()
         || (segments[0] & 0xfe00) == 0xfc00
         || (segments[0] & 0xffc0) == 0xfe80
-        || (segments[0] == 0x2001 && segments[1] == 0x0db8))
+        || (segments[0] & 0xffc0) == 0xfec0
+        || (segments[0] == 0x0100 && segments[1..4] == [0, 0, 0])
+        || (segments[0] == 0x0064 && segments[1] == 0xff9b)
+        || (segments[0] == 0x2001 && segments[1] == 0)
+        || (segments[0] == 0x2001 && (segments[1] & 0xfff0) == 0x0010)
+        || (segments[0] == 0x2001 && (segments[1] & 0xfff0) == 0x0020)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8)
+        || segments[0] == 0x2002)
 }
 
 #[must_use]
@@ -58,7 +66,8 @@ fn validate_url(url: &Url) -> Option<(&str, u16)> {
         return None;
     }
     let host = url.host_str()?;
-    if host.eq_ignore_ascii_case("localhost") || host.ends_with(".localhost") {
+    let lower_host = host.to_ascii_lowercase();
+    if lower_host == "localhost" || lower_host.ends_with(".localhost") {
         return None;
     }
     Some((host, url.port_or_known_default()?))
@@ -189,11 +198,18 @@ mod tests {
             "192.168.1.1",
             "169.254.1.1",
             "100.64.0.1",
+            "192.88.99.1",
             "0.0.0.0",
             "::1",
             "fc00::1",
             "fe80::1",
             "2001:db8::1",
+            "fec0::1",
+            "100::1",
+            "64:ff9b::7f00:1",
+            "2001::1",
+            "2001:20::1",
+            "2002:7f00:1::1",
             "::ffff:127.0.0.1",
         ] {
             assert!(

--- a/qq-chat-export-server/src/api/ws.rs
+++ b/qq-chat-export-server/src/api/ws.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
+use std::io::{self, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
+use std::time::Duration;
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
@@ -12,10 +14,48 @@ use tokio::sync::Mutex;
 use crate::api::state::SharedState;
 use crate::fetcher::{BatchFetchConfig, BatchMessageFetcher, MessageFilter, Peer};
 
-/// 活跃流式搜索的取消标记（searchId → flag）。
-fn active_searches() -> &'static Mutex<HashMap<String, Arc<AtomicBool>>> {
-    static SEARCHES: OnceLock<Mutex<HashMap<String, Arc<AtomicBool>>>> = OnceLock::new();
+const MAX_WS_MESSAGE_BYTES: usize = 256 * 1024;
+const MAX_ACTIVE_STREAM_SEARCHES: usize = 8;
+const MAX_ACTIVE_STREAM_SEARCHES_PER_CONNECTION: usize = 2;
+const MAX_STREAM_SEARCH_MESSAGES: usize = 100_000;
+const MAX_STREAM_SEARCH_DURATION: Duration = Duration::from_secs(5 * 60);
+const MAX_SEARCHABLE_TEXT_CHARS: usize = 16_384;
+const MAX_SEARCH_RESULTS_PER_BATCH: usize = 100;
+const MAX_SEARCH_RESULT_BYTES_PER_BATCH: usize = 192 * 1024;
+
+struct ActiveSearch {
+    owner_id: String,
+    cancel_flag: Arc<AtomicBool>,
+}
+
+/// 活跃流式搜索及其连接所有者。
+fn active_searches() -> &'static Mutex<HashMap<String, ActiveSearch>> {
+    static SEARCHES: OnceLock<Mutex<HashMap<String, ActiveSearch>>> = OnceLock::new();
     SEARCHES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn cancel_owned_search(
+    searches: &HashMap<String, ActiveSearch>,
+    owner_id: &str,
+    search_id: &str,
+) -> bool {
+    let Some(search) = searches.get(search_id) else {
+        return false;
+    };
+    if search.owner_id != owner_id {
+        return false;
+    }
+    search.cancel_flag.store(true, Ordering::SeqCst);
+    true
+}
+
+fn cancel_owner_searches(searches: &HashMap<String, ActiveSearch>, owner_id: &str) {
+    for search in searches
+        .values()
+        .filter(|search| search.owner_id == owner_id)
+    {
+        search.cancel_flag.store(true, Ordering::SeqCst);
+    }
 }
 
 fn now_iso() -> String {
@@ -61,7 +101,9 @@ fn build_task_resync_payload(tasks: &[Value]) -> Vec<Value> {
 
 /// `GET /ws` — WebSocket 升级入口。
 pub async fn ws_handler(State(state): State<SharedState>, ws: WebSocketUpgrade) -> Response {
-    ws.on_upgrade(move |socket| handle_socket(state, socket))
+    ws.max_message_size(MAX_WS_MESSAGE_BYTES)
+        .max_frame_size(MAX_WS_MESSAGE_BYTES)
+        .on_upgrade(move |socket| handle_socket(state, socket))
 }
 
 /// 单连接处理：下发连接确认与 task_resync，转发广播，处理客户端指令。
@@ -139,7 +181,7 @@ async fn handle_socket(state: SharedState, socket: WebSocket) {
         let data = payload.get("data").cloned().unwrap_or(Value::Null);
         match msg_type {
             "start_stream_search" => {
-                handle_stream_search(&state, Arc::clone(&sender), data).await;
+                handle_stream_search(&state, Arc::clone(&sender), &request_id, data).await;
             }
             "cancel_search" => {
                 let search_id = data
@@ -148,9 +190,7 @@ async fn handle_socket(state: SharedState, socket: WebSocket) {
                     .unwrap_or("")
                     .to_string();
                 let searches = active_searches().lock().await;
-                if let Some(flag) = searches.get(&search_id) {
-                    flag.store(true, Ordering::SeqCst);
-                }
+                cancel_owned_search(&searches, &request_id, &search_id);
             }
             other => {
                 tracing::warn!("[ApiServer] 未知的WebSocket消息类型: {other}");
@@ -158,20 +198,37 @@ async fn handle_socket(state: SharedState, socket: WebSocket) {
         }
     }
 
+    {
+        let searches = active_searches().lock().await;
+        cancel_owner_searches(&searches, &request_id);
+    }
     forward.abort();
     tracing::info!("[API] WebSocket连接关闭: {request_id}");
 }
 
 type WsSender = Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>;
 
-async fn send_json(sender: &WsSender, payload: &Value) {
+async fn send_json(sender: &WsSender, payload: &Value) -> bool {
     let mut guard = sender.lock().await;
-    let _ = guard.send(Message::Text(payload.to_string())).await;
+    guard.send(Message::Text(payload.to_string())).await.is_ok()
 }
 
 /// 提取消息文本（正文 + 发送者名，供搜索匹配）。
 fn extract_text(message: &Value) -> String {
-    let mut texts: Vec<String> = Vec::new();
+    let mut text = String::new();
+    let mut remaining = MAX_SEARCHABLE_TEXT_CHARS;
+    let mut append = |value: &str| {
+        if remaining == 0 || value.is_empty() {
+            return;
+        }
+        if !text.is_empty() {
+            text.push(' ');
+        }
+        for character in value.chars().take(remaining) {
+            text.push(character);
+            remaining -= 1;
+        }
+    };
     if let Some(elements) = message.get("elements").and_then(Value::as_array) {
         for element in elements {
             if let Some(content) = element
@@ -179,23 +236,73 @@ fn extract_text(message: &Value) -> String {
                 .and_then(|t| t.get("content"))
                 .and_then(Value::as_str)
             {
-                texts.push(content.to_string());
+                append(content);
             }
         }
     }
     for key in ["sendMemberName", "sendNickName"] {
         if let Some(name) = message.get(key).and_then(Value::as_str) {
             if !name.is_empty() {
-                texts.push(name.to_string());
+                append(name);
                 break;
             }
         }
     }
-    texts.join(" ")
+    text
+}
+
+struct SizeLimitedWriter {
+    written: usize,
+    limit: usize,
+}
+
+impl Write for SizeLimitedWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        if buffer.len() > self.limit.saturating_sub(self.written) {
+            return Err(io::Error::other("serialized value exceeds limit"));
+        }
+        self.written += buffer.len();
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn serialized_size_with_limit(value: &Value, limit: usize) -> Option<usize> {
+    let mut writer = SizeLimitedWriter { written: 0, limit };
+    serde_json::to_writer(&mut writer, value).ok()?;
+    Some(writer.written)
+}
+
+fn bounded_search_results(messages: &[Value], query_lower: &str) -> (Vec<Value>, usize, bool) {
+    let mut results = Vec::new();
+    let mut matched = 0usize;
+    let mut serialized_bytes = 0usize;
+    let mut truncated = false;
+    for message in messages {
+        if !extract_text(message).to_lowercase().contains(query_lower) {
+            continue;
+        }
+        matched += 1;
+        let remaining_bytes = MAX_SEARCH_RESULT_BYTES_PER_BATCH.saturating_sub(serialized_bytes);
+        let Some(size) = serialized_size_with_limit(message, remaining_bytes) else {
+            truncated = true;
+            continue;
+        };
+        if results.len() >= MAX_SEARCH_RESULTS_PER_BATCH {
+            truncated = true;
+            continue;
+        }
+        serialized_bytes += size;
+        results.push(message.clone());
+    }
+    (results, matched, truncated)
 }
 
 /// 处理流式搜索：边拉取边匹配边推送，处理完一批即释放。
-async fn handle_stream_search(state: &SharedState, sender: WsSender, data: Value) {
+async fn handle_stream_search(state: &SharedState, sender: WsSender, owner_id: &str, data: Value) {
     let search_id = data
         .get("searchId")
         .and_then(Value::as_str)
@@ -221,7 +328,13 @@ async fn handle_stream_search(state: &SharedState, sender: WsSender, data: Value
         .await;
         return;
     };
-    if search_id.is_empty() || search_id.len() > 128 || query.is_empty() {
+    if search_id.is_empty()
+        || search_id.len() > 128
+        || query.is_empty()
+        || peer.peer_uid.is_empty()
+        || peer.peer_uid.len() > 256
+        || peer.peer_uid.chars().any(char::is_control)
+    {
         send_json(
             &sender,
             &json!({
@@ -249,11 +362,33 @@ async fn handle_stream_search(state: &SharedState, sender: WsSender, data: Value
         ),
         ..MessageFilter::default()
     };
+    if filter
+        .start_time
+        .zip(filter.end_time)
+        .is_some_and(|(start, end)| end < start)
+    {
+        send_json(
+            &sender,
+            &json!({
+                "type": "search_error",
+                "data": { "searchId": search_id, "message": "结束时间不能早于开始时间" },
+            }),
+        )
+        .await;
+        return;
+    }
 
     let cancel_flag = Arc::new(AtomicBool::new(false));
     {
         let mut searches = active_searches().lock().await;
-        if searches.len() >= 64 || searches.contains_key(&search_id) {
+        let owner_search_count = searches
+            .values()
+            .filter(|search| search.owner_id == owner_id)
+            .count();
+        if searches.len() >= MAX_ACTIVE_STREAM_SEARCHES
+            || owner_search_count >= MAX_ACTIVE_STREAM_SEARCHES_PER_CONNECTION
+            || searches.contains_key(&search_id)
+        {
             send_json(
                 &sender,
                 &json!({
@@ -264,7 +399,13 @@ async fn handle_stream_search(state: &SharedState, sender: WsSender, data: Value
             .await;
             return;
         }
-        searches.insert(search_id.clone(), Arc::clone(&cancel_flag));
+        searches.insert(
+            search_id.clone(),
+            ActiveSearch {
+                owner_id: owner_id.to_string(),
+                cancel_flag: Arc::clone(&cancel_flag),
+            },
+        );
     }
 
     let napcat = Arc::new(state.napcat.clone());
@@ -275,10 +416,11 @@ async fn handle_stream_search(state: &SharedState, sender: WsSender, data: Value
         let mut matched: usize = 0;
         let mut previous = None;
         let query_lower = query.to_lowercase();
+        let deadline = tokio::time::Instant::now() + MAX_STREAM_SEARCH_DURATION;
 
         loop {
             if cancel_flag.load(Ordering::SeqCst) {
-                send_json(
+                let _ = send_json(
                     &sender,
                     &json!({
                         "type": "search_progress",
@@ -294,13 +436,32 @@ async fn handle_stream_search(state: &SharedState, sender: WsSender, data: Value
                 .await;
                 break;
             }
+            if tokio::time::Instant::now() >= deadline {
+                let _ = send_json(
+                    &sender,
+                    &json!({
+                        "type": "search_progress",
+                        "data": {
+                            "searchId": search_id_bg,
+                            "status": "completed",
+                            "processedCount": processed,
+                            "matchedCount": matched,
+                            "results": [],
+                            "truncated": true,
+                            "warning": "搜索已达到时间上限，请缩小时间范围后继续",
+                        },
+                    }),
+                )
+                .await;
+                break;
+            }
             let batch = match fetcher
                 .fetch_next_batch(&peer, &filter, previous.as_ref())
                 .await
             {
                 Ok(Some(batch)) => batch,
                 Ok(None) => {
-                    send_json(
+                    let _ = send_json(
                         &sender,
                         &json!({
                             "type": "search_progress",
@@ -317,7 +478,7 @@ async fn handle_stream_search(state: &SharedState, sender: WsSender, data: Value
                     break;
                 }
                 Err(error) => {
-                    send_json(
+                    let _ = send_json(
                         &sender,
                         &json!({
                             "type": "search_progress",
@@ -336,16 +497,14 @@ async fn handle_stream_search(state: &SharedState, sender: WsSender, data: Value
                 }
             };
 
-            let results: Vec<Value> = batch
-                .messages
-                .iter()
-                .filter(|message| extract_text(message).to_lowercase().contains(&query_lower))
-                .cloned()
-                .collect();
-            processed += batch.messages.len();
-            matched += results.len();
+            let remaining = MAX_STREAM_SEARCH_MESSAGES.saturating_sub(processed);
+            let searched_count = remaining.min(batch.messages.len());
+            let (results, batch_matched, results_truncated) =
+                bounded_search_results(&batch.messages[..searched_count], &query_lower);
+            processed += searched_count;
+            matched += batch_matched;
 
-            send_json(
+            if !send_json(
                 &sender,
                 &json!({
                     "type": "search_progress",
@@ -355,14 +514,91 @@ async fn handle_stream_search(state: &SharedState, sender: WsSender, data: Value
                         "processedCount": processed,
                         "matchedCount": matched,
                         "results": results,
+                        "resultsTruncated": results_truncated,
                     },
                 }),
             )
-            .await;
+            .await
+            {
+                break;
+            }
+            if searched_count < batch.messages.len() || processed >= MAX_STREAM_SEARCH_MESSAGES {
+                let _ = send_json(
+                    &sender,
+                    &json!({
+                        "type": "search_progress",
+                        "data": {
+                            "searchId": search_id_bg,
+                            "status": "completed",
+                            "processedCount": processed,
+                            "matchedCount": matched,
+                            "results": [],
+                            "truncated": true,
+                            "warning": "搜索已达到消息扫描上限，请缩小时间范围后继续",
+                        },
+                    }),
+                )
+                .await;
+                break;
+            }
             previous = Some(batch);
         }
 
         let mut searches = active_searches().lock().await;
         searches.remove(&search_id_bg);
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        bounded_search_results, cancel_owned_search, extract_text, ActiveSearch,
+        MAX_SEARCHABLE_TEXT_CHARS,
+    };
+    use serde_json::json;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    #[test]
+    fn searchable_text_is_bounded() {
+        let message = json!({
+            "elements": [{ "textElement": { "content": "x".repeat(MAX_SEARCHABLE_TEXT_CHARS + 100) } }],
+            "sendNickName": "sender"
+        });
+        assert_eq!(
+            extract_text(&message).chars().count(),
+            MAX_SEARCHABLE_TEXT_CHARS
+        );
+    }
+
+    #[test]
+    fn search_results_are_bounded_by_serialized_size() {
+        let messages = vec![
+            json!({ "elements": [{ "textElement": { "content": "needle" } }], "data": "x".repeat(200_000) }),
+            json!({ "elements": [{ "textElement": { "content": "needle" } }] }),
+        ];
+        let (results, matched, truncated) = bounded_search_results(&messages, "needle");
+        assert!(truncated);
+        assert_eq!(matched, 2);
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn search_cancellation_is_scoped_to_owner() {
+        let cancel_flag = Arc::new(AtomicBool::new(false));
+        let mut searches = HashMap::new();
+        searches.insert(
+            "search-1".to_string(),
+            ActiveSearch {
+                owner_id: "connection-1".to_string(),
+                cancel_flag: Arc::clone(&cancel_flag),
+            },
+        );
+
+        assert!(!cancel_owned_search(&searches, "connection-2", "search-1"));
+        assert!(!cancel_flag.load(Ordering::SeqCst));
+        assert!(cancel_owned_search(&searches, "connection-1", "search-1"));
+        assert!(cancel_flag.load(Ordering::SeqCst));
+    }
 }

--- a/qq-chat-export-server/src/security/manager.rs
+++ b/qq-chat-export-server/src/security/manager.rs
@@ -2,8 +2,30 @@ use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 use std::time::Duration;
 
+#[cfg(unix)]
+use std::io::Write;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+
+#[cfg(unix)]
+fn write_security_config(path: &Path, data: &str) -> std::io::Result<()> {
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .mode(0o600)
+        .open(path)?;
+    file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    file.write_all(data.as_bytes())
+}
+
+#[cfg(not(unix))]
+fn write_security_config(path: &Path, data: &str) -> std::io::Result<()> {
+    std::fs::write(path, data)
+}
 
 /// `security.json` 结构，字段序列化为 camelCase。
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -427,16 +449,8 @@ impl SecurityManager {
     /// 保存安全配置快照到磁盘。
     fn save_config_snapshot(&self, config: &SecurityConfig) {
         if let Ok(data) = serde_json::to_string_pretty(config) {
-            if std::fs::write(&self.config_path, data).is_err() {
+            if write_security_config(&self.config_path, &data).is_err() {
                 tracing::warn!("[QCE][SecurityManager] security.json 写入失败");
-            }
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                let permissions = std::fs::Permissions::from_mode(0o600);
-                if std::fs::set_permissions(&self.config_path, permissions).is_err() {
-                    tracing::warn!("[QCE][SecurityManager] security.json 权限设置失败");
-                }
             }
         }
         self.record_mtime();


### PR DESCRIPTION
## Scope
- API security audit and fixes only.
- No integrity-status task, WebSocket, or frontend UX changes.

## Fixes
- Bound WebSocket frames and stream-search duration, scan volume, text extraction, result count, and serialized output.
- Bind search cancellation to the owning WebSocket connection and limit per-connection searches.
- Reject additional reserved and special-use IPv4/IPv6 SSRF targets and normalize localhost checks.
- Set Unix security.json permissions before writing token data.

## Validation
- cargo test --manifest-path qq-chat-export-server/Cargo.toml --lib --bins --no-fail-fast
- cargo clippy --manifest-path qq-chat-export-server/Cargo.toml --all-targets -- -D warnings
- cargo build --manifest-path qq-chat-export-server/Cargo.toml
- cargo audit --file qq-chat-export-server/Cargo.lock
- npm audit --omit=dev --audit-level=high (plugin)
