### PR TITLE
fix(linux): 兼容 QQNT 3.2.29 的 ESM 启动作用域

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/napcatLinuxLauncherEsm.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/napcatLinuxLauncherEsm.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression coverage for QQNT 3.2.29's ESM package scope (issue #499).
+ *
+ * The Linux LD_PRELOAD shim writes loadNapCat.js as QQ's replacement entry
+ * point. Newer QQ packages may mark .js files as ESM, so that bootstrap must
+ * not rely on CommonJS-only globals such as require or __filename.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync, spawnSync } from 'node:child_process';
+
+import { createTempDir } from '../helpers/tempDir.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const LAUNCHER_DIR = path.join(REPO_ROOT, 'scripts', 'napcat-launcher');
+const BUILD_SH = path.join(LAUNCHER_DIR, 'build.sh');
+
+function hasGpp(): boolean {
+    return spawnSync('g++', ['--version'], { stdio: 'ignore' }).status === 0;
+}
+
+const skipReason = process.platform !== 'linux'
+    ? 'napcat-launcher is Linux-only'
+    : !hasGpp()
+        ? 'g++ not available'
+        : !fs.existsSync(BUILD_SH)
+            ? 'napcat-launcher build.sh not present'
+            : null;
+
+test('napcat-launcher: generated bootstrap runs inside an ESM package scope', { skip: skipReason ?? false }, () => {
+    const tmp = createTempDir('napcat-launcher-esm-');
+    try {
+        const shim = path.join(tmp.path, 'libnapcat_launcher.so');
+        execFileSync(BUILD_SH, [shim], {
+            cwd: tmp.path,
+            stdio: ['ignore', 'ignore', 'pipe'],
+        });
+
+        // Loading the shim runs its constructor and writes the disk fallback
+        // loadNapCat.js into the current working directory.
+        const generate = spawnSync('true', [], {
+            cwd: tmp.path,
+            env: {
+                ...process.env,
+                LD_PRELOAD: shim,
+                NAPCAT_BOOTMAIN: tmp.path,
+                NAPCAT_LAUNCHER_DEBUG: '0',
+            },
+            encoding: 'utf8',
+        });
+        assert.equal(generate.status, 0, `shim constructor failed: ${generate.stderr}`);
+
+        const bootstrap = path.join(tmp.path, 'loadNapCat.js');
+        assert.ok(fs.existsSync(bootstrap), 'shim should generate loadNapCat.js');
+
+        // Reproduce QQNT 3.2.29: .js files in this package are interpreted as
+        // ES modules. The generated entry must still import napcat.mjs.
+        fs.writeFileSync(
+            path.join(tmp.path, 'package.json'),
+            JSON.stringify({ name: 'qq-esm-scope', type: 'module' }),
+        );
+        fs.writeFileSync(
+            path.join(tmp.path, 'napcat.mjs'),
+            "import fs from 'node:fs';\nfs.writeFileSync(new URL('./esm-bootstrap-ran.txt', import.meta.url), 'ok');\n",
+        );
+
+        const run = spawnSync(process.execPath, [bootstrap], {
+            cwd: tmp.path,
+            env: {
+                ...process.env,
+                NAPCAT_BOOTMAIN: tmp.path,
+            },
+            encoding: 'utf8',
+        });
+
+        assert.equal(run.status, 0, `ESM bootstrap failed: ${run.stderr}`);
+        assert.equal(
+            fs.readFileSync(path.join(tmp.path, 'esm-bootstrap-ran.txt'), 'utf8'),
+            'ok',
+        );
+    } finally {
+        tmp.cleanup();
+    }
+});

--- a/scripts/napcat-launcher/launcher.cpp
+++ b/scripts/napcat-launcher/launcher.cpp
@@ -88,15 +88,18 @@ static const char *ORIGINAL_MAIN_PLAIN =
 
 // JS injected as the new entry point. NAPCAT_BOOTMAIN is exported by
 // launcher-user.sh and points at the QCE pack directory, where napcat.mjs
-// lives alongside the bundled NapCat runtime. We deliberately do NOT chain
-// through napcat-bootstrap.mjs: the bootstrap only existed to monkey-patch
-// process.execPath when running under plain Node, and under real Electron
-// process.execPath already points at the QQ binary.
+// lives alongside the bundled NapCat runtime. The bootstrap deliberately uses
+// only dynamic import() and process globals, so the same loadNapCat.js works
+// whether QQ's package scope treats .js files as CommonJS or ESM (issue #499).
+// We do NOT chain through napcat-bootstrap.mjs: that bootstrap only existed to
+// monkey-patch process.execPath under plain Node, while real Electron already
+// points process.execPath at the QQ binary.
 static const char *NAPCAT_JS_CONTENT =
-    "const path = require('path');"
-    "const CurrentPath = process.env.NAPCAT_BOOTMAIN || path.dirname(__filename);"
     "(async () => {"
-    "  await import('file://' + path.join(CurrentPath, './napcat.mjs'));"
+    "  const path = await import('node:path');"
+    "  const { pathToFileURL } = await import('node:url');"
+    "  const CurrentPath = process.env.NAPCAT_BOOTMAIN || process.cwd();"
+    "  await import(pathToFileURL(path.join(CurrentPath, 'napcat.mjs')).href);"
     "})();";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 问题

Linux 默认启动模式会通过 LD_PRELOAD 改写 QQ 的 `package.json.main`，再执行生成的 `loadNapCat.js`。旧实现使用 `require()` 和 `__filename`，当 QQNT 3.2.29 将 `.js` 放在 ESM 包作用域中时，这些 CommonJS 全局变量不可用，导致 NapCat/QCE 无法正常启动。

## 修改

- 将注入 bootstrap 改为只使用 `import()`、`process` 与 `pathToFileURL`
- 保持 `loadNapCat.js` 文件名和现有启动链路不变，同时兼容 CommonJS 与 ESM 解释方式
- 使用 `pathToFileURL` 生成导入地址，避免目录包含空格或特殊字符时手工拼接 `file://` URL
- 增加 Linux 回归测试：构建真实 launcher shim、生成 `loadNapCat.js`，并在 `type: module` 作用域中实际执行，确认能够加载 `napcat.mjs`

## 验证

- 分支从上游当前 `master`（`9d9259c`）创建
- merge-base diff 仅包含 launcher 修复和对应回归测试
- 测试 QCE 插件：通过（Ubuntu Node 20/22、Windows Node 20/22、Rust exporter/server、Playwright API smoke）
- 构建 QCE 插件：通过
- Ubuntu 插件测试中实际运行新增 ESM 启动回归测试

Fixes #499