### PR TITLE
fix(export): 修复设备聊天记录导出为空

### DIFF
--- a/qq-chat-export-server/src/napcat/client.rs
+++ b/qq-chat-export-server/src/napcat/client.rs
@@ -310,9 +310,32 @@ impl NapCatBridgeClient {
             .call("MsgService.getMsgsIncludeSelf", params.clone())
             .await
         {
-            Ok(result) => Ok(result),
-            Err(_) => self.call("MsgApi.getMsgHistory", params).await,
+            Ok(result) => Ok(normalize_message_response(result)),
+            Err(service_error) => {
+                tracing::debug!(
+                    "MsgService.getMsgsIncludeSelf 调用失败，尝试 MsgApi 包装层: {}",
+                    service_error
+                );
+                self.call("MsgApi.getMsgHistory", params)
+                    .await
+                    .map(normalize_message_response)
+            }
         }
+    }
+
+    /// 从 NTQQ 本地消息数据库读取会话最新消息。
+    /// 该内核接口与首屏/历史查询相互独立，用于数据线会话空结果回退。
+    async fn get_latest_db_messages(
+        &self,
+        peer: &Peer,
+        count: i64,
+    ) -> Result<Value, BridgeError> {
+        self.call(
+            "MsgService.getLatestDbMsgs",
+            json!([peer_to_value(peer), count]),
+        )
+        .await
+        .map(normalize_message_response)
     }
 
     async fn latest_device_message_id(&self, peer: &Peer) -> Option<String> {
@@ -365,6 +388,47 @@ fn message_list(value: &Value) -> Option<&Vec<Value>> {
                 .and_then(|data| data.get("msgList"))
                 .and_then(Value::as_array)
         })
+        .or_else(|| {
+            value
+                .get("data")
+                .and_then(|data| data.get("result"))
+                .and_then(|result| result.get("msgList"))
+                .and_then(Value::as_array)
+        })
+}
+
+/// 统一为批量获取器能够稳定消费的顶层 `msgList` 响应。
+fn normalize_message_response(value: Value) -> Value {
+    message_list(&value)
+        .cloned()
+        .map_or(value, |messages| json!({ "msgList": messages }))
+}
+
+fn message_response_shape(value: &Value) -> &'static str {
+    if value.get("msgList").is_some() {
+        "msgList"
+    } else if value
+        .get("result")
+        .and_then(|result| result.get("msgList"))
+        .is_some()
+    {
+        "result.msgList"
+    } else if value
+        .get("data")
+        .and_then(|data| data.get("msgList"))
+        .is_some()
+    {
+        "data.msgList"
+    } else if value
+        .get("data")
+        .and_then(|data| data.get("result"))
+        .and_then(|result| result.get("msgList"))
+        .is_some()
+    {
+        "data.result.msgList"
+    } else {
+        "missing"
+    }
 }
 
 fn response_has_messages(value: &Value) -> bool {
@@ -390,6 +454,19 @@ fn recent_contact_list(value: &Value) -> Option<&Vec<Value>> {
         value
             .get("result")
             .and_then(|result| result.get("changedList"))
+            .and_then(Value::as_array)
+    })
+    .or_else(|| {
+        value
+            .get("data")
+            .and_then(|data| data.get("info"))
+            .and_then(|info| info.get("changedList"))
+            .and_then(Value::as_array)
+    })
+    .or_else(|| {
+        value
+            .get("data")
+            .and_then(|data| data.get("changedList"))
             .and_then(Value::as_array)
     })
 }
@@ -483,29 +560,99 @@ impl MessageFetchApi for NapCatBridgeClient {
             .await
         {
             Ok(result) => result,
-            Err(_) => self
-                .call("MsgApi.getAioFirstViewLatestMsgs", params)
-                .await
-                .map_err(|error| error.to_string())?,
+            Err(service_error) => {
+                tracing::debug!(
+                    "MsgService.getAioFirstViewLatestMsgs 调用失败，尝试 MsgApi 包装层: {}",
+                    service_error
+                );
+                self.call("MsgApi.getAioFirstViewLatestMsgs", params)
+                    .await
+                    .map_err(|error| error.to_string())?
+            }
         };
 
-        if !is_device_chat_type(peer.chat_type) || response_has_messages(&result) {
+        if !is_device_chat_type(peer.chat_type) {
             return Ok(result);
         }
 
+        if response_has_messages(&result) {
+            return Ok(normalize_message_response(result));
+        }
+
+        tracing::warn!(
+            "设备会话首屏消息为空，开始多级回退: peerUid={}, chatType={}, responseShape={}",
+            peer.peer_uid,
+            peer.chat_type,
+            message_response_shape(&result)
+        );
+
+        match self.get_latest_db_messages(peer, count).await {
+            Ok(db_messages) if response_has_messages(&db_messages) => {
+                tracing::info!(
+                    "设备会话已通过 getLatestDbMsgs 读取本地消息: peerUid={}, chatType={}, count={}",
+                    peer.peer_uid,
+                    peer.chat_type,
+                    message_list(&db_messages).map_or(0, Vec::len)
+                );
+                return Ok(db_messages);
+            }
+            Ok(db_messages) => tracing::warn!(
+                "设备会话 getLatestDbMsgs 仍为空: peerUid={}, chatType={}, responseShape={}",
+                peer.peer_uid,
+                peer.chat_type,
+                message_response_shape(&db_messages)
+            ),
+            Err(error) => tracing::warn!(
+                "设备会话 getLatestDbMsgs 调用失败: peerUid={}, chatType={}, error={}",
+                peer.peer_uid,
+                peer.chat_type,
+                error
+            ),
+        }
+
         let Some(msg_id) = self.latest_device_message_id(peer).await else {
-            return Ok(result);
+            tracing::warn!(
+                "设备会话无法从最近联系人定位消息锚点: peerUid={}, chatType={}",
+                peer.peer_uid,
+                peer.chat_type
+            );
+            return Ok(normalize_message_response(result));
         };
         tracing::info!(
-            "设备会话首屏消息为空，使用最近会话锚点回退查询: peerUid={}, chatType={}, msgId={}",
+            "设备会话使用最近会话锚点回退查询: peerUid={}, chatType={}, msgId={}",
             peer.peer_uid,
             peer.chat_type,
             msg_id
         );
 
         match self.get_message_history(peer, &msg_id, count).await {
-            Ok(history) if response_has_messages(&history) => Ok(history),
-            Ok(_) | Err(_) => Ok(result),
+            Ok(history) if response_has_messages(&history) => {
+                tracing::info!(
+                    "设备会话已通过最近会话锚点读取消息: peerUid={}, chatType={}, count={}",
+                    peer.peer_uid,
+                    peer.chat_type,
+                    message_list(&history).map_or(0, Vec::len)
+                );
+                Ok(history)
+            }
+            Ok(history) => {
+                tracing::warn!(
+                    "设备会话锚点历史查询仍为空: peerUid={}, chatType={}, responseShape={}",
+                    peer.peer_uid,
+                    peer.chat_type,
+                    message_response_shape(&history)
+                );
+                Ok(normalize_message_response(result))
+            }
+            Err(error) => {
+                tracing::warn!(
+                    "设备会话锚点历史查询失败: peerUid={}, chatType={}, error={}",
+                    peer.peer_uid,
+                    peer.chat_type,
+                    error
+                );
+                Ok(normalize_message_response(result))
+            }
         }
     }
 
@@ -590,7 +737,7 @@ fn download_media_params(
 mod tests {
     use super::{
         download_media_params, extract_forward_messages, is_device_chat_type,
-        latest_message_id_for_peer, response_has_messages,
+        latest_message_id_for_peer, normalize_message_response, response_has_messages,
     };
     use crate::fetcher::Peer;
     use serde_json::json;
@@ -622,8 +769,26 @@ mod tests {
         assert!(response_has_messages(
             &json!({"data": {"msgList": [{"msgId": "1"}]}})
         ));
+        assert!(response_has_messages(
+            &json!({"data": {"result": {"msgList": [{"msgId": "1"}]}}})
+        ));
         assert!(!response_has_messages(&json!({"msgList": []})));
         assert!(!response_has_messages(&json!({})));
+    }
+
+    #[test]
+    fn normalizes_wrapped_message_lists_for_batch_fetcher() {
+        let message = json!({"msgId": "1"});
+        assert_eq!(
+            normalize_message_response(json!({"data": {"msgList": [message.clone()]}})),
+            json!({"msgList": [message.clone()]})
+        );
+        assert_eq!(
+            normalize_message_response(json!({
+                "data": {"result": {"msgList": [message.clone()]}}
+            })),
+            json!({"msgList": [message]})
+        );
     }
 
     #[test]
@@ -656,10 +821,16 @@ mod tests {
         assert_eq!(
             latest_message_id_for_peer(
                 &json!({
-                    "result": {
-                        "changedList": [
-                            {"chatType": "134", "peerUid": "u_mobile_device", "msgId": 12345}
-                        ]
+                    "data": {
+                        "info": {
+                            "changedList": [
+                                {
+                                    "chatType": "134",
+                                    "peerUid": "u_mobile_device",
+                                    "msgId": 12345
+                                }
+                            ]
+                        }
                     }
                 }),
                 &mobile_peer,

--- a/qq-chat-export-server/src/napcat/client.rs
+++ b/qq-chat-export-server/src/napcat/client.rs
@@ -298,6 +298,39 @@ impl NapCatBridgeClient {
         self.call("PacketApi.getGroupFileUrl", json!([group_code, file_id]))
             .await
     }
+
+    async fn get_message_history(
+        &self,
+        peer: &Peer,
+        msg_id: &str,
+        count: i64,
+    ) -> Result<Value, BridgeError> {
+        let params = json!([peer_to_value(peer), msg_id, count, true]);
+        match self
+            .call("MsgService.getMsgsIncludeSelf", params.clone())
+            .await
+        {
+            Ok(result) => Ok(result),
+            Err(_) => self.call("MsgApi.getMsgHistory", params).await,
+        }
+    }
+
+    async fn latest_device_message_id(&self, peer: &Peer) -> Option<String> {
+        if let Ok(contacts) = self.get_recent_contact_list_sync().await {
+            if let Some(msg_id) = latest_message_id_for_peer(&contacts, peer) {
+                return Some(msg_id);
+            }
+        }
+        if let Ok(contacts) = self.get_recent_contact_list().await {
+            if let Some(msg_id) = latest_message_id_for_peer(&contacts, peer) {
+                return Some(msg_id);
+            }
+        }
+        if let Ok(contacts) = self.get_recent_contact_list_snapshot(2_000).await {
+            return latest_message_id_for_peer(&contacts, peer);
+        }
+        None
+    }
 }
 
 fn extract_forward_messages(value: &Value) -> Option<Vec<Value>> {
@@ -310,6 +343,82 @@ fn extract_forward_messages(value: &Value) -> Option<Vec<Value>> {
     .flatten()
     .find_map(Value::as_array)
     .cloned()
+}
+
+fn is_device_chat_type(chat_type: i64) -> bool {
+    matches!(chat_type, 8 | 134)
+}
+
+fn message_list(value: &Value) -> Option<&Vec<Value>> {
+    value
+        .get("msgList")
+        .and_then(Value::as_array)
+        .or_else(|| {
+            value
+                .get("result")
+                .and_then(|result| result.get("msgList"))
+                .and_then(Value::as_array)
+        })
+        .or_else(|| {
+            value
+                .get("data")
+                .and_then(|data| data.get("msgList"))
+                .and_then(Value::as_array)
+        })
+}
+
+fn response_has_messages(value: &Value) -> bool {
+    message_list(value).is_some_and(|messages| !messages.is_empty())
+}
+
+fn recent_contact_list(value: &Value) -> Option<&Vec<Value>> {
+    value.as_array().or_else(|| {
+        value
+            .get("info")
+            .and_then(|info| info.get("changedList"))
+            .and_then(Value::as_array)
+    })
+    .or_else(|| value.get("changedList").and_then(Value::as_array))
+    .or_else(|| {
+        value
+            .get("result")
+            .and_then(|result| result.get("info"))
+            .and_then(|info| info.get("changedList"))
+            .and_then(Value::as_array)
+    })
+    .or_else(|| {
+        value
+            .get("result")
+            .and_then(|result| result.get("changedList"))
+            .and_then(Value::as_array)
+    })
+}
+
+fn value_as_string(value: Option<&Value>) -> Option<String> {
+    match value? {
+        Value::String(value) if !value.is_empty() => Some(value.clone()),
+        Value::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn value_as_i64(value: Option<&Value>) -> Option<i64> {
+    match value? {
+        Value::Number(value) => value.as_i64(),
+        Value::String(value) => value.parse().ok(),
+        _ => None,
+    }
+}
+
+fn latest_message_id_for_peer(value: &Value, peer: &Peer) -> Option<String> {
+    recent_contact_list(value)?
+        .iter()
+        .find(|contact| {
+            value_as_i64(contact.get("chatType")) == Some(peer.chat_type)
+                && value_as_string(contact.get("peerUid")).as_deref()
+                    == Some(peer.peer_uid.as_str())
+        })
+        .and_then(|contact| value_as_string(contact.get("msgId")))
 }
 
 #[async_trait::async_trait]
@@ -369,15 +478,34 @@ impl MessageFetchApi for NapCatBridgeClient {
         count: i64,
     ) -> Result<Value, String> {
         let params = json!([peer_to_value(peer), count]);
-        match self
+        let result = match self
             .call("MsgService.getAioFirstViewLatestMsgs", params.clone())
             .await
         {
-            Ok(result) => Ok(result),
+            Ok(result) => result,
             Err(_) => self
                 .call("MsgApi.getAioFirstViewLatestMsgs", params)
                 .await
-                .map_err(|error| error.to_string()),
+                .map_err(|error| error.to_string())?,
+        };
+
+        if !is_device_chat_type(peer.chat_type) || response_has_messages(&result) {
+            return Ok(result);
+        }
+
+        let Some(msg_id) = self.latest_device_message_id(peer).await else {
+            return Ok(result);
+        };
+        tracing::info!(
+            "设备会话首屏消息为空，使用最近会话锚点回退查询: peerUid={}, chatType={}, msgId={}",
+            peer.peer_uid,
+            peer.chat_type,
+            msg_id
+        );
+
+        match self.get_message_history(peer, &msg_id, count).await {
+            Ok(history) if response_has_messages(&history) => Ok(history),
+            Ok(_) | Err(_) => Ok(result),
         }
     }
 
@@ -387,17 +515,9 @@ impl MessageFetchApi for NapCatBridgeClient {
         msg_id: &str,
         count: i64,
     ) -> Result<Value, String> {
-        let params = json!([peer_to_value(peer), msg_id, count, true]);
-        match self
-            .call("MsgService.getMsgsIncludeSelf", params.clone())
+        self.get_message_history(peer, msg_id, count)
             .await
-        {
-            Ok(result) => Ok(result),
-            Err(_) => self
-                .call("MsgApi.getMsgHistory", params)
-                .await
-                .map_err(|error| error.to_string()),
-        }
+            .map_err(|error| error.to_string())
     }
 
     async fn get_msgs_by_seq_range(
@@ -468,7 +588,11 @@ fn download_media_params(
 
 #[cfg(test)]
 mod tests {
-    use super::{download_media_params, extract_forward_messages};
+    use super::{
+        download_media_params, extract_forward_messages, is_device_chat_type,
+        latest_message_id_for_peer, response_has_messages,
+    };
+    use crate::fetcher::Peer;
     use serde_json::json;
 
     #[test]
@@ -487,6 +611,69 @@ mod tests {
             Some(1)
         );
         assert_eq!(extract_forward_messages(&json!({"data": {}})), None);
+    }
+
+    #[test]
+    fn recognizes_message_lists_from_supported_response_shapes() {
+        assert!(response_has_messages(&json!({"msgList": [{"msgId": "1"}]})));
+        assert!(response_has_messages(
+            &json!({"result": {"msgList": [{"msgId": "1"}]}})
+        ));
+        assert!(response_has_messages(
+            &json!({"data": {"msgList": [{"msgId": "1"}]}})
+        ));
+        assert!(!response_has_messages(&json!({"msgList": []})));
+        assert!(!response_has_messages(&json!({})));
+    }
+
+    #[test]
+    fn finds_device_anchor_in_recent_contact_response_shapes() {
+        let peer = Peer {
+            chat_type: 8,
+            peer_uid: "u_device".to_string(),
+            guild_id: None,
+        };
+        assert_eq!(
+            latest_message_id_for_peer(
+                &json!({
+                    "info": {
+                        "changedList": [
+                            {"chatType": 1, "peerUid": "u_friend", "msgId": "friend-msg"},
+                            {"chatType": 8, "peerUid": "u_device", "msgId": "device-msg"}
+                        ]
+                    }
+                }),
+                &peer,
+            ),
+            Some("device-msg".to_string())
+        );
+
+        let mobile_peer = Peer {
+            chat_type: 134,
+            peer_uid: "u_mobile_device".to_string(),
+            guild_id: None,
+        };
+        assert_eq!(
+            latest_message_id_for_peer(
+                &json!({
+                    "result": {
+                        "changedList": [
+                            {"chatType": "134", "peerUid": "u_mobile_device", "msgId": 12345}
+                        ]
+                    }
+                }),
+                &mobile_peer,
+            ),
+            Some("12345".to_string())
+        );
+    }
+
+    #[test]
+    fn device_chat_types_are_limited_to_data_line_sessions() {
+        assert!(is_device_chat_type(8));
+        assert!(is_device_chat_type(134));
+        assert!(!is_device_chat_type(1));
+        assert!(!is_device_chat_type(2));
     }
 
     #[test]


### PR DESCRIPTION
## 概述

- 检测数据线设备会话（`chatType` 为 8/134）首次拉取结果为空的情况
- 首先使用独立的 NTQQ 本地数据库接口 `MsgService.getLatestDbMsgs` 读取最新消息
- 本地数据库接口不可用或仍为空时，再从最近联系人中解析 `msgId` 并回退历史查询
- 将 `msgList`、`result.msgList`、`data.msgList` 与 `data.result.msgList` 统一为批量获取器可消费的顶层 `msgList`
- 增加每一级回退的诊断日志，真实环境仍失败时可直接判断是数据库读取、会话锚点还是历史查询失败
- 增加设备会话类型、最近联系人响应结构及消息响应归一化的回归测试

修复 #626

## 审计结论

上一版修复没有成功的主要原因：

1. `MsgApi.getMsgHistory` 在 NapCat 内部仍委托给 `getMsgsIncludeSelf`，并不是独立的读取路径。
2. 上一版仅在 `getMsgsIncludeSelf` 抛错时调用包装层；真实用户遇到的是调用成功但 `msgList` 为空，因此不会触发有效切换。
3. 上一版判定逻辑接受 `data.msgList`，但批量获取器只消费顶层 `msgList` / `result.msgList`，存在“回退取到数据后又被下游解析为 0 条”的结构不一致。
4. 原测试主要覆盖手写 JSON helper，没有覆盖“RPC 成功但返回空数组”和回退路径并非独立这两个关键条件。

## 新的读取顺序

1. `getAioFirstViewLatestMsgs`
2. 设备会话为空时：`MsgService.getLatestDbMsgs`
3. 仍为空时：最近联系人 `msgId` + 历史查询
4. 全过程归一化响应结构并输出分级诊断日志

## 验证

- Rust exporter tests：18 项通过
- Rust server tests：111 项通过（含新增回归测试）
- Node 插件测试矩阵：Windows / macOS / Linux，Node 20 / 22 均通过
- API smoke：21 项通过；2 项既有 UI 用例首次超时、重试通过，工作流最终成功
- 完整构建：Windows x64、Linux x64、macOS arm64、NapCat 商店包与 Framework 包均成功产出
- `构建 QCE 插件` 与 `测试 QCE 插件` 两个工作流最终均为 success

> 该问题依赖真实 QQNT 数据线会话环境，CI 通过后仍需要 Issue #626 报告者使用最新构建进行最终确认。