### PR TITLE
fix(ui): 点击导出完成 toast 不再关闭任务向导

### DIFF
--- a/qce-v4-tool/components/ui/dialog.tsx
+++ b/qce-v4-tool/components/ui/dialog.tsx
@@ -37,42 +37,72 @@ type DialogContentProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.
   fullScreen?: boolean
 }
 
+/** Toast 叠在 Dialog 之上且可点；点 toast 时不能当成 Dialog「点外部」关闭。 */
+function isInsideQceToaster(target: EventTarget | null): boolean {
+  return target instanceof Element && Boolean(target.closest("[data-qce-toaster]"))
+}
+
 export const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   DialogContentProps
->(({ className, children, overlayClassName, fullScreen = false, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay className={overlayClassName} />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        fullScreen
-          ? [
-              "fixed inset-0 z-[101]",
-              "w-full h-full",
-              "bg-card dark:bg-card",
-            ]
-          : [
-              "fixed left-1/2 top-1/2 z-[101]",
-              "-translate-x-1/2 -translate-y-1/2",
-              "w-full max-w-lg",
-              "bg-card dark:bg-card",
-              "rounded-xl shadow-[0_8px_30px_rgba(0,0,0,0.08)]",
-              "",
-            ],
-        "data-[state=open]:animate-in data-[state=closed]:animate-out",
-        "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
-        "data-[state=open]:zoom-in-[0.97] data-[state=closed]:zoom-out-[0.97]",
-        "data-[state=open]:duration-300 data-[state=closed]:duration-200 ease-[cubic-bezier(0.32,0.72,0,1)]",
-        "outline-none",
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </DialogPrimitive.Content>
-  </DialogPortal>
-))
+>(
+  (
+    {
+      className,
+      children,
+      overlayClassName,
+      fullScreen = false,
+      onInteractOutside,
+      onPointerDownOutside,
+      ...props
+    },
+    ref
+  ) => (
+    <DialogPortal>
+      <DialogOverlay className={overlayClassName} />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          fullScreen
+            ? [
+                "fixed inset-0 z-[101]",
+                "w-full h-full",
+                "bg-card dark:bg-card",
+              ]
+            : [
+                "fixed left-1/2 top-1/2 z-[101]",
+                "-translate-x-1/2 -translate-y-1/2",
+                "w-full max-w-lg",
+                "bg-card dark:bg-card",
+                "rounded-xl shadow-[0_8px_30px_rgba(0,0,0,0.08)]",
+                "",
+              ],
+          "data-[state=open]:animate-in data-[state=closed]:animate-out",
+          "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
+          "data-[state=open]:zoom-in-[0.97] data-[state=closed]:zoom-out-[0.97]",
+          "data-[state=open]:duration-300 data-[state=closed]:duration-200 ease-[cubic-bezier(0.32,0.72,0,1)]",
+          "outline-none",
+          className
+        )}
+        onPointerDownOutside={(event) => {
+          if (isInsideQceToaster(event.target)) {
+            event.preventDefault()
+          }
+          onPointerDownOutside?.(event)
+        }}
+        onInteractOutside={(event) => {
+          if (isInsideQceToaster(event.target)) {
+            event.preventDefault()
+          }
+          onInteractOutside?.(event)
+        }}
+        {...props}
+      >
+        {children}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+)
 DialogContent.displayName = DialogPrimitive.Content.displayName
 
 export const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (

--- a/qce-v4-tool/components/ui/toast.tsx
+++ b/qce-v4-tool/components/ui/toast.tsx
@@ -866,6 +866,7 @@ export const Toaster: React.FC<ToasterProps> = ({
 
   return (
     <div
+      data-qce-toaster=""
       className={`fixed ${positionClasses[position]} w-[calc(100vw-32px)] sm:w-[360px] z-[1000] pointer-events-none`}
       style={{ height: items.length > 0 ? (isHovered ? totalHeight : 80) : 0 }}
       onMouseEnter={handleMouseEnter}

--- a/qce-v4-tool/e2e/dialog-toast-outside-click.spec.ts
+++ b/qce-v4-tool/e2e/dialog-toast-outside-click.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression: 导出完成 toast（z-index 高于 Dialog）点击任意处时，
+ * 不应被 Radix Dialog 当成「点外部」而关闭任务向导。
+ *
+ * 本地跑法与其它 UI e2e 相同：mock server + 已构建的 /qce 静态资源，
+ * 或 next dev + mock API。
+ */
+
+import { test, expect } from '@playwright/test';
+
+const TOKEN = process.env.QCE_MOCK_TOKEN ?? 'qce_mock_token_for_tests';
+const FRONTEND_BASE = process.env.E2E_FRONTEND_URL ?? 'http://localhost:40653';
+const SHELL_PATH = `/qce`;
+
+async function clearLocalStorage(page: import('@playwright/test').Page) {
+  await page.goto(`${FRONTEND_BASE}${SHELL_PATH}`).catch(() => null);
+  await page.evaluate(() => localStorage.clear()).catch(() => null);
+}
+
+test.describe('Dialog vs completion toast outside click', () => {
+  test('clicking a toast does not dismiss the task wizard', async ({ page }) => {
+    await clearLocalStorage(page);
+    await page.evaluate((value) => {
+      localStorage.setItem('qce_access_token', value);
+    }, TOKEN);
+
+    const response = await page.goto(`${FRONTEND_BASE}${SHELL_PATH}`).catch(() => null);
+    test.skip(
+      !response || response.status() >= 500,
+      `frontend not reachable at ${FRONTEND_BASE}`
+    );
+
+    const skipBtn = page.getByRole('button', { name: '跳过' }).first();
+    if (await skipBtn.isVisible({ timeout: 1500 }).catch(() => false)) {
+      await skipBtn.click().catch(() => null);
+    }
+
+    await page.getByRole('button', { name: '新建任务' }).first().click();
+    const wizard = page.getByRole('dialog', { name: '创建导出任务' });
+    await expect(wizard).toBeVisible({ timeout: 15_000 });
+
+    // Toaster 根节点应带稳定标记，供 Dialog 识别「点在 toast 上」。
+    const toaster = page.locator('[data-qce-toaster]');
+    await expect(toaster).toHaveCount(1);
+
+    // 在真实 Toaster 内注入可点的完成态卡片（与生产 toast 一样 pointer-events-auto）。
+    await page.evaluate(() => {
+      const root = document.querySelector('[data-qce-toaster]');
+      if (!root) throw new Error('missing data-qce-toaster');
+      const card = document.createElement('div');
+      card.setAttribute('data-testid', 'fake-completion-toast');
+      card.textContent = '导出完成';
+      card.style.cssText =
+        'pointer-events:auto;padding:16px;background:white;border:1px solid #ddd;border-radius:12px;';
+      root.appendChild(card);
+    });
+
+    await page.getByTestId('fake-completion-toast').click();
+    await expect(wizard).toBeVisible();
+
+    await page.getByRole('button', { name: '取消' }).click();
+    await expect(wizard).toBeHidden();
+  });
+});


### PR DESCRIPTION
## 问题

导出完成 toast 叠在 Dialog 之上。打开「创建导出任务」后点击 toast 任意位置，
会被 Radix 当成「点外部」而关闭任务向导。见 #627。

## 修改

- Toaster 根节点增加 `data-qce-toaster`
- `DialogContent` 对 toast 内的 outside 交互 `preventDefault()`，避免误关 Dialog

## 验证

- `pnpm build` 通过
- Playwright：`e2e/dialog-toast-outside-click.spec.ts` 通过
- 手动：完成导出保留 toast → 打开导出向导 → 点击 toast → 向导仍打开；点取消仍可关闭

Fixes #627