### PR TITLE
docs(auth): 区分 QCE 与 NapCat 的访问令牌

### DIFF
--- a/qce-v4-tool/app/auth/page.tsx
+++ b/qce-v4-tool/app/auth/page.tsx
@@ -156,6 +156,8 @@ export default function AuthPage() {
                 请输入访问令牌以继续使用。
                 <br />
                 令牌会在 QCE 启动时打印在控制台里。
+                <br />
+                请勿使用 NapCat WebUI Token。
               </p>
 
               {/* Issue #287: 当 URL 带 ?token= 时显示自动登录条幅，让用户清楚状态 */}
@@ -262,8 +264,18 @@ export default function AuthPage() {
               {/* Modal Content */}
               <div className="p-6 space-y-5 max-h-[70vh] overflow-y-auto">
                 <p className="text-muted-foreground text-[14px] leading-relaxed">
-                  令牌是一串随机字符，用来验证你的身份。每次启动 NapCat / QCE 时会自动生成一个新的。
+                  令牌是一串随机字符，用来验证你的身份。这里需要的是 QCE 自己生成的访问令牌。
                 </p>
+
+                {/* Issue #349: 明确区分 NapCat 管理页令牌与 QCE 访问令牌。 */}
+                <div className="rounded-xl border border-amber-200/80 dark:border-amber-500/20 bg-amber-50/80 dark:bg-amber-500/10 px-4 py-3 space-y-1.5">
+                  <p className="text-[13px] font-medium text-amber-900 dark:text-amber-200">
+                    NapCat WebUI Token 不能用于这里
+                  </p>
+                  <p className="text-[13px] leading-relaxed text-amber-800/90 dark:text-amber-200/80">
+                    控制台中的 <span className="font-mono">[NapCat] [WebUi] WebUi Token</span> 只用于 NapCat 管理页；本页需要 <span className="font-mono">[QCE] Token</span>，或 <span className="font-mono">security.json</span> 中的 <span className="font-mono">accessToken</span>。
+                  </p>
+                </div>
 
                 {/* Issue #287: 一键登录是 Framework 用户最省心的入口，先讲它 */}
                 <div className="space-y-3">

--- a/qce-v4-tool/e2e/auth-token-help.spec.ts
+++ b/qce-v4-tool/e2e/auth-token-help.spec.ts
@@ -16,9 +16,12 @@ test.describe('Auth token help (issue #349)', () => {
         await expect(page.getByText('请勿使用 NapCat WebUI Token。')).toBeVisible();
         await page.getByRole('button', { name: '找不到令牌？' }).click();
 
-        await expect(page.getByText('NapCat WebUI Token 不能用于这里')).toBeVisible();
-        await expect(page.getByText(/只用于 NapCat 管理页/)).toBeVisible();
-        await expect(page.getByText(/security\.json/)).toBeVisible();
-        await expect(page.getByText(/accessToken/)).toBeVisible();
+        const tokenWarning = page
+            .getByText('NapCat WebUI Token 不能用于这里')
+            .locator('..');
+        await expect(tokenWarning).toBeVisible();
+        await expect(tokenWarning).toContainText('只用于 NapCat 管理页');
+        await expect(tokenWarning).toContainText('security.json');
+        await expect(tokenWarning).toContainText('accessToken');
     });
 });

--- a/qce-v4-tool/e2e/auth-token-help.spec.ts
+++ b/qce-v4-tool/e2e/auth-token-help.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+const FRONTEND_BASE = process.env.E2E_FRONTEND_URL ?? 'http://localhost:40653';
+const AUTH_PATH = '/qce/auth';
+
+test.describe('Auth token help (issue #349)', () => {
+    test('distinguishes the QCE access token from the NapCat WebUI token', async ({ page }) => {
+        const response = await page
+            .goto(`${FRONTEND_BASE}${AUTH_PATH}`)
+            .catch(() => null);
+        test.skip(
+            !response || response.status() >= 500,
+            `frontend not reachable at ${FRONTEND_BASE}`
+        );
+
+        await expect(page.getByText('请勿使用 NapCat WebUI Token。')).toBeVisible();
+        await page.getByRole('button', { name: '找不到令牌？' }).click();
+
+        await expect(page.getByText('NapCat WebUI Token 不能用于这里')).toBeVisible();
+        await expect(page.getByText(/只用于 NapCat 管理页/)).toBeVisible();
+        await expect(page.getByText(/security\.json/)).toBeVisible();
+        await expect(page.getByText(/accessToken/)).toBeVisible();
+    });
+});


### PR DESCRIPTION
## 问题

用户在 Shell / Framework 启动日志中可能先看到 NapCat 自己的 `WebUi Token`，容易误以为它可以用于 QCE 的访问验证。实际上 QCE 登录页需要的是 `[QCE] Token`，或 `security.json` 中的 `accessToken`。

## 修改

- 在 QCE 访问验证页直接提示不要使用 NapCat WebUI Token
- 在“找不到令牌？”帮助弹窗中说明两种 Token 的用途区别
- 保留并突出 `[QCE] Token`、一键登录链接及 `security.json.accessToken` 三种正确入口
- 增加 Playwright 回归测试，确保关键说明持续显示

## 验证

- 测试 QCE 插件：通过
- 构建 QCE 插件：通过

Fixes #349