### PR TITLE
wip(macos): 探索 Apple Silicon Shell 支持

### DIFF
--- a/.github/workflows/build-macos-shell.yml
+++ b/.github/workflows/build-macos-shell.yml
@@ -172,13 +172,13 @@ jobs:
           NOTES_FILE="$RUNNER_TEMP/release-notes.md"
           gh release view "$TAG" --json body --jq '.body' > "$NOTES_FILE"
           if ! grep -q "NapCat-QCE-macOS-arm64-${TAG}.tar.gz" "$NOTES_FILE"; then
-            cat >> "$NOTES_FILE" <<EOF
-
-### macOS Apple Silicon 预览包
-
-- 适用于 Apple Silicon（arm64）设备：\`NapCat-QCE-macOS-arm64-${TAG}.tar.gz\`
-- 首次运行前请执行 \`xattr -r -d com.apple.quarantine .\` 和 \`chmod +x launcher-user.sh start-standalone.sh qce-server\`
-- 当前为预览支持；CI 已验证 ARM64 服务端、打包结构与启动脚本，真实 QQ 登录兼容性仍需社区反馈
-EOF
+            {
+              echo
+              echo '### macOS Apple Silicon 预览包'
+              echo
+              echo "- 适用于 Apple Silicon（arm64）设备：\`NapCat-QCE-macOS-arm64-${TAG}.tar.gz\`"
+              echo '- 首次运行前请执行 `xattr -r -d com.apple.quarantine .` 和 `chmod +x launcher-user.sh start-standalone.sh qce-server`'
+              echo '- 当前为预览支持；CI 已验证 ARM64 服务端、打包结构与启动脚本，真实 QQ 登录兼容性仍需社区反馈'
+            } >> "$NOTES_FILE"
             gh release edit "$TAG" --notes-file "$NOTES_FILE"
           fi

--- a/.github/workflows/build-macos-shell.yml
+++ b/.github/workflows/build-macos-shell.yml
@@ -43,17 +43,17 @@ jobs:
           workspaces: qq-chat-export-server
           shared-key: qce-server-macos-arm64
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
           cache: pnpm
           cache-dependency-path: qce-v4-tool/pnpm-lock.yaml
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Generate package version
         id: version

--- a/.github/workflows/build-macos-shell.yml
+++ b/.github/workflows/build-macos-shell.yml
@@ -1,0 +1,184 @@
+name: 构建 macOS QCE 完整包
+
+on:
+  pull_request:
+    branches: [main, master]
+    paths:
+      - '.github/workflows/build-macos-shell.yml'
+      - 'scripts/quick-pack.py'
+      - 'scripts/plugin_runtime.py'
+      - 'scripts/napcat-launcher/**'
+      - 'qq-chat-export-server/**'
+      - 'qce-v4-tool/**'
+      - 'plugins/qq-chat-exporter/**'
+  push:
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-alpha.*'
+      - 'v*.*.*-beta.*'
+      - 'v*.*.*-rc.*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: macos-shell-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build-macos-shell:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: qq-chat-export-server
+          shared-key: qce-server-macos-arm64
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: pnpm
+          cache-dependency-path: qce-v4-tool/pnpm-lock.yaml
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Generate package version
+        id: version
+        shell: bash
+        run: |
+          BASE_VERSION=$(node -p "require('./plugins/qq-chat-exporter/package.json').version")
+          SHORT_SHA=$(echo "$GITHUB_SHA" | cut -c1-7)
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            VERSION="${BASE_VERSION}-pr${{ github.event.pull_request.number }}-${SHORT_SHA}"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="${BASE_VERSION}-dev-${SHORT_SHA}"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Generated version: ${VERSION}"
+
+      - name: Build frontend
+        working-directory: qce-v4-tool
+        env:
+          QCE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm run build
+
+      - name: Build macOS ARM64 Rust server
+        working-directory: qq-chat-export-server
+        env:
+          QCE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          cargo build --release
+          BINARY=target/release/qce-server
+          test -x "$BINARY"
+          file "$BINARY"
+          ARCHS=$(lipo -archs "$BINARY")
+          echo "qce-server architectures: $ARCHS"
+          echo "$ARCHS" | grep -qw arm64
+
+      - name: Build macOS Shell package
+        env:
+          NODE_ENV: production
+          NODE_OPTIONS: --max-old-space-size=4096
+          QCE_VERSION: ${{ steps.version.outputs.version }}
+          QCE_FRONTEND_OUT: qce-v4-tool/out
+          QCE_SERVER_BINARY: qq-chat-export-server/target/release/qce-server
+        run: python3 scripts/quick-pack.py
+
+      - name: Validate macOS package
+        shell: bash
+        run: |
+          set -euo pipefail
+          PACKAGE="NapCat-QCE-macOS-arm64-v${{ steps.version.outputs.version }}.tar.gz"
+          test -f "$PACKAGE"
+
+          TMP_DIR=$(mktemp -d)
+          trap 'rm -rf "$TMP_DIR"' EXIT
+          tar -xzf "$PACKAGE" -C "$TMP_DIR"
+          ROOT="$TMP_DIR/NapCat-QCE-macOS-arm64"
+
+          test -d "$ROOT"
+          test -x "$ROOT/qce-server"
+          test -x "$ROOT/launcher-user.sh"
+          test -x "$ROOT/start-standalone.sh"
+          test -f "$ROOT/napcat-bootstrap.mjs"
+          test -f "$ROOT/static/qce/index.html"
+          test -f "$ROOT/plugins/napcat-plugin-qce/index.mjs"
+
+          file "$ROOT/qce-server" | grep -q 'Mach-O.*arm64'
+          lipo -archs "$ROOT/qce-server" | grep -qw arm64
+          bash -n "$ROOT/launcher-user.sh"
+          bash -n "$ROOT/start-standalone.sh"
+          node --check "$ROOT/napcat-bootstrap.mjs"
+          grep -q '平台: macOS-arm64' "$ROOT/README.txt"
+
+          if find "$ROOT" -maxdepth 1 -type f \( -name '*.bat' -o -name '*.dll' -o -name '*.exe' \) -print | grep -q .; then
+            echo 'FAIL: Windows-only artifacts leaked into the macOS package'
+            exit 1
+          fi
+
+          echo "Validated $PACKAGE"
+
+      - name: Upload macOS package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: NapCat-QCE-macOS-arm64-${{ steps.version.outputs.version }}
+          path: NapCat-QCE-macOS-arm64-v${{ steps.version.outputs.version }}.tar.gz
+          retention-days: 7
+
+      - name: Upload macOS package to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="$GITHUB_REF_NAME"
+          PACKAGE="NapCat-QCE-macOS-arm64-${TAG}.tar.gz"
+
+          RELEASE_READY=0
+          for attempt in $(seq 1 40); do
+            if gh release view "$TAG" >/dev/null 2>&1; then
+              RELEASE_READY=1
+              break
+            fi
+            echo "Waiting for the main release workflow ($attempt/40)..."
+            sleep 15
+          done
+
+          if [ "$RELEASE_READY" != "1" ]; then
+            echo "FAIL: release $TAG was not created in time"
+            exit 1
+          fi
+
+          gh release upload "$TAG" "$PACKAGE" --clobber
+
+          NOTES_FILE="$RUNNER_TEMP/release-notes.md"
+          gh release view "$TAG" --json body --jq '.body' > "$NOTES_FILE"
+          if ! grep -q "NapCat-QCE-macOS-arm64-${TAG}.tar.gz" "$NOTES_FILE"; then
+            cat >> "$NOTES_FILE" <<EOF
+
+### macOS Apple Silicon 预览包
+
+- 适用于 Apple Silicon（arm64）设备：\`NapCat-QCE-macOS-arm64-${TAG}.tar.gz\`
+- 首次运行前请执行 \`xattr -r -d com.apple.quarantine .\` 和 \`chmod +x launcher-user.sh start-standalone.sh qce-server\`
+- 当前为预览支持；CI 已验证 ARM64 服务端、打包结构与启动脚本，真实 QQ 登录兼容性仍需社区反馈
+EOF
+            gh release edit "$TAG" --notes-file "$NOTES_FILE"
+          fi

--- a/README.md
+++ b/README.md
@@ -33,12 +33,15 @@
 2. 用 QQ 扫码登录
 3. 打开 `http://localhost:40653/qce`，开始导出
 
-### Shell 模式（Windows / Linux）
+### Shell 模式（Windows / Linux / macOS Apple Silicon 预览）
 
 1. 从 [Releases][releases-link] 下载对应平台的压缩包
-2. 运行 `launcher-user.bat`（Windows）或 `./launcher-user.sh`（Linux）
+2. 运行 `launcher-user.bat`（Windows）或 `./launcher-user.sh`（Linux / macOS）
 3. 用 QQ 扫码登录，复制控制台输出的 Token
 4. 打开 `http://localhost:40653/qce`
+
+> \[!NOTE]
+> macOS 当前仅提供 Apple Silicon（arm64）预览包。首次运行前需要移除隔离属性并补充执行权限，详见 [macOS 使用指南][macos-doc]。
 
 ### Docker 一键部署
 
@@ -64,7 +67,7 @@ docker logs -f napcat-qce
 
 [![ChatLab](docs/images/bento-chatlab.png)](https://chatlab.fun/cn)
 
-<p><a href="https://github.com/Ruoan-486/QCE2Chatlab"><img src="docs/images/bento-qce2chatlab.png" alt="QCE2ChatLab" width="49%"></a><a href="https://github.com/CutrelyAlex/QQChatAnalyzer"><img src="docs/images/bento-qqchatanalyzer.png" alt="QQChatAnalyzer" width="49%"></a><a href="https://github.com/JUSTMONIKA2022/QQ-Chat-AI-Analyzer"><img src="docs/images/bento-qq-chat-ai-analyzer.png" alt="QQ-Chat-AI-Analyzer" width="49%"></a><a href="https://github.com/streetartist/napcat-qce-python"><img src="docs/images/bento-napcat-qce-python.png" alt="napcat-qce-python" width="49%"></a></p>
+<p><a href="https://github.com/Ruoan-486/QCE2Chatlab"><img src="docs/images/bento-qce2chatlab.png" alt="QCE2ChatLab" width="49%"></a><a href="https://github.com/CutrelyAlex/QQChatAnalyzer"><img src="docs/images/bento-qce2chatlab.png" alt="QCE2ChatLab" width="49%"></a><a href="https://github.com/JUSTMONIKA2022/QQ-Chat-AI-Analyzer"><img src="docs/images/bento-qq-chat-ai-analyzer.png" alt="QQ-Chat-AI-Analyzer" width="49%"></a><a href="https://github.com/streetartist/napcat-qce-python"><img src="docs/images/bento-napcat-qce-python.png" alt="napcat-qce-python" width="49%"></a></p>
 
 我们非常欢迎和 QCE 有关的社区项目！如果需要展示您的项目，可以在[这里](https://github.com/shuakami/qq-chat-exporter/issues/new)提一个 issue。
 
@@ -89,6 +92,7 @@ docker logs -f napcat-qce
 [stars-link]: https://github.com/shuakami/qq-chat-exporter/stargazers
 [license-link]: LICENSE
 [docker-doc]: https://shuakami.github.io/qq-chat-exporter/docs/docker-napcat-deployment.html
+[macos-doc]: https://shuakami.github.io/qq-chat-exporter/docs/macos-deploy.html
 [github-release-shield]: https://img.shields.io/github/v/release/shuakami/qq-chat-exporter?color=317cfe&labelColor=black&logo=github&style=flat-square
 [github-downloads-shield]: https://img.shields.io/github/downloads/shuakami/qq-chat-exporter/total?color=317cfe&labelColor=black&style=flat-square
 [github-stars-shield]: https://img.shields.io/github/stars/shuakami/qq-chat-exporter?color=317cfe&labelColor=black&style=flat-square

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ docker logs -f napcat-qce
 
 [![ChatLab](docs/images/bento-chatlab.png)](https://chatlab.fun/cn)
 
-<p><a href="https://github.com/Ruoan-486/QCE2Chatlab"><img src="docs/images/bento-qce2chatlab.png" alt="QCE2ChatLab" width="49%"></a><a href="https://github.com/CutrelyAlex/QQChatAnalyzer"><img src="docs/images/bento-qce2chatlab.png" alt="QCE2ChatLab" width="49%"></a><a href="https://github.com/JUSTMONIKA2022/QQ-Chat-AI-Analyzer"><img src="docs/images/bento-qq-chat-ai-analyzer.png" alt="QQ-Chat-AI-Analyzer" width="49%"></a><a href="https://github.com/streetartist/napcat-qce-python"><img src="docs/images/bento-napcat-qce-python.png" alt="napcat-qce-python" width="49%"></a></p>
+<p><a href="https://github.com/Ruoan-486/QCE2Chatlab"><img src="docs/images/bento-qce2chatlab.png" alt="QCE2ChatLab" width="49%"></a><a href="https://github.com/CutrelyAlex/QQChatAnalyzer"><img src="docs/images/bento-qqchatanalyzer.png" alt="QQChatAnalyzer" width="49%"></a><a href="https://github.com/JUSTMONIKA2022/QQ-Chat-AI-Analyzer"><img src="docs/images/bento-qq-chat-ai-analyzer.png" alt="QQ-Chat-AI-Analyzer" width="49%"></a><a href="https://github.com/streetartist/napcat-qce-python"><img src="docs/images/bento-napcat-qce-python.png" alt="napcat-qce-python" width="49%"></a></p>
 
 我们非常欢迎和 QCE 有关的社区项目！如果需要展示您的项目，可以在[这里](https://github.com/shuakami/qq-chat-exporter/issues/new)提一个 issue。
 

--- a/docs/macos-deploy.md
+++ b/docs/macos-deploy.md
@@ -1,0 +1,82 @@
+# macOS Apple Silicon 预览支持
+
+QQ Chat Exporter 现在可以为 Apple Silicon（arm64）构建独立的 Shell 完整包。
+
+> [!WARNING]
+> macOS 支持目前仍处于预览阶段。自动化构建会验证 ARM64 `qce-server`、压缩包结构和启动脚本，但无法在 CI 中完成真实 QQ 扫码登录与聊天记录导出验证。
+
+## 适用范围
+
+- Apple Silicon Mac（M1 及后续芯片）
+- 已安装当前官方 macOS 版 QQ
+- 已安装 Node.js 18 或更高版本
+- Intel Mac 暂无官方 x64 完整包
+
+## 安装与启动
+
+1. 从 Releases 下载 `NapCat-QCE-macOS-arm64-v*.tar.gz`。
+2. 解压后进入目录。
+3. 移除 macOS 隔离属性并补充执行权限：
+
+```bash
+xattr -r -d com.apple.quarantine .
+chmod +x launcher-user.sh start-standalone.sh qce-server
+```
+
+4. 启动完整模式：
+
+```bash
+./launcher-user.sh
+```
+
+5. 完成 QQ 登录后，在浏览器打开：
+
+```text
+http://localhost:40653/qce
+```
+
+## 自定义 QQ 路径
+
+启动器会优先查找以下位置：
+
+```text
+/Applications/QQ.app/Contents/MacOS/QQ
+~/Applications/QQ.app/Contents/MacOS/QQ
+```
+
+QQ 安装在其他位置时，可以手动指定：
+
+```bash
+export NAPCAT_QQ_PATH="/你的路径/QQ.app/Contents/MacOS/QQ"
+./launcher-user.sh
+```
+
+`NAPCAT_QQ_PATH` 必须指向 `.app` 内部真实的 QQ 可执行文件，而不是 `.app` 目录本身。
+
+## 独立查看模式
+
+只需要浏览已经导出的聊天记录时，不必启动 QQ：
+
+```bash
+./start-standalone.sh
+```
+
+## 与旧版 Linux 包的区别
+
+不要在 macOS 上使用 `NapCat-QCE-Linux-x64`。Linux 包包含 Linux 架构的服务端和注入组件，无法作为 macOS 完整包使用。
+
+macOS 完整包会：
+
+- 使用原生 ARM64 `qce-server`；
+- 使用 macOS QQ 的 `.app` 路径；
+- 通过 `napcat-bootstrap.mjs` 在加载 NapCat 前同步 QQ 可执行文件路径；
+- 排除 Windows 的 BAT、DLL 和 EXE 文件。
+
+## 反馈问题
+
+提交 Issue 时请附上：
+
+- Mac 芯片型号和 macOS 版本；
+- QQ、QCE 与 NapCat 版本；
+- `logs/qce-runtime.log`；
+- 终端中从启动到报错前后的完整日志。


### PR DESCRIPTION
## 当前状态

> [!CAUTION]
> 真机测试已确认：当前分支**尚未实现可用的 macOS NapCat 启动链路**。现有 `node napcat-bootstrap.mjs` 路径只会启动 QQ.app 自身，`napcat.mjs` 没有被执行，因此不会生成二维码，也不会监听 40653 端口。PR 已退回 Draft，暂不应合并或发布产物。

## 已确认的根因

macOS 官方 QQ 是已经签名、打包的 Electron App，其 `package.json` 的 `main` 固定指向 QQ 自身的 `application.asar`。将 `process.execPath` 覆写为 QQ 可执行文件后再 `fork(napcat.mjs)`，不能像通用 Electron 二进制那样把额外脚本作为应用入口。

Linux 使用 `LD_PRELOAD` 动态改写 `package.json` 入口；当前 macOS 路径没有对应的运行时注入机制。本分支此前只增加了构建、打包和文档，没有修改这一核心运行时代码。

感谢 @cwenwensen 的真机验证和根因定位。

## 当前分支已经完成但不足以证明可用的内容

- 在 macOS Apple Silicon runner 上构建原生 ARM64 `qce-server`
- 生成 macOS ARM64 压缩包
- 检查 Mach-O 架构、Shell/Node 语法、可执行权限和包结构
- 添加 macOS 文档草稿

这些检查只能证明“产物可构建”，不能证明“NapCat 能在 QQ.app 中加载”。

## 后续修复方向

根据真机验证，目前可行方向是：

1. 启动前备份 QQ 的 `resources/app/package.json`；
2. 将 `main` 临时改为 QCE/NapCat loader；
3. 对必要的 QQ 可执行文件执行临时重签名，并处理不适用于 ad-hoc 签名的 entitlements；
4. 使用必要的 Chromium 启动参数；
5. 启动失败或退出时恢复原文件，并提供明确的超时/失败提示；
6. 由 macOS 真机再次验证二维码、NapCat 数据目录及 40653 端口。

在运行时代码和恢复机制完成、并通过真机验证前，本 PR 保持 Draft。

Addresses #367
Related to #320