### PR TITLE
fix(ci): 修复 NapCat 版本探测静默回退导致 macOS 包无法登录

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -76,6 +76,9 @@ jobs:
           NODE_ENV: production
           NODE_OPTIONS: --max-old-space-size=4096
           QCE_VERSION: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || format('pr-{0}', github.run_id) }}
+          # Authenticated NapCat version lookup: the anonymous 60/hour quota is
+          # per source IP and shared across runners, so it runs out at random.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Inject uninstaller exe into the Shell zip so it gets extracted
       # to the install directory alongside the main application files.

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -97,6 +97,9 @@ jobs:
           NODE_ENV: production
           NODE_OPTIONS: --max-old-space-size=4096
           QCE_VERSION: ${{ steps.version.outputs.version }}
+          # Authenticated NapCat version lookup: the anonymous 60/hour quota is
+          # per source IP and shared across runners, so it runs out at random.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build complete package (Linux)
         if: matrix.platform == 'Linux'
@@ -106,6 +109,7 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=4096
           QCE_VERSION: ${{ steps.version.outputs.version }}
           QCE_SERVER_BINARY: qq-chat-export-server/target/x86_64-unknown-linux-musl/release/qce-server
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # quick-pack.py builds qce-server itself when no prebuilt binary is
       # supplied, same as the Windows leg above.
@@ -116,6 +120,7 @@ jobs:
           NODE_ENV: production
           NODE_OPTIONS: --max-old-space-size=4096
           QCE_VERSION: ${{ steps.version.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify macOS package is native arm64
         if: matrix.platform == 'macOS'
@@ -182,6 +187,7 @@ jobs:
         env:
           NODE_ENV: production
           QCE_VERSION: ${{ steps.version.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Framework artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -17,13 +17,31 @@ jobs:
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:
+      # 整条发布流程唯一一次 NapCat 版本查询，结果分发给下面所有打包任务。
+      # 之前每个打包任务各查一次（5 次匿名请求），而匿名配额 60 次/小时、按来源
+      # IP 计算，Actions 构建机共用出口 IP —— v6.1.9 发布时 macOS 那台被限流，
+      # 静默回退到写死的 v4.8.119，产出了一个能构建、能过校验却无法登录的包。
       - name: "获取 NapCat 最新版本"
         id: get_version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          NAPCAT_VERSION=$(curl -s https://api.github.com/repos/NapNeko/NapCatQQ/releases/latest | jq -r '.tag_name')
-          if [ -z "$NAPCAT_VERSION" ] || [ "$NAPCAT_VERSION" == "null" ]; then
-            echo "无法获取最新版本，使用默认版本"
-            NAPCAT_VERSION="v4.8.119"
+          set -uo pipefail
+          # 本步骤由 Actions 以 bash -e 运行，errexit 始终生效，所以 curl 与 jq
+          # 都要用 `|| VAR=""` 兜住——否则它们非零退出会直接中断这一步，
+          # 下面那段说明该怎么办的提示就永远不会打印出来。
+          # 带 token 认证走 1000 次/小时的仓库配额，而不是共享 IP 的 60 次。
+          RESPONSE=$(curl -fsSL --retry 3 --retry-delay 2 \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            https://api.github.com/repos/NapNeko/NapCatQQ/releases/latest) || RESPONSE=""
+          # `// empty` 已把 JSON null 归一为空串，只需判空。
+          NAPCAT_VERSION=$(printf '%s' "$RESPONSE" | jq -r '.tag_name // empty') || NAPCAT_VERSION=""
+          if [ -z "$NAPCAT_VERSION" ]; then
+            echo "::error::无法解析 NapCat 最新版本。"
+            echo "::error::不再回退到写死的版本：过期的 NapCat 会产出无法登录的包。"
+            echo "::error::配额恢复后重跑失败任务即可（无需新建 tag）。"
+            exit 1
           fi
           echo "version=${NAPCAT_VERSION}" >> $GITHUB_OUTPUT
           echo "检测到 NapCat 版本: ${NAPCAT_VERSION}"
@@ -137,7 +155,7 @@ jobs:
           retention-days: 7
 
   build-shell-packages:
-    needs: [build-frontend, build-server-binaries]
+    needs: [get-napcat-version, build-frontend, build-server-binaries]
     strategy:
       # A failure on one platform must not cancel the others mid-package:
       # release tags are never reused, so a partially built release costs a
@@ -202,6 +220,8 @@ jobs:
           NODE_ENV: production
           NODE_OPTIONS: --max-old-space-size=4096
           QCE_VERSION: ${{ github.ref_name }}
+          # 用上面解析好的版本号，三个平台因此必然打包同一个 NapCat。
+          NAPCAT_VERSION: ${{ needs.get-napcat-version.outputs.version }}
           QCE_FRONTEND_OUT: qce-v4-tool/out
           QCE_SERVER_BINARY: prebuilt-server/${{ matrix.server_binary }}
       
@@ -227,6 +247,17 @@ jobs:
 
           file "$ROOT/qce-server" | grep -q 'Mach-O.*arm64'
           lipo -archs "$ROOT/qce-server" | grep -qw arm64
+
+          # 断言 get-napcat-version -> NAPCAT_VERSION -> 包内 README.txt 这条传递
+          # 链没断：真正杜绝 v6.1.9 事故的是删掉兜底版本，这里守的是日后重构
+          # 悄悄绕开 NAPCAT_VERSION、让各平台又各查各的。
+          EXPECTED_NAPCAT="${{ needs.get-napcat-version.outputs.version }}"
+          if ! grep -qF "NapCat 版本: ${EXPECTED_NAPCAT}" "$ROOT/README.txt"; then
+            echo "FAIL: packaged NapCat is not ${EXPECTED_NAPCAT}"
+            grep -F 'NapCat 版本:' "$ROOT/README.txt" || true
+            exit 1
+          fi
+          echo "Bundled NapCat: ${EXPECTED_NAPCAT}"
           bash -n "$ROOT/launcher-user.sh"
           bash -n "$ROOT/start-standalone.sh"
           node --check "$ROOT/napcat-bootstrap.mjs"
@@ -247,7 +278,7 @@ jobs:
           retention-days: 7
 
   build-framework-package:
-    needs: [build-frontend, build-server-binaries]
+    needs: [get-napcat-version, build-frontend, build-server-binaries]
     runs-on: ubuntu-latest
     
     steps:
@@ -278,6 +309,7 @@ jobs:
         env:
           NODE_ENV: production
           QCE_VERSION: ${{ github.ref_name }}
+          NAPCAT_VERSION: ${{ needs.get-napcat-version.outputs.version }}
           QCE_FRONTEND_OUT: qce-v4-tool/out
           QCE_SERVER_WINDOWS_X64: prebuilt-server/qce-server.exe
       

--- a/docs/macos-deploy.md
+++ b/docs/macos-deploy.md
@@ -26,13 +26,17 @@ QCE 的 Shell 模式包现在也可以在 Apple Silicon（M1 及以上）Mac 上
 
 ### 1. 下载并解压
 
-去 [GitHub Releases](https://github.com/shuakami/qq-chat-exporter/releases) 页面下载最新的 `NapCat-QCE-macOS-arm64-vXXX.tar.gz`，然后在终端执行以下命令解压（默认解压到 `~/qce`，想放别处把命令里的路径改掉即可）：
+去 [GitHub Releases](https://github.com/shuakami/qq-chat-exporter/releases) 页面，下载文件名以 `NapCat-QCE-macOS-arm64` 开头的压缩包。
+
+下载完成后打开「终端」，把下面三行整段复制进去执行。命令会自动找到你刚下载的那个压缩包并解压到 `~/qce`，不需要改动任何内容：
 
 ```bash
 mkdir -p ~/qce && cd ~/qce
-tar -xzf ~/Downloads/NapCat-QCE-macOS-arm64-vXXX.tar.gz
+tar -xf "$(ls -t ~/Downloads/NapCat-QCE-macOS-arm64-*.tar* | head -1)"
 cd NapCat-QCE-macOS-arm64
 ```
+
+如果你把压缩包存到了「下载」以外的位置，把命令里的 `~/Downloads` 换成实际所在的文件夹；想解压到别处，把两处 `~/qce` 换掉即可。
 
 ### 2. 退出桌面 QQ
 

--- a/plugins/qq-chat-exporter/__tests__/unit/napcatVersionLookup.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/napcatVersionLookup.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '../../../..');
+
+function read(relativePath: string) {
+    return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+const PACKAGING_SCRIPTS = [
+    'scripts/plugin_runtime.py',
+    'scripts/quick-pack.py',
+    'scripts/build-framework-plugin.py',
+    'scripts/pack-windows-on-linux.py'
+];
+
+/*
+ * v6.1.9 shipped a macOS package built around NapCat v4.8.119: the lookup hit
+ * GitHub's unauthenticated rate limit and fell back to a hardcoded version, so
+ * the package built, passed every check and could never log in. The fallback
+ * lived in four near-copies, and the one fix that had been applied never
+ * reached the other three.
+ */
+test('no packaging script can fall back to a hardcoded NapCat version', () => {
+    for (const script of PACKAGING_SCRIPTS) {
+        assert.ok(
+            !/return\s+"v\d/.test(read(script)),
+            `${script} still returns a hardcoded NapCat version`
+        );
+    }
+});
+
+test('the NapCat lookup has exactly one implementation', () => {
+    assert.ok(read('scripts/plugin_runtime.py').includes('def get_napcat_latest_version'));
+
+    for (const script of ['scripts/quick-pack.py', 'scripts/build-framework-plugin.py']) {
+        const source = read(script);
+        assert.match(
+            source,
+            /from plugin_runtime import \([^)]*get_napcat_latest_version,/,
+            `${script} must import the lookup from plugin_runtime`
+        );
+        assert.ok(
+            !source.includes('def get_napcat_latest_version'),
+            `${script} must not define a second copy of the lookup`
+        );
+    }
+
+    // The Windows-on-Linux wrapper used to monkey-patch its own copy of the
+    // lookup; that divergence is what let the fix miss three call sites.
+    assert.ok(!read('scripts/pack-windows-on-linux.py').includes('get_napcat_latest_version'));
+});
+
+test('one release-wide lookup feeds every packaging job', () => {
+    const workflow = read('.github/workflows/release-plugin.yml');
+
+    // Shell (all three platforms) and Framework packages both consume the one
+    // resolved version, so a release can never bundle two different NapCats.
+    const consumers = workflow.match(/NAPCAT_VERSION: \$\{\{ needs\.get-napcat-version\.outputs\.version \}\}/g);
+    assert.equal(consumers?.length, 2);
+
+    for (const job of ['build-shell-packages', 'build-framework-package']) {
+        assert.match(
+            workflow,
+            new RegExp(`\\n  ${job}:\\s+needs: \\[get-napcat-version,`),
+            `${job} must depend on the shared lookup`
+        );
+    }
+
+    // Honouring the pinned value is what makes the fan-out work at all.
+    assert.ok(read('scripts/plugin_runtime.py').includes('os.environ.get("NAPCAT_VERSION"'));
+});

--- a/scripts/build-framework-plugin.py
+++ b/scripts/build-framework-plugin.py
@@ -12,10 +12,11 @@ import subprocess
 import zipfile
 import platform
 from pathlib import Path
-from urllib.request import urlretrieve, urlopen
+from urllib.request import urlretrieve
 from datetime import datetime
 from plugin_runtime import (
     copy_windows_server_binary,
+    get_napcat_latest_version,
     stage_plugin_runtime,
     write_find_qq_script,
 )
@@ -32,19 +33,6 @@ def get_qce_version():
             return json.load(f).get('version', 'unknown')
     except:
         return 'unknown'
-
-def get_napcat_latest_version():
-    """Get latest NapCat version from GitHub API"""
-    print("[*] Getting NapCat latest version...")
-    try:
-        with urlopen("https://api.github.com/repos/NapNeko/NapCatQQ/releases/latest") as response:
-            data = json.loads(response.read())
-            version = data["tag_name"]
-            print(f"[x] NapCat version: {version}")
-            return version
-    except Exception as e:
-        print(f"[!] Failed to get latest version: {e}")
-        return "v4.8.119"
 
 def write_napcat_builtin_plugin_config(config_dir):
     """Disable the builtin #napcat reply command by default."""

--- a/scripts/napcat-launcher/launcher-user.sh
+++ b/scripts/napcat-launcher/launcher-user.sh
@@ -311,10 +311,13 @@ if [[ "${OSTYPE:-}" == darwin* ]]; then
     # binary gets silently SIGKILLed the instant it's spawned, before it can
     # log anything (confirmed on real hardware: qce-server died on launch,
     # QQ/NapCat kept running fine, and the web UI was simply unreachable with
-    # no error dialog at all). The docs also tell users to run
-    # `xattr -r -d com.apple.quarantine .` themselves before first launch, but
-    # that step is easy to get wrong (wrong cwd, extracting via Finder after
-    # already having run it, etc.), so don't rely on it having worked.
+    # no error dialog at all). Nothing in the docs asks users to clear the
+    # attribute themselves, and extracting from Terminal does not avoid it
+    # either: macOS propagates the archive's own quarantine to every extracted
+    # file whatever the tool -- verified with `tar -xf` on a Safari-downloaded
+    # release tarball, where qce-server came out quarantined just as it does
+    # via Finder. This strip is therefore the only thing that keeps a
+    # browser-downloaded package runnable; do not drop it as redundant.
     [ -e "$SCRIPT_DIR/qce-server" ] && xattr -cr "$SCRIPT_DIR/qce-server" 2>/dev/null
     [ -d "$SCRIPT_DIR/native" ] && xattr -cr "$SCRIPT_DIR/native" 2>/dev/null
 

--- a/scripts/pack-windows-on-linux.py
+++ b/scripts/pack-windows-on-linux.py
@@ -26,28 +26,6 @@ spec.loader.exec_module(qp)
 
 qp.get_platform_info = lambda: ("Windows", "x64", ".zip")
 
-# GitHub API 受速率限制时回退到 v4.18.8。
-_orig_get_napcat_latest_version = qp.get_napcat_latest_version
-def get_napcat_latest_version():
-    import urllib.request, json as _json
-    try:
-        req = urllib.request.Request(
-            "https://api.github.com/repos/NapNeko/NapCatQQ/releases/latest",
-            headers={"Accept": "application/vnd.github+json"},
-        )
-        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("TEMP_GITHUB_PAT")
-        if token:
-            req.add_header("Authorization", f"Bearer {token}")
-        with urllib.request.urlopen(req) as resp:
-            version = _json.loads(resp.read())["tag_name"]
-            print(f"[x] Detected NapCat version: {version}")
-            return version
-    except Exception as e:
-        print(f"[!] Failed to get latest version: {e}")
-        print("[!] Using fallback version v4.18.8")
-        return "v4.18.8"
-qp.get_napcat_latest_version = get_napcat_latest_version
-
 _orig_run_command = qp.run_command
 
 def run_command(cmd, cwd=None, shell=False):

--- a/scripts/plugin_runtime.py
+++ b/scripts/plugin_runtime.py
@@ -8,10 +8,82 @@ import platform
 import shutil
 import subprocess
 import stat
+import time
 from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 
 SERVER_DIR = Path("qq-chat-export-server")
+
+NAPCAT_LATEST_API = "https://api.github.com/repos/NapNeko/NapCatQQ/releases/latest"
+
+
+def _rate_limit_hint(headers) -> str:
+    """Say when the GitHub quota lifts and how to get past it meanwhile."""
+    reset = (headers.get("X-RateLimit-Reset") or "").strip()
+    until = f" until {time.strftime('%H:%M:%S UTC', time.gmtime(int(reset)))}" if reset.isdigit() else ""
+    return (
+        f"[!] GitHub API rate limited{until}. Re-run the failed jobs once it lifts\n"
+        "[!] (no new tag needed), or set GITHUB_TOKEN for the 1000/hour quota,\n"
+        "[!] or pin NAPCAT_VERSION=vX.Y.Z."
+    )
+
+
+def get_napcat_latest_version(progress: str = "[*]") -> str:
+    """Resolve which NapCat release to bundle.
+
+    NAPCAT_VERSION wins when set, so one CI lookup can feed every packaging job
+    and all platforms in a release are guaranteed to bundle the same NapCat.
+
+    There is deliberately no hardcoded fallback. A stale NapCat still builds,
+    still passes every packaging check and still ships -- but cannot log in at
+    all: v6.1.9's macOS package fell back to NapCat v4.8.119 this way after the
+    lookup hit the 60/hour unauthenticated rate limit, and QQ's native bridge
+    then failed with `NodeIQQNTWrapperSession.create is not a function` before a
+    QR code could ever be generated. Failing the build is the cheaper outcome:
+    it happens in seconds, before any artifact exists.
+    """
+    print(f"{progress} Getting NapCat latest version...")
+
+    pinned = os.environ.get("NAPCAT_VERSION", "").strip()
+    if pinned:
+        print(f"[x] Using NAPCAT_VERSION from environment: {pinned}")
+        return pinned
+
+    headers = {"Accept": "application/vnd.github+json", "User-Agent": "qce-packaging"}
+    # GITHUB_TOKEN is injected per-run by Actions; TEMP_GITHUB_PAT lets a local
+    # build borrow the same authenticated quota without inventing a new name.
+    token = (os.environ.get("GITHUB_TOKEN") or os.environ.get("TEMP_GITHUB_PAT") or "").strip()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    attempts = 4
+    for attempt in range(1, attempts + 1):
+        try:
+            with urlopen(Request(NAPCAT_LATEST_API, headers=headers), timeout=30) as response:
+                version = json.loads(response.read())["tag_name"]
+            if not version:
+                raise ValueError("empty tag_name")
+            print(f"[x] Detected NapCat version: {version}")
+            return version
+        except HTTPError as error:
+            # A 4xx will not change on a retry. Rate limiting in particular
+            # resets hourly, so report when it lifts rather than retry blindly.
+            if error.code < 500:
+                if error.code in (403, 429):
+                    print(_rate_limit_hint(error.headers))
+                raise SystemExit(f"NapCat version lookup failed: HTTP {error.code}")
+            reason = f"HTTP {error.code}"
+        except (URLError, TimeoutError, ValueError, KeyError) as error:
+            reason = str(error) or error.__class__.__name__
+
+        if attempt < attempts:
+            delay = 2**attempt
+            print(f"[!] Attempt {attempt}/{attempts} failed ({reason}); retrying in {delay}s...")
+            time.sleep(delay)
+
+    raise SystemExit(f"NapCat version lookup failed after {attempts} attempts: {reason}")
 
 
 def run_command(command: list[str], cwd: Path | None = None) -> None:

--- a/scripts/quick-pack.py
+++ b/scripts/quick-pack.py
@@ -10,9 +10,14 @@ import subprocess
 import zipfile
 import tarfile
 from pathlib import Path
-from urllib.request import urlretrieve, urlopen
+from urllib.request import urlretrieve
 from datetime import datetime
-from plugin_runtime import FIND_QQ_PS1, copy_native_server_binary, stage_plugin_runtime
+from plugin_runtime import (
+    FIND_QQ_PS1,
+    copy_native_server_binary,
+    get_napcat_latest_version,
+    stage_plugin_runtime,
+)
 
 def get_qce_version():
     """Get QCE version from package.json or environment variable"""
@@ -46,20 +51,6 @@ def get_platform_info():
     else:
         print(f"[!] Unsupported platform: {system}")
         sys.exit(1)
-
-def get_napcat_latest_version():
-    """Get latest NapCat version from GitHub API"""
-    print("[1/11] Getting NapCat latest version...")
-    try:
-        with urlopen("https://api.github.com/repos/NapNeko/NapCatQQ/releases/latest") as response:
-            data = json.loads(response.read())
-            version = data["tag_name"]
-            print(f"[x] Detected NapCat version: {version}")
-            return version
-    except Exception as e:
-        print(f"[!] Failed to get latest version: {e}")
-        print("[!] Using default version v4.8.119")
-        return "v4.8.119"
 
 def download_file(url, dest):
     """Download file with progress"""
@@ -163,7 +154,7 @@ def main():
     print()
     
     # Get NapCat version
-    napcat_version = get_napcat_latest_version()
+    napcat_version = get_napcat_latest_version("[1/11]")
     napcat_url = f"https://github.com/NapNeko/NapCatQQ/releases/download/{napcat_version}/NapCat.Shell.zip"
     print()
     


### PR DESCRIPTION
## 问题

v6.1.9 的 macOS 包内置的是 NapCat v4.8.119,而同一次发布的 Windows / Linux 包内置的是 v4.18.13。构建日志显示 macOS 那台构建机的版本查询收到了 `HTTP Error 403: rate limit exceeded`,随后静默回退到代码里写死的 v4.8.119 继续打包。

GitHub API 匿名配额是 60 次/小时、按来源 IP 计算,而 Actions 构建机共用出口 IP;当时一次发布会发起 5 次独立查询,撞上限流只是早晚的事。构建仍然成功、所有校验通过、Release 正常发布——因为没有任何一步会检查内置的 NapCat 到底是哪个版本。

v4.8.119 缺少新版 QQ 需要的 napi2native,核心初始化直接崩溃(`NodeIQQNTWrapperSession.create is not a function`),登录服务从未启动,用户看到的是终端既不出二维码、也没有任何报错。

## 修改

- **合并查询**:新增 `get-napcat-version` 任务,整条发布流程只查一次版本号,结果通过 `NAPCAT_VERSION` 传给所有打包任务,查询次数从 5 次降到 1 次,三个平台从机制上保证内置同一个 NapCat。
- **认证请求**:带 `GITHUB_TOKEN` 走 1000 次/小时的仓库配额,而不是共享 IP 的 60 次/小时。
- **失败即停**:删除全部硬编码兜底版本,拿不到版本号就让构建失败,不再产出一个能构建、能过校验、但登录不了的包。失败点落在最前面的独立任务里,几秒内、早于任何实际打包动作;限流时会打印配额恢复时间和处置办法(重跑失败任务即可,无需新建 tag)。
- **收敛重复实现**:同一段查询逻辑此前有 4 份拷贝、且兜底版本号各不相同,现收敛为 `scripts/plugin_runtime.py` 中的一份,其余脚本改为导入。这正是此前"修了一处、另外三处没跟着改"的根源。
- **产物一致性校验**:macOS 包打包后新增断言,校验包内 `README.txt` 记录的版本与 `NAPCAT_VERSION` 一致,防止日后重构悄悄绕开这条传递链。
- **回归测试**:新增 `napcatVersionLookup.test.ts`,锁定三条不变量——不能有硬编码兜底、查询逻辑只能有一份实现、发布流程只查一次并分发给所有打包任务。

顺带修复两处与此关联的文档/注释问题:
- macOS 部署文档的解压命令不再要求用户手填版本号和文件后缀,改为自动定位最近下载的压缩包。
- 修正 `launcher-user.sh` 里一处过时注释:该注释曾声称文档要求用户手动清除隔离属性,但文档从未有过这个说明;同时补充了实测结论——无论用终端还是访达解压,浏览器下载的包都会带隔离标记,这一步不是冗余保险。

## 验证

- 本地实际执行打包脚本,联网请求真实解析到 NapCat 版本并继续下载,确认整条调用链(`pack-windows-on-linux.py` → `quick-pack.py` → `plugin_runtime.py`)可用。
- 模拟了 404(不可重试)、网络中断(重试 4 次后失败)、403 限流(打印配额恢复时间)三种失败路径,均无异常崩溃,行为符合预期。
- 新增的 `napcatVersionLookup.test.ts` 三项断言全部通过。
- 三个改动过的 workflow 文件(`release-plugin.yml`、`build-plugin.yml`、`build-installer.yml`)用 `yaml.safe_load` 校验语法通过。
- `scripts/quick-pack.py` 含 CRLF 编码的批处理内容,已确认改动是逐行精确删减、未整体重写或改变换行符编码。
