### PR TITLE
fix(scheduler): 兼容预设任务的空 cronExpression

### DIFF
--- a/qq-chat-export-server/src/api/routes/scheduled.rs
+++ b/qq-chat-export-server/src/api/routes/scheduled.rs
@@ -68,33 +68,38 @@ fn validate_config(body: &Value, partial: bool) -> Result<(), ApiError> {
     validate_string_field(body, "timeRangeType", !partial, 32)?;
     validate_string_field(body, "format", !partial, 16)?;
 
-    if let Some(schedule_type) = body.get("scheduleType").and_then(Value::as_str) {
+    let schedule_type = body.get("scheduleType").and_then(Value::as_str);
+    if let Some(schedule_type) = schedule_type {
         if !matches!(schedule_type, "daily" | "weekly" | "monthly" | "custom") {
             return Err(ApiError::validation(
                 "scheduleType 无效",
                 "INVALID_SCHEDULE_TYPE",
             ));
         }
-        if schedule_type == "custom" {
+    }
+
+    match body.get("cronExpression") {
+        Some(Value::String(expression))
+            if expression.trim().is_empty()
+                && matches!(schedule_type, Some("daily" | "weekly" | "monthly")) => {}
+        Some(_) => {
             validate_string_field(body, "cronExpression", true, 128)?;
-            let expression = body["cronExpression"].as_str().unwrap_or_default();
-            if expression.split_whitespace().count() != 5 {
+            if body["cronExpression"]
+                .as_str()
+                .unwrap_or_default()
+                .split_whitespace()
+                .count()
+                != 5
+            {
                 return Err(ApiError::validation("cronExpression 无效", "INVALID_CRON"));
             }
         }
-    }
-    if body.get("cronExpression").is_some() {
-        validate_string_field(body, "cronExpression", true, 128)?;
-        if body["cronExpression"]
-            .as_str()
-            .unwrap_or_default()
-            .split_whitespace()
-            .count()
-            != 5
-        {
-            return Err(ApiError::validation("cronExpression 无效", "INVALID_CRON"));
+        None if schedule_type == Some("custom") => {
+            validate_string_field(body, "cronExpression", true, 128)?;
         }
+        None => {}
     }
+
     if let Some(time_range_type) = body.get("timeRangeType").and_then(Value::as_str) {
         if !matches!(
             time_range_type,
@@ -417,14 +422,45 @@ mod tests {
     }
 
     #[test]
+    fn accepts_empty_cron_for_preset_schedule() {
+        let mut config = valid_config();
+        config["cronExpression"] = json!("");
+        assert!(validate_config(&config, false).is_ok());
+    }
+
+    #[test]
+    fn requires_valid_cron_for_custom_schedule() {
+        let mut missing = valid_config();
+        missing["scheduleType"] = json!("custom");
+        assert!(validate_config(&missing, false).is_err());
+
+        let mut empty = valid_config();
+        empty["scheduleType"] = json!("custom");
+        empty["cronExpression"] = json!("");
+        assert!(validate_config(&empty, false).is_err());
+
+        let mut valid = valid_config();
+        valid["scheduleType"] = json!("custom");
+        valid["cronExpression"] = json!("0 2 * * *");
+        assert!(validate_config(&valid, false).is_ok());
+
+        let mut invalid = valid_config();
+        invalid["scheduleType"] = json!("custom");
+        invalid["cronExpression"] = json!("* * *");
+        assert!(validate_config(&invalid, false).is_err());
+    }
+
+    #[test]
+    fn rejects_non_empty_invalid_cron_for_preset_schedule() {
+        let mut config = valid_config();
+        config["cronExpression"] = json!("* * *");
+        assert!(validate_config(&config, false).is_err());
+    }
+
+    #[test]
     fn rejects_invalid_types_enums_and_ranges() {
         let mut config = valid_config();
         config["name"] = json!({});
-        assert!(validate_config(&config, false).is_err());
-
-        let mut config = valid_config();
-        config["scheduleType"] = json!("custom");
-        config["cronExpression"] = json!("* * *");
         assert!(validate_config(&config, false).is_err());
 
         let mut config = valid_config();


### PR DESCRIPTION
## 问题

Framework 模式创建每天、每周或每月定时任务时，前端请求会携带空字符串 `cronExpression`。服务端此前只要检测到该字段存在，就会按五段 Cron 表达式校验，因此返回“cronExpression 无效”。

## 修改

- 预设调度类型（`daily` / `weekly` / `monthly`）显式携带空 `cronExpression` 时允许通过
- `custom` 调度仍然必须提供非空且为五段的 Cron 表达式
- 非空但格式错误的 Cron 仍然会被拒绝
- 补充回归测试，覆盖预设任务空值、自定义任务缺失/空值/有效值/无效值

## 验证

- 测试 QCE 插件：通过
- 构建 QCE 插件：通过

Fixes #611