### PR TITLE
fix(export): survive huge group history fetches and stop the 50% stall

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/helpers/MockNapCatCore.ts
+++ b/plugins/qq-chat-exporter/__tests__/helpers/MockNapCatCore.ts
@@ -63,6 +63,7 @@ interface Logger {
 interface MsgApi {
     getMsgHistory(peer: MockPeer, msgId: string, count: number, reverse: boolean): Promise<{ msgList: RawMessage[] }>;
     getAioFirstViewLatestMsgs(peer: MockPeer, count: number): Promise<{ msgList: RawMessage[] }>;
+    getMsgsBySeqAndCount(peer: MockPeer, anchorSeq: string, count: number): Promise<{ msgList: RawMessage[] }>;
     getMultiMsg(params: { peer?: MockPeer; rootMsgId?: string; parentMsgId?: string; forwardId?: string; resId?: string }): Promise<{ msgList: RawMessage[] } | undefined>;
 }
 
@@ -105,6 +106,7 @@ interface SessionFacade {
     getMsgService(): {
         getAioFirstViewLatestMsgs(peer: MockPeer, count: number): Promise<{ msgList: RawMessage[] }>;
         getMsgsBySeqRange(peer: MockPeer, endSeq: string, startSeq: string): Promise<{ msgList: RawMessage[] }>;
+        getMsgsBySeqAndCount(peer: MockPeer, anchorSeq: string, count: number): Promise<{ msgList: RawMessage[] }>;
     };
     getRichMediaService(): Record<string, never>;
 }
@@ -175,6 +177,17 @@ export function createMockCore(config: MockConfig = {}): MockNapCatCore {
             if (!conv) return { msgList: [] };
             const sorted = [...conv.messages].sort(sortByTimeDesc);
             return { msgList: sorted.slice(0, count) };
+        },
+
+        async getMsgsBySeqAndCount(peer, anchorSeq, count) {
+            track('MsgApi.getMsgsBySeqAndCount', [peer, anchorSeq, count]);
+            const conv = findConversation(peer);
+            if (!conv) return { msgList: [] };
+            const anchor = parseInt(String(anchorSeq), 10);
+            if (!Number.isFinite(anchor) || anchor <= 0) return { msgList: [] };
+            const sorted = [...conv.messages].sort(sortByTimeDesc);
+            const list = sorted.filter((m) => parseInt(m.msgSeq ?? '0', 10) <= anchor);
+            return { msgList: list.slice(0, count) };
         },
 
         async getMultiMsg(params) {
@@ -307,7 +320,9 @@ export function createMockCore(config: MockConfig = {}): MockNapCatCore {
                             return s >= lo && s <= hi;
                         }).sort(sortByTimeDesc)
                     };
-                }
+                },
+                getMsgsBySeqAndCount: (peer, anchorSeq, count) =>
+                    MsgApi.getMsgsBySeqAndCount(peer, anchorSeq, count)
             };
         },
         getRichMediaService() {

--- a/qq-chat-export-server/src/api/routes/messages.rs
+++ b/qq-chat-export-server/src/api/routes/messages.rs
@@ -1304,16 +1304,23 @@ async fn fetch_group_member_title_map(
     }
 }
 
-/// 补全群消息的群昵称（sendMemberName）。
-async fn fill_group_member_names(state: &SharedState, peer_uid: &str, messages: &mut [Value]) {
-    let Ok(group_members) = state.napcat.get_group_member_all(peer_uid, false).await else {
-        return;
-    };
-    let Some(infos) = group_members
+/// 拉取群成员 infos（用于群昵称补全，只拉一次，逐块复用）。
+async fn fetch_group_member_infos(state: &SharedState, peer_uid: &str) -> Option<Value> {
+    let group_members = state
+        .napcat
+        .get_group_member_all(peer_uid, false)
+        .await
+        .ok()?;
+    group_members
         .pointer("/result/infos")
         .or_else(|| group_members.get("infos"))
-        .and_then(Value::as_object)
-    else {
+        .filter(|infos| infos.is_object())
+        .cloned()
+}
+
+/// 补全群消息的群昵称（sendMemberName）。
+fn apply_group_member_names(member_infos: &Value, messages: &mut [Value]) {
+    let Some(infos) = member_infos.as_object() else {
         return;
     };
     for message in messages.iter_mut() {
@@ -1389,6 +1396,7 @@ fn to_value_resource_map(
 }
 
 /// ZIP 打包（阻塞线程执行）：HTML 文件 + resources 相对路径列表。
+/// issue #634：逐文件流式复制，不把单个文件整体读入内存。
 async fn create_zip_with_resources(
     base_dir: PathBuf,
     main_file: PathBuf,
@@ -1396,7 +1404,6 @@ async fn create_zip_with_resources(
     zip_path: PathBuf,
 ) -> Result<(), String> {
     tokio::task::spawn_blocking(move || -> Result<(), String> {
-        use std::io::Write as _;
         let file = std::fs::File::create(&zip_path).map_err(|e| e.to_string())?;
         let mut zip = zip::ZipWriter::new(file);
         let options = zip::write::SimpleFileOptions::default()
@@ -1407,18 +1414,18 @@ async fn create_zip_with_resources(
             .ok_or_else(|| "无效的主文件名".to_string())?;
         zip.start_file(&main_name, options)
             .map_err(|e| e.to_string())?;
-        let data = std::fs::read(&main_file).map_err(|e| e.to_string())?;
-        zip.write_all(&data).map_err(|e| e.to_string())?;
+        let mut main = std::fs::File::open(&main_file).map_err(|e| e.to_string())?;
+        std::io::copy(&mut main, &mut zip).map_err(|e| e.to_string())?;
         for rel in resource_rel_paths {
             let src = base_dir.join(&rel);
-            let Ok(data) = std::fs::read(&src) else {
+            let Ok(mut src) = std::fs::File::open(&src) else {
                 continue;
             };
             let entry_name = rel.replace('\\', "/");
             if zip.start_file(&entry_name, options).is_err() {
                 continue;
             }
-            let _ = zip.write_all(&data);
+            let _ = std::io::copy(&mut src, &mut zip);
         }
         zip.finish().map_err(|e| e.to_string())?;
         Ok(())
@@ -1428,9 +1435,9 @@ async fn create_zip_with_resources(
 }
 
 /// ZIP 打包整个目录（阻塞线程执行）。
+/// issue #634：逐文件流式复制，不把单个文件整体读入内存。
 async fn create_zip_from_dir(dir: PathBuf, zip_path: PathBuf) -> Result<(), String> {
     tokio::task::spawn_blocking(move || -> Result<(), String> {
-        use std::io::Write as _;
         let file = std::fs::File::create(&zip_path).map_err(|e| e.to_string())?;
         let mut zip = zip::ZipWriter::new(file);
         let options = zip::write::SimpleFileOptions::default()
@@ -1445,14 +1452,151 @@ async fn create_zip_from_dir(dir: PathBuf, zip_path: PathBuf) -> Result<(), Stri
             let rel = entry.path().strip_prefix(&dir).map_err(|e| e.to_string())?;
             zip.start_file(rel.to_string_lossy().replace('\\', "/"), options)
                 .map_err(|e| e.to_string())?;
-            let data = std::fs::read(entry.path()).map_err(|e| e.to_string())?;
-            zip.write_all(&data).map_err(|e| e.to_string())?;
+            let mut src = std::fs::File::open(entry.path()).map_err(|e| e.to_string())?;
+            std::io::copy(&mut src, &mut zip).map_err(|e| e.to_string())?;
         }
         zip.finish().map_err(|e| e.to_string())?;
         Ok(())
     })
     .await
     .map_err(|e| e.to_string())?
+}
+
+/// issue #634：分块流水线的块大小（原始消息条数）。
+const RAW_SPOOL_CHUNK_SIZE: usize = 20_000;
+
+/// issue #634：抓取阶段的磁盘 spool。原始消息逐批落盘为 JSONL，避免在内存
+/// 中累积超大群聊的全部原始消息；任何退出路径（Drop）都会清理文件。
+struct RawMessageSpool {
+    path: PathBuf,
+    writer: Option<tokio::io::BufWriter<tokio::fs::File>>,
+    count: usize,
+}
+
+impl RawMessageSpool {
+    async fn create(path: PathBuf) -> Result<Self, String> {
+        let file = tokio::fs::File::create(&path)
+            .await
+            .map_err(|e| format!("创建消息暂存文件失败: {e}"))?;
+        Ok(Self {
+            path,
+            writer: Some(tokio::io::BufWriter::new(file)),
+            count: 0,
+        })
+    }
+
+    async fn append(&mut self, messages: &[Value]) -> Result<(), String> {
+        use tokio::io::AsyncWriteExt as _;
+        let writer = self
+            .writer
+            .as_mut()
+            .ok_or_else(|| "消息暂存文件已关闭".to_string())?;
+        for message in messages {
+            let line = serde_json::to_vec(message).map_err(|e| e.to_string())?;
+            writer
+                .write_all(&line)
+                .await
+                .map_err(|e| format!("写入消息暂存文件失败: {e}"))?;
+            writer
+                .write_all(b"\n")
+                .await
+                .map_err(|e| format!("写入消息暂存文件失败: {e}"))?;
+            self.count += 1;
+        }
+        Ok(())
+    }
+
+    async fn finish(&mut self) -> Result<(), String> {
+        use tokio::io::AsyncWriteExt as _;
+        if let Some(mut writer) = self.writer.take() {
+            writer
+                .flush()
+                .await
+                .map_err(|e| format!("写入消息暂存文件失败: {e}"))?;
+        }
+        Ok(())
+    }
+
+    fn path(&self) -> &FsPath {
+        &self.path
+    }
+
+    fn count(&self) -> usize {
+        self.count
+    }
+}
+
+impl Drop for RawMessageSpool {
+    fn drop(&mut self) {
+        self.writer.take();
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// 按块读取 spool JSONL。
+struct SpoolChunkReader {
+    lines: tokio::io::Lines<tokio::io::BufReader<tokio::fs::File>>,
+    chunk_size: usize,
+}
+
+impl SpoolChunkReader {
+    async fn open(path: &FsPath, chunk_size: usize) -> Result<Self, String> {
+        use tokio::io::AsyncBufReadExt as _;
+        let file = tokio::fs::File::open(path)
+            .await
+            .map_err(|e| format!("打开消息暂存文件失败: {e}"))?;
+        Ok(Self {
+            lines: tokio::io::BufReader::new(file).lines(),
+            chunk_size: chunk_size.max(1),
+        })
+    }
+
+    async fn next_chunk(&mut self) -> Result<Option<Vec<Value>>, String> {
+        let mut chunk = Vec::new();
+        while chunk.len() < self.chunk_size {
+            match self
+                .lines
+                .next_line()
+                .await
+                .map_err(|e| format!("读取消息暂存文件失败: {e}"))?
+            {
+                Some(line) if !line.trim().is_empty() => {
+                    chunk.push(serde_json::from_str(&line).map_err(|e| e.to_string())?);
+                }
+                Some(_) => {}
+                None => break,
+            }
+        }
+        Ok(if chunk.is_empty() { None } else { Some(chunk) })
+    }
+}
+
+/// issue #634：基于序列号的真实抓取进度（1–49），取代硬编码的 50% 假进度。
+fn estimate_fetch_progress(max_seq: Option<i64>, min_seq: Option<i64>, batch_count: i64) -> i64 {
+    if let (Some(max), Some(min)) = (max_seq, min_seq) {
+        if max > 0 && max >= min {
+            let done = (max - min) as f64 / max as f64;
+            return (1.0 + done * 48.0).round() as i64;
+        }
+    }
+    // 无序列号信息时按批次数渐近逼近 49。
+    let asymptotic = (1.0 - 1.0 / (1.0 + batch_count.max(0) as f64 / 20.0)) * 49.0;
+    (asymptotic.round() as i64).clamp(1, 49)
+}
+
+/// 累加逐块资源下载摘要。
+fn merge_resource_summary(total: &mut ResourceBatchSummary, batch: &ResourceBatchSummary) {
+    total.attempted += batch.attempted;
+    total.already_available += batch.already_available;
+    total.downloaded += batch.downloaded;
+    total.failed += batch.failed;
+    total.skipped += batch.skipped;
+    for sample in &batch.failed_samples {
+        if total.failed_samples.len() >= 5 {
+            break;
+        }
+        total.failed_samples.push(sample.clone());
+    }
 }
 
 /// 导出主流程。
@@ -1516,9 +1660,19 @@ async fn process_export_task(
         ..MessageFilter::default()
     };
 
-    let mut all_messages: Vec<Value> = Vec::new();
+    // issue #634：磁盘分块流水线——原始消息逐批落盘，不在内存累积。
+    tokio::fs::create_dir_all(&req.output_dir)
+        .await
+        .map_err(|e| format!("创建输出目录失败: {e}"))?;
+    let mut spool =
+        RawMessageSpool::create(req.output_dir.join(format!(".qce_spool_{task_id}.jsonl"))).await?;
+
     let mut previous = None;
     let mut batch_count: i64 = 0;
+    let mut max_seq_seen: Option<i64> = None;
+    let mut min_seq_seen: Option<i64> = None;
+    // 群聊序列修复所需的轻量索引（仅 msgId / msgSeq）。
+    let mut seq_stubs: Vec<Value> = Vec::new();
     loop {
         if is_cancelled(state, task_id, cancel_flag).await {
             fetcher.cancel();
@@ -1538,17 +1692,31 @@ async fn process_export_task(
             Err(error) => return Err(format!("获取消息失败: {error}")),
         };
         batch_count += 1;
-        all_messages.append(&mut batch.messages);
+        for message in &batch.messages {
+            let Some(seq) = loose_i64(message.get("msgSeq")) else {
+                continue;
+            };
+            max_seq_seen = Some(max_seq_seen.map_or(seq, |v| v.max(seq)));
+            min_seq_seen = Some(min_seq_seen.map_or(seq, |v| v.min(seq)));
+            if req.chat_type == GROUP_CHAT_TYPE {
+                if let Some(id) = message.get("msgId").and_then(Value::as_str) {
+                    seq_stubs.push(json!({ "msgId": id, "msgSeq": seq }));
+                }
+            }
+        }
+        spool.append(&batch.messages).await?;
+        batch.messages = Vec::new();
 
-        let progress = (batch_count * 10).min(50);
-        let message = format!("已获取 {} 条消息...", all_messages.len());
+        // issue #634：基于序列号的真实抓取进度（1 → 49）。
+        let progress = estimate_fetch_progress(max_seq_seen, min_seq_seen, batch_count);
+        let message = format!("已获取 {} 条消息...", spool.count());
         update_task(
             state,
             task_id,
-            json!({ "progress": progress, "messageCount": all_messages.len(), "message": message }),
+            json!({ "progress": progress, "messageCount": spool.count(), "message": message }),
         )
         .await;
-        broadcast_progress(state, task_id, progress, &message, all_messages.len());
+        broadcast_progress(state, task_id, progress, &message, spool.count());
         previous = Some(batch);
     }
 
@@ -1556,11 +1724,12 @@ async fn process_export_task(
         return Err("任务已被用户停止".to_string());
     }
 
-    if req.chat_type == GROUP_CHAT_TYPE && !all_messages.is_empty() {
+    if req.chat_type == GROUP_CHAT_TYPE && !seq_stubs.is_empty() {
+        let stubs_before_repair = seq_stubs.len();
         match repair_group_message_sequence(
             &state.napcat,
             &peer,
-            &mut all_messages,
+            &mut seq_stubs,
             SequenceRepairConfig::default(),
         )
         .await
@@ -1585,38 +1754,30 @@ async fn process_export_task(
                     .await;
             }
         }
+        // 修复补齐的完整消息追加进 spool。
+        if seq_stubs.len() > stubs_before_repair {
+            spool.append(&seq_stubs[stubs_before_repair..]).await?;
+        }
     }
+    drop(seq_stubs);
 
     // 群昵称补全 + 群头衔映射（issue #331）
     let mut title_map: Option<HashMap<String, String>> = None;
-    if req.chat_type == GROUP_CHAT_TYPE && !all_messages.is_empty() {
-        fill_group_member_names(state, &req.peer_uid, &mut all_messages).await;
+    let mut member_infos: Option<Value> = None;
+    if req.chat_type == GROUP_CHAT_TYPE && spool.count() > 0 {
+        member_infos = fetch_group_member_infos(state, &req.peer_uid).await;
         title_map = fetch_group_member_title_map(state, &req.peer_uid, req.chat_type).await;
     }
 
-    // 按 includeUserUins / excludeUserUins 过滤（issue #369）。
-    let mut filtered_messages = apply_sender_filter(all_messages, &req.filter);
+    spool.finish().await?;
 
     update_task(
         state,
         task_id,
-        json!({ "progress": 60, "message": "正在解析消息...", "messageCount": filtered_messages.len() }),
+        json!({ "progress": 55, "message": "正在解析消息...", "messageCount": spool.count() }),
     )
     .await;
-    broadcast_progress(
-        state,
-        task_id,
-        60,
-        "正在解析消息...",
-        filtered_messages.len(),
-    );
-
-    filtered_messages.sort_by_key(msg_time_ms);
-    if let Some(debug) = &debug_session {
-        debug
-            .write_jsonl("01-raw-messages.jsonl", &filtered_messages)
-            .await?;
-    }
+    broadcast_progress(state, task_id, 55, "正在解析消息...", spool.count());
 
     let sender_title_resolver = title_map.map(|map| {
         let map = Arc::new(map);
@@ -1635,61 +1796,15 @@ async fn process_export_task(
         sender_title_resolver,
         forward_fetcher: Some(Arc::new(state.napcat.clone()) as Arc<dyn ForwardFetcher>),
     });
-    let mut clean_messages: Vec<CleanMessage> = parser.parse_messages(&filtered_messages).await;
-    if let Some(debug) = &debug_session {
-        debug
-            .write_jsonl("02-parsed-messages.jsonl", &clean_messages)
-            .await?;
-    }
-    let mut resource_messages = filtered_messages.clone();
-    resource_messages.extend(parser.take_forward_raw_messages());
-    let mut resource_message_ids = HashSet::new();
-    resource_messages.retain(|message| {
-        let Some(message_id) = message.get("msgId").and_then(Value::as_str) else {
-            return true;
-        };
-        message_id == "0" || resource_message_ids.insert(message_id.to_string())
-    });
-
-    // 阶段 2：资源下载（70 → 85）
+    // 阶段 2（issue #634）：磁盘分块流水线，逐块解析 + 逐块资源下载（55 → 85）。
     let filter_pure_image = req
         .options
         .get("filterPureImageMessages")
         .and_then(Value::as_bool)
         == Some(true);
-    let mut resource_map: HashMap<String, Vec<ResourceInfo>> = HashMap::new();
-    let mut resource_summary: Option<ResourceBatchSummary> = None;
     if filter_pure_image {
         tracing::info!("[ApiServer] 已启用纯多媒体消息过滤，跳过资源下载");
     } else {
-        update_task(
-            state,
-            task_id,
-            json!({ "progress": 70, "message": "正在下载资源...", "messageCount": filtered_messages.len() }),
-        )
-        .await;
-        broadcast_progress(
-            state,
-            task_id,
-            70,
-            "正在下载资源...",
-            filtered_messages.len(),
-        );
-
-        // 资源下载进度回调（70 → 85）。
-        let state_cb = Arc::clone(state);
-        let task_id_cb = task_id.to_string();
-        let count_cb = filtered_messages.len();
-        state
-            .resource_handler
-            .set_progress_callback(Some(Arc::new(move |progress| {
-                let percent = 70
-                    + ((progress.completed as f64 / progress.total.max(1) as f64) * 15.0).round()
-                        as i64;
-                broadcast_progress(&state_cb, &task_id_cb, percent, &progress.message, count_cb);
-            })))
-            .await;
-
         // Issue #341：跳过下载的资源类型（仅保留元数据）。
         let requested_skip_types: Vec<String> = req
             .options
@@ -1726,48 +1841,146 @@ async fn process_export_task(
                 .set_skip_download_types(Some(&normalized_skip_types))
                 .await;
         }
+    }
 
-        resource_map = state
-            .resource_handler
-            .process_message_resources_with_cancel_and_trace(
-                &resource_messages,
-                Arc::clone(cancel_flag),
-                debug_session.as_ref().map(ExportDebugSession::trace),
-            )
-            .await;
-        let summary = state.resource_handler.last_batch_summary().await;
-        state.resource_handler.set_progress_callback(None).await;
-        state.resource_handler.set_skip_download_types(None).await;
+    let total_chunks = spool.count().div_ceil(RAW_SPOOL_CHUNK_SIZE).max(1);
+    let mut clean_messages: Vec<CleanMessage> = Vec::new();
+    let mut resource_map: HashMap<String, Vec<ResourceInfo>> = HashMap::new();
+    let mut resource_summary_total = ResourceBatchSummary::default();
+    let mut parsed_message_ids: HashSet<String> = HashSet::new();
+    let mut resource_message_ids: HashSet<String> = HashSet::new();
+    let mut reader = SpoolChunkReader::open(spool.path(), RAW_SPOOL_CHUNK_SIZE).await?;
+    let mut chunk_index: usize = 0;
+    while let Some(chunk) = reader.next_chunk().await? {
+        if is_cancelled(state, task_id, cancel_flag).await {
+            return Err("任务已被用户停止".to_string());
+        }
+        // 按 includeUserUins / excludeUserUins 过滤（issue #369）。
+        let mut chunk = apply_sender_filter(chunk, &req.filter);
+        // 跨块去重（保持原先单次 parse 的全局去重语义）。
+        chunk.retain(
+            |message| match message.get("msgId").and_then(Value::as_str) {
+                Some(id) if !id.is_empty() && id != "0" => {
+                    parsed_message_ids.insert(id.to_string())
+                }
+                _ => true,
+            },
+        );
+        if let Some(infos) = &member_infos {
+            apply_group_member_names(infos, &mut chunk);
+        }
+        chunk.sort_by_key(msg_time_ms);
+        if let Some(debug) = &debug_session {
+            debug.append_jsonl("01-raw-messages.jsonl", &chunk).await?;
+        }
+
+        let parsed = parser.parse_messages(&chunk).await;
+        if let Some(debug) = &debug_session {
+            debug
+                .append_jsonl("02-parsed-messages.jsonl", &parsed)
+                .await?;
+        }
+        clean_messages.extend(parsed);
+
+        let progress_base = (55 + 30 * chunk_index / total_chunks) as i64;
+        let progress_next = (55 + 30 * (chunk_index + 1) / total_chunks) as i64;
+        if !filter_pure_image {
+            let mut resource_chunk = chunk;
+            resource_chunk.extend(parser.take_forward_raw_messages());
+            resource_chunk.retain(|message| {
+                let Some(message_id) = message.get("msgId").and_then(Value::as_str) else {
+                    return true;
+                };
+                message_id == "0" || resource_message_ids.insert(message_id.to_string())
+            });
+
+            // 资源下载进度回调：映射到本块的进度区间。
+            let state_cb = Arc::clone(state);
+            let task_id_cb = task_id.to_string();
+            let count_cb = clean_messages.len();
+            let span = (progress_next - progress_base).max(0) as f64;
+            state
+                .resource_handler
+                .set_progress_callback(Some(Arc::new(move |progress| {
+                    let percent = progress_base
+                        + ((progress.completed as f64 / progress.total.max(1) as f64) * span)
+                            .round() as i64;
+                    broadcast_progress(
+                        &state_cb,
+                        &task_id_cb,
+                        percent,
+                        &progress.message,
+                        count_cb,
+                    );
+                })))
+                .await;
+            let chunk_map = state
+                .resource_handler
+                .process_message_resources_with_cancel_and_trace(
+                    &resource_chunk,
+                    Arc::clone(cancel_flag),
+                    debug_session.as_ref().map(ExportDebugSession::trace),
+                )
+                .await;
+            merge_resource_summary(
+                &mut resource_summary_total,
+                &state.resource_handler.last_batch_summary().await,
+            );
+            resource_map.extend(chunk_map);
+        }
+
+        chunk_index += 1;
+        let message = format!("正在解析消息与下载资源... ({chunk_index}/{total_chunks})");
+        update_task(
+            state,
+            task_id,
+            json!({ "progress": progress_next, "message": message, "messageCount": clean_messages.len() }),
+        )
+        .await;
+        broadcast_progress(
+            state,
+            task_id,
+            progress_next,
+            &message,
+            clean_messages.len(),
+        );
+    }
+    drop(reader);
+    drop(parsed_message_ids);
+    drop(resource_message_ids);
+    state.resource_handler.set_progress_callback(None).await;
+    state.resource_handler.set_skip_download_types(None).await;
+
+    let resource_summary: Option<ResourceBatchSummary> = if filter_pure_image {
+        None
+    } else {
         tracing::info!(
             "[ApiServer] 处理了 {} 个消息的资源（attempted={}, downloaded={}, alreadyAvailable={}, failed={}, skipped={}）",
             resource_map.len(),
-            summary.attempted,
-            summary.downloaded,
-            summary.already_available,
-            summary.failed,
-            summary.skipped,
+            resource_summary_total.attempted,
+            resource_summary_total.downloaded,
+            resource_summary_total.already_available,
+            resource_summary_total.failed,
+            resource_summary_total.skipped,
         );
-        resource_summary = Some(summary);
-    }
+        Some(resource_summary_total)
+    };
+
+    // 全局按时间排序（分块解析后跨块归并）。
+    clean_messages.sort_by_key(|message| message.timestamp);
 
     if is_cancelled(state, task_id, cancel_flag).await {
         return Err("任务已被用户停止".to_string());
     }
 
-    // 阶段 3：解析 + 生成文件（85 →）
+    // 阶段 3：生成文件（85 →）
     update_task(
         state,
         task_id,
-        json!({ "progress": 85, "message": "正在生成文件...", "messageCount": filtered_messages.len() }),
+        json!({ "progress": 85, "message": "正在生成文件...", "messageCount": clean_messages.len() }),
     )
     .await;
-    broadcast_progress(
-        state,
-        task_id,
-        85,
-        "正在生成文件...",
-        filtered_messages.len(),
-    );
+    broadcast_progress(state, task_id, 85, "正在生成文件...", clean_messages.len());
 
     // Issue #30 / #192：确保输出目录存在。
     tokio::fs::create_dir_all(&req.output_dir)

--- a/qq-chat-export-server/src/export_debug.rs
+++ b/qq-chat-export-server/src/export_debug.rs
@@ -124,6 +124,30 @@ impl ExportDebugSession {
         file.flush().await.map_err(|error| error.to_string())
     }
 
+    /// 追加写 JSONL（用于分块流水线逐块落盘，issue #634）。
+    pub async fn append_jsonl<T: Serialize>(
+        &self,
+        file_name: &str,
+        values: &[T],
+    ) -> Result<(), String> {
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(self.directory.join(file_name))
+            .await
+            .map_err(|error| error.to_string())?;
+        for value in values {
+            let line = serde_json::to_vec(value).map_err(|error| error.to_string())?;
+            file.write_all(&line)
+                .await
+                .map_err(|error| error.to_string())?;
+            file.write_all(b"\n")
+                .await
+                .map_err(|error| error.to_string())?;
+        }
+        file.flush().await.map_err(|error| error.to_string())
+    }
+
     pub async fn write_json<T: Serialize>(&self, file_name: &str, value: &T) -> Result<(), String> {
         let bytes = serde_json::to_vec_pretty(value).map_err(|error| error.to_string())?;
         tokio::fs::write(self.directory.join(file_name), bytes)

--- a/qq-chat-export-server/src/fetcher/batch_fetcher.rs
+++ b/qq-chat-export-server/src/fetcher/batch_fetcher.rs
@@ -1,11 +1,11 @@
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Semaphore};
 
 use crate::fetcher::chat_type::is_private_like_chat_type;
 
@@ -17,6 +17,30 @@ const BATCH_SIZE_RECOVERY_SUCCESSES: u32 = 3;
 
 /// 分页批次之间的间隔（本地 IPC 调用，仅留出让路空隙）。
 const INTER_BATCH_DELAY_MS: u64 = 20;
+
+/// issue #634：群聊序列分页的单页上限。大窗口历史查询会在 QQ 原生
+/// Worker（wrapper.node）内积累巨大内存压力，最终导致 0xC0000005 崩溃。
+const GROUP_SEQ_PAGE_MAX: i64 = 500;
+
+/// issue #634：超时后的冷却时间。本地超时并不代表 Worker 内的原生查询已经
+/// 结束，立即重试会造成重量级查询在 Worker 内叠加。
+const TIMEOUT_COOLDOWN_MS: u64 = 15_000;
+
+/// issue #634：bridge / Worker 崩溃后等待恢复（NapCat 重启并重新登录）的上限。
+const BRIDGE_RECOVERY_WAIT_MS: u64 = 10 * 60 * 1000;
+
+/// bridge 恢复探测间隔。
+const BRIDGE_PROBE_INTERVAL_MS: u64 = 5_000;
+
+/// 单次 API 调用允许的 bridge 崩溃恢复次数（不计入普通重试次数）。
+const MAX_BRIDGE_RECOVERIES: u32 = 5;
+
+/// issue #634：进程级历史查询门控。同一时刻只允许一个重量级历史消息查询
+/// 进入 NapCat Worker，防止并发/叠加查询压垮 QQ 原生模块。
+fn history_fetch_gate() -> &'static Semaphore {
+    static GATE: OnceLock<Semaphore> = OnceLock::new();
+    GATE.get_or_init(|| Semaphore::new(1))
+}
 
 /// 聊天对象（对应 NapCat `Peer`）。
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -178,6 +202,30 @@ impl FetchError {
             _ => false,
         }
     }
+
+    /// 判断错误是否属于 bridge / Worker 不可用（NapCat Worker 崩溃或重启）。
+    fn is_bridge_down(&self) -> bool {
+        let Self::Api(message) = self else {
+            return false;
+        };
+        if message.contains("传输错误") {
+            return true;
+        }
+        let lower = message.to_lowercase();
+        [
+            "connection refused",
+            "connection reset",
+            "connection closed",
+            "broken pipe",
+            "error sending request",
+            "connect error",
+            "unexpected eof",
+            "channel closed",
+            "dns error",
+        ]
+        .iter()
+        .any(|pattern| lower.contains(pattern))
+    }
 }
 
 /// NapCat 消息获取 API 抽象（由 bridge 客户端实现）。
@@ -210,6 +258,11 @@ pub trait MessageFetchApi: Send + Sync {
         anchor_seq: i64,
         count: i64,
     ) -> Result<Value, String>;
+
+    /// bridge / Worker 是否健康可用（默认视为健康）。
+    async fn bridge_healthy(&self) -> bool {
+        true
+    }
 }
 
 /// 获取策略。
@@ -221,6 +274,8 @@ pub enum FetchStrategy {
     SequenceBasedRange,
     /// 混合策略（动态选择）。
     Hybrid,
+    /// issue #634：基于序列号的小页分页（群聊安全路径）。
+    SequenceBasedPaged,
 }
 
 /// 内部可变状态。
@@ -420,9 +475,15 @@ impl BatchMessageFetcher {
         if !self.config.enable_optimization {
             return FetchStrategy::TimeBasedSequential;
         }
-        // 暂时统一使用基础方法，避免不同版本的复杂 API 差异。
+        // issue #634：群聊使用小页序列分页，避免大窗口 getMsgHistory 查询
+        // 压垮 QQ 原生 Worker。
         let _ = filter;
-        FetchStrategy::TimeBasedSequential
+        tracing::debug!(
+            "策略选择: 群聊使用序列小页分页, 对等体={}, chatType={}",
+            peer.peer_uid,
+            peer.chat_type
+        );
+        FetchStrategy::SequenceBasedPaged
     }
 
     /// 执行指定的获取策略。
@@ -446,7 +507,61 @@ impl BatchMessageFetcher {
                 self.fetch_by_hybrid_strategy(peer, filter, start_message_id, start_seq)
                     .await
             }
+            FetchStrategy::SequenceBasedPaged => {
+                self.fetch_by_seq_paged(peer, filter, start_seq).await
+            }
         }
+    }
+
+    /// issue #634：基于序列号的小页分页获取（群聊安全路径）。
+    ///
+    /// 首批用 `getAioFirstViewLatestMsgs` 的小窗口拿到当前最新序列号，之后
+    /// 每批用 `getMsgsBySeqAndCount` 从锚点向前翻小页。空页（历史缺口）按
+    /// 页宽线性跳过，序列号单调递减保证终止。
+    async fn fetch_by_seq_paged(
+        &self,
+        peer: &Peer,
+        filter: &MessageFilter,
+        start_seq: Option<&str>,
+    ) -> Result<BatchFetchResult, FetchError> {
+        let anchor = start_seq.and_then(|seq| seq.parse::<i64>().ok());
+        if let Some(anchor) = anchor {
+            if anchor <= 0 {
+                return Ok(BatchFetchResult::default());
+            }
+        }
+
+        let api = Arc::clone(&self.api);
+        let peer_clone = peer.clone();
+        let result = self
+            .call_with_retry(move |batch_size| {
+                let api = Arc::clone(&api);
+                let peer = peer_clone.clone();
+                let page = seq_page_size(batch_size);
+                async move {
+                    match anchor {
+                        None => {
+                            tracing::info!(
+                                "[BatchMessageFetcher] 调用 getAioFirstViewLatestMsgs API (seq 分页首批), count={page}"
+                            );
+                            api.get_aio_first_view_latest_msgs(&peer, page).await
+                        }
+                        Some(anchor) => {
+                            tracing::info!(
+                                "[BatchMessageFetcher] 调用 getMsgsBySeqAndCount API, anchorSeq={anchor}, count={page}"
+                            );
+                            api.get_msgs_by_seq_and_count(&peer, anchor, page).await
+                        }
+                    }
+                }
+            })
+            .await?;
+
+        let page = seq_page_size(self.state.lock().await.batch_size);
+        let mut batch = process_seq_page_result(result, filter, anchor, page);
+        batch.messages = apply_client_side_filter(batch.messages, filter);
+        batch.actual_count = batch.messages.len();
+        Ok(batch)
     }
 
     /// 基于时间的顺序获取策略。
@@ -591,9 +706,10 @@ impl BatchMessageFetcher {
         F: Fn(i64) -> Fut,
         Fut: std::future::Future<Output = Result<Value, String>>,
     {
-        let mut last_error = FetchError::Api("未知API错误".to_string());
+        let mut bridge_recoveries = 0_u32;
+        let mut attempt = 0_u32;
 
-        for attempt in 0..=self.config.retry_count {
+        loop {
             if self.is_cancelled() {
                 return Err(FetchError::Cancelled);
             }
@@ -604,11 +720,17 @@ impl BatchMessageFetcher {
                 self.config.retry_count + 1
             );
 
+            // issue #634：进程级串行门控，避免多个重量级历史查询同时进入 Worker。
+            let gate_permit = history_fetch_gate()
+                .acquire()
+                .await
+                .map_err(|_| FetchError::Api("历史查询门控已关闭".to_string()))?;
             let call_result = tokio::time::timeout(
                 Duration::from_millis(self.config.timeout_ms),
                 api_call(batch_size),
             )
             .await;
+            drop(gate_permit);
             let result = match call_result {
                 Ok(Ok(value)) => {
                     tracing::info!("[BatchMessageFetcher] API调用成功");
@@ -646,32 +768,79 @@ impl BatchMessageFetcher {
                 state.stats.consecutive_failures += 1;
             }
 
-            if attempt == self.config.retry_count {
-                last_error = result;
-                break;
+            // issue #634：bridge / Worker 崩溃属于可恢复状态：等待 NapCat 重启
+            // 并重新登录后从当前游标继续，不计入普通重试次数。
+            if result.is_bridge_down() {
+                if bridge_recoveries >= MAX_BRIDGE_RECOVERIES {
+                    return Err(result);
+                }
+                bridge_recoveries += 1;
+                self.shrink_batch_size().await;
+                tracing::warn!(
+                    "[BatchMessageFetcher] bridge 不可用（Worker 可能崩溃/重启），等待恢复后继续 (第 {bridge_recoveries}/{MAX_BRIDGE_RECOVERIES} 次)"
+                );
+                if !self.wait_for_bridge_recovery().await {
+                    return Err(result);
+                }
+                continue;
             }
+
+            if attempt >= self.config.retry_count {
+                return Err(result);
+            }
+            attempt += 1;
 
             // issue #305 / #316：超时类错误下次重试用更小的 batchSize。
+            // issue #634：本地超时不代表 Worker 内旧查询已结束，先冷却再等
+            // bridge 健康，避免重量级查询在 Worker 内叠加。
             if result.is_timeout() {
-                let mut state = self.state.lock().await;
-                state.consecutive_successes = 0;
-                if state.batch_size > MIN_BATCH_SIZE_ON_TIMEOUT {
-                    let previous = state.batch_size;
-                    let next = (previous / 2).max(MIN_BATCH_SIZE_ON_TIMEOUT);
-                    state.batch_size = next;
-                    tracing::warn!(
-                        "[BatchMessageFetcher] 检测到超时，自适应缩小 batchSize: {previous} -> {next}"
-                    );
+                self.shrink_batch_size().await;
+                let cooldown =
+                    TIMEOUT_COOLDOWN_MS.max(self.config.retry_interval_ms * u64::from(attempt));
+                tracing::info!("[BatchMessageFetcher] 超时冷却 {cooldown}ms 后重试");
+                tokio::time::sleep(Duration::from_millis(cooldown)).await;
+                if !self.wait_for_bridge_recovery().await {
+                    return Err(result);
                 }
+            } else {
+                let retry_delay = self.config.retry_interval_ms * u64::from(attempt);
+                tracing::info!("[BatchMessageFetcher] 等待 {retry_delay}ms 后重试");
+                tokio::time::sleep(Duration::from_millis(retry_delay)).await;
             }
-            last_error = result;
-
-            let retry_delay = self.config.retry_interval_ms * u64::from(attempt + 1);
-            tracing::info!("[BatchMessageFetcher] 等待 {retry_delay}ms 后重试");
-            tokio::time::sleep(Duration::from_millis(retry_delay)).await;
         }
+    }
 
-        Err(last_error)
+    /// 超时 / 崩溃后自适应缩小 batchSize（不低于 [`MIN_BATCH_SIZE_ON_TIMEOUT`]）。
+    async fn shrink_batch_size(&self) {
+        let mut state = self.state.lock().await;
+        state.consecutive_successes = 0;
+        if state.batch_size > MIN_BATCH_SIZE_ON_TIMEOUT {
+            let previous = state.batch_size;
+            let next = (previous / 2).max(MIN_BATCH_SIZE_ON_TIMEOUT);
+            state.batch_size = next;
+            tracing::warn!("[BatchMessageFetcher] 自适应缩小 batchSize: {previous} -> {next}");
+        }
+    }
+
+    /// 等待 bridge / Worker 恢复健康；被取消或超出等待上限时返回 `false`。
+    async fn wait_for_bridge_recovery(&self) -> bool {
+        let deadline = std::time::Instant::now() + Duration::from_millis(BRIDGE_RECOVERY_WAIT_MS);
+        loop {
+            if self.is_cancelled() {
+                return false;
+            }
+            if self.api.bridge_healthy().await {
+                return true;
+            }
+            if std::time::Instant::now() >= deadline {
+                tracing::error!(
+                    "[BatchMessageFetcher] bridge 在 {BRIDGE_RECOVERY_WAIT_MS}ms 内未恢复"
+                );
+                return false;
+            }
+            tracing::info!("[BatchMessageFetcher] 等待 bridge 恢复...");
+            tokio::time::sleep(Duration::from_millis(BRIDGE_PROBE_INTERVAL_MS)).await;
+        }
     }
 
     /// 更新统计信息。
@@ -691,32 +860,105 @@ impl BatchMessageFetcher {
     }
 }
 
+/// 序列分页的每页大小：跟随自适应 batchSize，但不超过 [`GROUP_SEQ_PAGE_MAX`]。
+fn seq_page_size(batch_size: i64) -> i64 {
+    batch_size.clamp(1, GROUP_SEQ_PAGE_MAX)
+}
+
+/// 宽松读取 msgSeq（可能是字符串或数字）。
+fn loose_msg_seq(msg: &Value) -> Option<i64> {
+    match msg.get("msgSeq") {
+        Some(Value::Number(n)) => n.as_i64(),
+        Some(Value::String(s)) => s.trim().parse::<i64>().ok(),
+        _ => None,
+    }
+}
+
+/// 从 API 响应中提取消息数组（兼容 `result.msgList` / `msgList` 两种包装）。
+fn extract_msg_list(api_result: Value) -> Vec<Value> {
+    match api_result {
+        Value::Object(mut root) => {
+            if let Some(Value::Object(result)) = root.get_mut("result") {
+                if let Some(Value::Array(messages)) = result.remove("msgList") {
+                    return messages;
+                }
+            }
+            match root.remove("msgList") {
+                Some(Value::Array(messages)) => messages,
+                _ => Vec::new(),
+            }
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// issue #634：处理序列分页的 API 结果。
+///
+/// 下一锚点 = 本页最小序列号 - 1；空页或序列未前进时按页宽线性跳过缺口，
+/// 序列号严格递减保证不会死循环。
+fn process_seq_page_result(
+    api_result: Value,
+    filter: &MessageFilter,
+    anchor: Option<i64>,
+    page: i64,
+) -> BatchFetchResult {
+    let messages = extract_msg_list(api_result);
+
+    let min_seq = messages.iter().filter_map(loose_msg_seq).min();
+    let mut earliest_msg_time = messages
+        .iter()
+        .filter_map(loose_msg_time)
+        .min()
+        .map(to_millis);
+    if messages.is_empty() {
+        earliest_msg_time = None;
+    }
+
+    let next_anchor = match (min_seq, anchor) {
+        (Some(min_seq), Some(anchor)) if min_seq < anchor => min_seq - 1,
+        (Some(min_seq), None) => min_seq - 1,
+        // 空页或未前进：按页宽跳过缺口。首批（无锚点）空结果视为空会话。
+        (_, Some(anchor)) => anchor - page.max(1),
+        (None, None) => 0,
+    };
+
+    let mut has_more = next_anchor > 0 && !(anchor.is_none() && messages.is_empty());
+
+    // 早停：最早时间早于筛选开始时间。
+    if let (Some(earliest), Some(start_time)) = (earliest_msg_time, filter.start_time) {
+        if earliest < start_time {
+            tracing::info!(
+                "[BatchMessageFetcher] 早停：earliestMsgTime={earliest} < startTime={start_time}，停止继续获取"
+            );
+            has_more = false;
+        }
+    }
+
+    let next_seq = has_more.then(|| next_anchor.to_string());
+    tracing::info!(
+        "[BatchMessageFetcher] 序列分页结果: {} 条消息, anchor={anchor:?}, nextSeq={next_seq:?}, hasMore={has_more}",
+        messages.len()
+    );
+
+    let actual_count = messages.len();
+    BatchFetchResult {
+        messages,
+        has_more,
+        next_message_id: None,
+        next_seq,
+        actual_count,
+        fetch_time_ms: 0,
+        earliest_msg_time,
+    }
+}
+
 /// 处理 API 调用结果，统一格式化。
 fn process_api_result(
     api_result: Value,
     filter: Option<&MessageFilter>,
     current_message_id: Option<&str>,
 ) -> BatchFetchResult {
-    let messages = match api_result {
-        Value::Object(mut root) => {
-            if let Some(Value::Object(result)) = root.get_mut("result") {
-                if let Some(Value::Array(messages)) = result.remove("msgList") {
-                    messages
-                } else {
-                    match root.remove("msgList") {
-                        Some(Value::Array(messages)) => messages,
-                        _ => Vec::new(),
-                    }
-                }
-            } else {
-                match root.remove("msgList") {
-                    Some(Value::Array(messages)) => messages,
-                    _ => Vec::new(),
-                }
-            }
-        }
-        _ => Vec::new(),
-    };
+    let messages = extract_msg_list(api_result);
 
     let mut has_more = !messages.is_empty();
     let mut next_message_id: Option<String> = None;
@@ -737,10 +979,7 @@ fn process_api_result(
             .get("msgId")
             .and_then(Value::as_str)
             .map(ToString::to_string);
-        next_seq = earliest
-            .get("msgSeq")
-            .and_then(Value::as_str)
-            .map(ToString::to_string);
+        next_seq = loose_msg_seq(earliest).map(|seq| seq.to_string());
         if let Some(raw_time) = loose_msg_time(earliest) {
             earliest_msg_time = Some(to_millis(raw_time));
         }
@@ -977,6 +1216,173 @@ mod tests {
                 .expect("call succeeds");
         }
         assert_eq!(fetcher.state.lock().await.batch_size, 5000);
+    }
+
+    #[test]
+    fn seq_page_result_advances_cursor_monotonically() {
+        let filter = MessageFilter::default();
+        let batch = process_seq_page_result(
+            json!({ "msgList": [
+                { "msgId": "m3", "msgSeq": "300", "msgTime": "1783866274" },
+                { "msgId": "m2", "msgSeq": 250, "msgTime": "1783866270" },
+            ] }),
+            &filter,
+            Some(320),
+            100,
+        );
+        assert!(batch.has_more);
+        assert_eq!(batch.next_seq.as_deref(), Some("249"));
+    }
+
+    #[test]
+    fn seq_page_result_skips_empty_pages_without_looping() {
+        let filter = MessageFilter::default();
+        // 空页（历史缺口）：按页宽跳过，游标必须前进。
+        let batch = process_seq_page_result(json!({ "msgList": [] }), &filter, Some(1000), 200);
+        assert!(batch.has_more);
+        assert_eq!(batch.next_seq.as_deref(), Some("800"));
+
+        // 序列号未前进（返回的最小 seq >= 锚点）同样按页宽跳过。
+        let batch = process_seq_page_result(
+            json!({ "msgList": [{ "msgId": "m1", "msgSeq": "1000" }] }),
+            &filter,
+            Some(1000),
+            200,
+        );
+        assert_eq!(batch.next_seq.as_deref(), Some("800"));
+
+        // 游标触底后终止。
+        let batch = process_seq_page_result(json!({ "msgList": [] }), &filter, Some(150), 200);
+        assert!(!batch.has_more);
+        assert!(batch.next_seq.is_none());
+    }
+
+    #[test]
+    fn seq_page_result_terminates_on_empty_first_page() {
+        let batch = process_seq_page_result(
+            json!({ "msgList": [] }),
+            &MessageFilter::default(),
+            None,
+            200,
+        );
+        assert!(!batch.has_more);
+        assert!(batch.next_seq.is_none());
+    }
+
+    #[test]
+    fn seq_page_result_stops_early_before_start_time() {
+        let filter = MessageFilter {
+            start_time: Some(1_800_000_000_000),
+            ..MessageFilter::default()
+        };
+        let batch = process_seq_page_result(
+            json!({ "msgList": [{ "msgId": "m1", "msgSeq": "500", "msgTime": "1783866274" }] }),
+            &filter,
+            Some(600),
+            200,
+        );
+        assert!(!batch.has_more);
+        assert!(batch.next_seq.is_none());
+    }
+
+    #[test]
+    fn seq_page_size_is_capped() {
+        assert_eq!(seq_page_size(5000), GROUP_SEQ_PAGE_MAX);
+        assert_eq!(seq_page_size(200), 200);
+        assert_eq!(seq_page_size(0), 1);
+    }
+
+    #[test]
+    fn bridge_down_errors_are_detected() {
+        assert!(FetchError::Api("传输错误: error sending request".to_string()).is_bridge_down());
+        assert!(FetchError::Api("Connection refused (os error 111)".to_string()).is_bridge_down());
+        assert!(!FetchError::Api("API调用超时".to_string()).is_bridge_down());
+        assert!(!FetchError::Timeout(1000).is_bridge_down());
+    }
+
+    #[tokio::test]
+    async fn history_gate_serializes_concurrent_calls() {
+        use std::sync::atomic::AtomicI64;
+
+        struct ConcurrencyProbe {
+            active: AtomicI64,
+            max_active: AtomicI64,
+        }
+
+        #[async_trait]
+        impl MessageFetchApi for ConcurrencyProbe {
+            async fn get_aio_first_view_latest_msgs(
+                &self,
+                _peer: &Peer,
+                _count: i64,
+            ) -> Result<Value, String> {
+                let now = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+                self.max_active.fetch_max(now, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                self.active.fetch_sub(1, Ordering::SeqCst);
+                Ok(json!({ "msgList": [] }))
+            }
+
+            async fn get_msg_history(
+                &self,
+                _peer: &Peer,
+                _msg_id: &str,
+                _count: i64,
+            ) -> Result<Value, String> {
+                Ok(json!({ "msgList": [] }))
+            }
+
+            async fn get_msgs_by_seq_range(
+                &self,
+                _peer: &Peer,
+                _start_seq: &str,
+                _end_seq: &str,
+            ) -> Result<Value, String> {
+                Ok(json!({ "msgList": [] }))
+            }
+
+            async fn get_msgs_by_seq_and_count(
+                &self,
+                _peer: &Peer,
+                _anchor_seq: i64,
+                _count: i64,
+            ) -> Result<Value, String> {
+                Ok(json!({ "msgList": [] }))
+            }
+        }
+
+        let api = Arc::new(ConcurrencyProbe {
+            active: AtomicI64::new(0),
+            max_active: AtomicI64::new(0),
+        });
+        // 两个独立 fetcher 实例并发调用，进程级门控必须保证串行。
+        let fetcher_a =
+            BatchMessageFetcher::new(Arc::clone(&api) as _, BatchFetchConfig::default());
+        let fetcher_b =
+            BatchMessageFetcher::new(Arc::clone(&api) as _, BatchFetchConfig::default());
+        let api_a = Arc::clone(&api);
+        let api_b = Arc::clone(&api);
+        let peer = Peer {
+            chat_type: 2,
+            peer_uid: "group".to_string(),
+            guild_id: None,
+        };
+        let peer_a = peer.clone();
+        let peer_b = peer;
+        let call_a = fetcher_a.call_with_retry(move |count| {
+            let api = Arc::clone(&api_a);
+            let peer = peer_a.clone();
+            async move { api.get_aio_first_view_latest_msgs(&peer, count).await }
+        });
+        let call_b = fetcher_b.call_with_retry(move |count| {
+            let api = Arc::clone(&api_b);
+            let peer = peer_b.clone();
+            async move { api.get_aio_first_view_latest_msgs(&peer, count).await }
+        });
+        let (a, b) = tokio::join!(call_a, call_b);
+        a.expect("call a succeeds");
+        b.expect("call b succeeds");
+        assert_eq!(api.max_active.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/qq-chat-export-server/src/fetcher/sequence_integrity.rs
+++ b/qq-chat-export-server/src/fetcher/sequence_integrity.rs
@@ -100,6 +100,7 @@ pub async fn repair_group_message_sequence(
 
         rounds += 1;
         let mut remaining_round_budget = config.round_budget.min(remaining_total_budget).max(0);
+        let mut fetched: Vec<Value> = Vec::new();
         for gap in gaps.iter().rev() {
             let mut anchor = gap.upper - 1;
             let mut remaining = gap.missing_positions;
@@ -111,17 +112,21 @@ pub async fn repair_group_message_sequence(
                     .min(remaining_total_budget)
                     .max(1);
                 let lower = (anchor - count + 1).max(gap.lower + 1);
-                let range_messages = api
+                let mut range_messages = api
                     .get_msgs_by_seq_range(peer, &lower.to_string(), &anchor.to_string())
                     .await
                     .ok()
                     .map(extract_messages)
                     .unwrap_or_default();
                 if range_messages.is_empty() {
-                    api.get_msgs_by_seq_and_count(peer, anchor, count)
-                        .await
-                        .map_err(FetchError::Api)?;
+                    // issue #634：count 回退的返回结果同样要并入修复集合。
+                    range_messages = extract_messages(
+                        api.get_msgs_by_seq_and_count(peer, anchor, count)
+                            .await
+                            .map_err(FetchError::Api)?,
+                    );
                 }
+                fetched.extend(range_messages);
                 remaining_round_budget -= count;
                 remaining_total_budget -= count;
                 remaining -= count;
@@ -131,6 +136,7 @@ pub async fn repair_group_message_sequence(
                 break;
             }
         }
+        merge_messages(messages, fetched);
 
         let reprobed = reprobe_with_message_history(api, peer, messages, &gaps, config).await?;
         merge_messages(messages, reprobed);
@@ -469,10 +475,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn merges_count_fallback_results() {
+        // issue #634：count 回退的返回消息必须并入修复集合。
+        let api = MockApi::new(
+            vec![Ok(json!({ "msgList": [] }))],
+            vec![Ok(repaired_history())],
+            vec![Ok(json!({ "msgList": endpoints() }))],
+        );
+        let mut messages = endpoints();
+        let report = repair_group_message_sequence(
+            &api,
+            &peer(),
+            &mut messages,
+            SequenceRepairConfig::default(),
+        )
+        .await
+        .unwrap();
+
+        assert!(report.repaired_messages > 0);
+        assert!(detect_large_seq_gaps(&messages, 5).is_empty());
+    }
+
+    #[tokio::test]
     async fn fails_when_normal_reprobe_makes_no_progress() {
         let api = MockApi::new(
-            vec![Ok(repaired_history())],
-            vec![],
+            vec![Ok(json!({ "msgList": [] }))],
+            vec![Ok(json!({ "msgList": [] }))],
             vec![Ok(json!({ "msgList": endpoints() }))],
         );
         let mut messages = endpoints();
@@ -492,11 +520,8 @@ mod tests {
     #[tokio::test]
     async fn continues_with_a_new_round_after_progress() {
         let api = MockApi::new(
-            vec![
-                Ok(json!({ "msgList": [{ "msgId": "loaded-first", "msgSeq": 5 }] })),
-                Ok(json!({ "msgList": [{ "msgId": "loaded-second", "msgSeq": 8 }] })),
-            ],
-            vec![],
+            vec![Ok(json!({ "msgList": [] })), Ok(json!({ "msgList": [] }))],
+            vec![Ok(json!({ "msgList": [] })), Ok(json!({ "msgList": [] }))],
             vec![
                 Ok(json!({ "msgList": [
                     { "msgId": "one", "msgSeq": 1 },

--- a/qq-chat-export-server/src/market_face.rs
+++ b/qq-chat-export-server/src/market_face.rs
@@ -21,10 +21,9 @@ pub fn alternate_url(url: &str) -> Option<String> {
         .map_or((url, None), |(path, query)| (path, Some(query)));
     let alternate = if let Some(base) = path.strip_suffix("/raw300.gif") {
         format!("{base}/raw300.png")
-    } else if let Some(base) = path.strip_suffix("/raw300.png") {
-        format!("{base}/raw300.gif")
     } else {
-        return None;
+        let base = path.strip_suffix("/raw300.png")?;
+        format!("{base}/raw300.gif")
     };
     Some(query.map_or(alternate.clone(), |query| format!("{alternate}?{query}")))
 }

--- a/qq-chat-export-server/src/napcat/client.rs
+++ b/qq-chat-export-server/src/napcat/client.rs
@@ -425,12 +425,23 @@ impl MessageFetchApi for NapCatBridgeClient {
         anchor_seq: i64,
         count: i64,
     ) -> Result<Value, String> {
+        // NapCat 的 msgSeq 参数是字符串。
         self.call(
             "MsgApi.getMsgsBySeqAndCount",
-            json!([peer_to_value(peer), anchor_seq, count, true, true]),
+            json!([
+                peer_to_value(peer),
+                anchor_seq.to_string(),
+                count,
+                true,
+                true
+            ]),
         )
         .await
         .map_err(|error| error.to_string())
+    }
+
+    async fn bridge_healthy(&self) -> bool {
+        self.healthy().await
     }
 }
 


### PR DESCRIPTION
Fixes #634.

Large group exports crashed the NapCat worker and stalled at 50%.

Fetch layer:
- A process-wide semaphore serializes every heavy history/sequence query, so a
  local timeout can no longer leave one native query running inside the worker
  while a second one starts on top of it.
- After a timeout the batch size shrinks, a 15s cooldown runs, and `/healthz` is
  polled before the next attempt.
- Transport-level failures are detected as a downed bridge; the fetcher waits up
  to 10 minutes for NapCat to come back and resumes from the current cursor.

Group pagination:
- Group chats now page by `msgSeq` with at most 500 messages per page instead of
  large history windows. The cursor moves strictly backwards, empty or
  non-advancing pages skip by one page width, and paging stops at the boundary.
- Private chat fetching is unchanged.

Export pipeline:
- Fetched raw batches are spooled to a per-task JSONL file and parsed in bounded
  chunks, replacing the in-memory `all_messages` accumulation and the full clone
  used by the resource stage.
- ZIP entries are streamed with `io::copy` instead of reading whole files.

Progress and repair:
- Fetch progress is derived from `msgSeq` movement and message counts; the
  hard-coded 50% cap is gone.
- Sequence repair now merges the result of the `getMsgsBySeqAndCount` fallback,
  which was previously discarded.

Checks: `cargo test` (114 tests, including new coverage for the serialization
gate, sequence cursor advancement, empty-page termination and bridge-failure
detection), `cargo clippy --all-targets -- -D warnings`, `cargo build`,
`rustfmt --check` on the changed files.
