### PR TITLE
fix(ui): 允许预览继续加载更早消息

### DIFF
--- a/qce-v4-tool/components/ui/message-preview-modal.tsx
+++ b/qce-v4-tool/components/ui/message-preview-modal.tsx
@@ -22,6 +22,7 @@ import {
 import { format } from "date-fns"
 import { cn } from "@/lib/utils"
 import { useStreamSearch, type SearchProgress } from "@/lib/useStreamSearch"
+import { canLoadNextMessagePage } from "@/lib/message-preview-pagination"
 
 interface MessagePreviewModalProps {
   open: boolean
@@ -598,7 +599,7 @@ export function MessagePreviewModal({ open, onClose, chat, onExport }: MessagePr
                 variant="ghost"
                 size="sm"
                 onClick={() => { setCurrentPage(p => p + 1); fetchMessages(currentPage + 1) }}
-                disabled={currentPage >= totalPages || loading}
+                disabled={!canLoadNextMessagePage(currentPage, totalPages, hasNext) || loading}
                 className="rounded-full h-8 w-8 p-0"
               >
                 <ChevronRight className="w-4 h-4" />

--- a/qce-v4-tool/e2e/message-preview-pagination.spec.ts
+++ b/qce-v4-tool/e2e/message-preview-pagination.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test'
+import { canLoadNextMessagePage } from '../lib/message-preview-pagination'
+
+test.describe('Message preview pagination (issue #493)', () => {
+  test('continues past the currently cached page boundary', () => {
+    expect(canLoadNextMessagePage(11, 11, true)).toBe(true)
+    expect(canLoadNextMessagePage(1, 2, false)).toBe(true)
+    expect(canLoadNextMessagePage(2, 2, false)).toBe(false)
+  })
+})

--- a/qce-v4-tool/lib/message-preview-pagination.ts
+++ b/qce-v4-tool/lib/message-preview-pagination.ts
@@ -1,0 +1,7 @@
+export function canLoadNextMessagePage(
+  currentPage: number,
+  totalPages: number,
+  hasNext: boolean,
+): boolean {
+  return currentPage < totalPages || hasNext
+}


### PR DESCRIPTION
## 问题

消息预览采用懒加载。后端在当前缓存边界仍有更早消息时会返回 `hasNext: true`，但前端下一页按钮只根据 `currentPage >= totalPages` 判断禁用，因此走到当前已缓存数据的最后一页后无法继续请求更早消息。

## 修改

- 下一页按钮同时参考后端返回的 `hasNext`
- 即使当前页等于当前 `totalPages`，只要仍有未加载消息，就允许继续翻页
- 将分页判断提取为独立函数，补充缓存边界回归测试

## 验证

- 测试 QCE 插件：通过
- 构建 QCE 插件：通过

Fixes #493