### PR TITLE
fix(ui): session dedupe, scheduled self-contained HTML, date picker, task plans, custom export path

### DIFF
--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -1273,7 +1273,9 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
 
   useEffect(() => {
     if (isStandalone) return
-    if (activeTab === "sessions" && groups.length === 0 && friends.length === 0) {
+    // Issue #641：「导出任务」页的群聊集合也需要真实群列表，否则新建任务时群组
+    // 选择器一直是空的，用户既搜不到也选不了自己的群。
+    if ((activeTab === "sessions" || activeTab === "plans") && groups.length === 0 && friends.length === 0) {
       loadChatData()
     }
   }, [activeTab, groups.length, friends.length, loadChatData, isStandalone])

--- a/qce-v4-tool/components/export-plans/plan-wizard.tsx
+++ b/qce-v4-tool/components/export-plans/plan-wizard.tsx
@@ -557,7 +557,7 @@ function FixedGroupPicker({
             <Users className="w-8 h-8 mx-auto text-muted-foreground/30 mb-2" />
             <p className="text-sm">{store.knownGroups.length === 0 ? "暂无群组数据" : `没有找到匹配 "${keyword}" 的群组`}</p>
             {store.knownGroups.length === 0 && (
-              <p className="text-xs text-muted-foreground/60 mt-1">请先在「会话」页加载群列表</p>
+              <p className="text-xs text-muted-foreground/60 mt-1">群列表正在加载，稍等一下或到「会话」页刷新</p>
             )}
           </div>
         ) : (

--- a/qce-v4-tool/components/export-plans/plans-panel.tsx
+++ b/qce-v4-tool/components/export-plans/plans-panel.tsx
@@ -172,16 +172,6 @@ export const ExportTaskPlansPanel = forwardRef<
             >
               新建导出任务
             </button>
-            <button
-              onClick={() => {
-                if (store.seedDemoData()) {
-                  toast({ title: "已载入示例数据", description: "包含标签、任务与运行记录，可直接体验" })
-                }
-              }}
-              className="h-8 px-3.5 rounded-full text-[12px] text-muted-foreground hover:text-foreground hover:bg-black/[0.04] dark:hover:bg-white/[0.06] transition-colors"
-            >
-              载入示例数据
-            </button>
           </div>
         </div>
       ) : filteredPlans.length === 0 ? (

--- a/qce-v4-tool/components/ui/date-range-picker.tsx
+++ b/qce-v4-tool/components/ui/date-range-picker.tsx
@@ -45,12 +45,36 @@ function formatDisplay(date?: Date): string {
   return `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, "0")}/${String(date.getDate()).padStart(2, "0")}`
 }
 
+/** 归一到月首日，作为日历可见月份。 */
+function startOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1)
+}
+
 export function DateRangePicker({ startTime, endTime, onChange, className }: DateRangePickerProps) {
   const [isOpen, setIsOpen] = React.useState(false)
 
   const from = parseDate(startTime)
   const to = parseDate(endTime)
   const range: DateRange | undefined = from ? { from, to } : undefined
+
+  // Issue #643：日历可见月份受控，否则 `defaultMonth` 只在首次渲染生效，已选
+  // 日期变化后面板仍停在旧月份，用户只能一个月一个月点过去。
+  const [visibleMonth, setVisibleMonth] = React.useState<Date>(() =>
+    startOfMonth(from ?? new Date()),
+  )
+  const fromMonthKey = from ? `${from.getFullYear()}-${from.getMonth()}` : ""
+  React.useEffect(() => {
+    if (!fromMonthKey) return
+    const [year, month] = fromMonthKey.split("-").map(Number)
+    setVisibleMonth((prev) =>
+      prev.getFullYear() === year && prev.getMonth() === month ? prev : new Date(year, month, 1),
+    )
+  }, [fromMonthKey])
+
+  // 年份下拉范围：QQ 聊天记录最早到 2005 年，上限给到今年年底。
+  const currentYear = new Date().getFullYear()
+  const startMonth = React.useMemo(() => new Date(2005, 0, 1), [])
+  const endMonth = React.useMemo(() => new Date(currentYear, 11, 31), [currentYear])
 
   const startClock = parseClock(startTime, "00:00")
   const endClock = parseClock(endTime, "23:59")
@@ -113,7 +137,12 @@ export function DateRangePicker({ startTime, endTime, onChange, className }: Dat
           <div className="p-3 shrink-0 flex justify-center w-full sm:w-[280px]">
             <Calendar
               mode="range"
-              defaultMonth={from}
+              // Issue #643：下拉式年/月选择，不再需要逐月翻页。
+              captionLayout="dropdown"
+              month={visibleMonth}
+              onMonthChange={setVisibleMonth}
+              startMonth={startMonth}
+              endMonth={endMonth}
               selected={range}
               onSelect={handleSelect}
               numberOfMonths={1}
@@ -160,6 +189,7 @@ export function DateRangePicker({ startTime, endTime, onChange, className }: Dat
                 className="w-full justify-center h-8 text-[13px] font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20"
                 onClick={() => {
                   const today = new Date()
+                  setVisibleMonth(startOfMonth(today))
                   emit({ from: today, to: today }, startClock, endClock)
                 }}
               >

--- a/qce-v4-tool/components/ui/scheduled-export-wizard.tsx
+++ b/qce-v4-tool/components/ui/scheduled-export-wizard.tsx
@@ -79,6 +79,8 @@ export function ScheduledExportWizard({
     filterPureImageMessages: false,
     preferGroupMemberName: true,
     debugExport: false,
+    // Issue #646：定时 HTML 导出把资源内联为 base64，生成自包含单文件。
+    embedResourcesAsDataUri: false,
     // Issue #344：定时导出也支持按资源类型逐项跳过下载。
     skipDownloadResourceTypes: undefined as SkipDownloadResourceType[] | undefined,
   })
@@ -128,6 +130,7 @@ export function ScheduledExportWizard({
           : defaultFilter,
         preferGroupMemberName: prefilledData.preferGroupMemberName !== undefined ? prefilledData.preferGroupMemberName : true,
         debugExport: prefilledData.debugExport ?? false,
+        embedResourcesAsDataUri: prefilledData.embedResourcesAsDataUri ?? false,
         skipDownloadResourceTypes: Array.isArray(prefilledData.skipDownloadResourceTypes) && prefilledData.skipDownloadResourceTypes.length > 0
           ? (prefilledData.skipDownloadResourceTypes as SkipDownloadResourceType[])
           : undefined,
@@ -167,6 +170,7 @@ export function ScheduledExportWizard({
         filterPureImageMessages: false,
         preferGroupMemberName: true,
         debugExport: false,
+        embedResourcesAsDataUri: false,
         skipDownloadResourceTypes: undefined,
       })
       setSelectedTargets([])
@@ -228,6 +232,8 @@ export function ScheduledExportWizard({
         filterPureImageMessages: baseForm.filterPureImageMessages,
         preferGroupMemberName: baseForm.preferGroupMemberName,
         debugExport: baseForm.debugExport,
+        // Issue #646：仅 HTML 支持自包含内联，其他格式忽略该开关。
+        embedResourcesAsDataUri: baseForm.format === 'HTML' && baseForm.embedResourcesAsDataUri,
         ...(!baseForm.filterPureImageMessages && baseForm.skipDownloadResourceTypes && baseForm.skipDownloadResourceTypes.length > 0 && {
           skipDownloadResourceTypes: baseForm.skipDownloadResourceTypes,
         }),
@@ -899,6 +905,15 @@ export function ScheduledExportWizard({
                       title: "不下载语音",
                       desc: "定时导出时跳过 SILK / AMR 语音消息。对只需要文字记录的备份场景很有用。",
                       visible: !baseForm.filterPureImageMessages,
+                    },
+                    // Issue #646：定时 HTML 导出生成自包含单文件，图片等资源直接内联。
+                    {
+                      id: "embedResourcesAsDataUri",
+                      checked: baseForm.embedResourcesAsDataUri,
+                      set: (v: boolean) => setBaseForm(p => ({ ...p, embedResourcesAsDataUri: v })),
+                      title: "自包含 HTML（内联图片等资源）",
+                      desc: "把已下载的图片、语音等资源以 base64 写进 HTML，单个文件即可离线查看，代价是文件体积明显变大。",
+                      visible: baseForm.format === 'HTML' && !baseForm.filterPureImageMessages,
                     },
                     {
                       id: "preferGroupMemberName",

--- a/qce-v4-tool/e2e/session-and-schedule-logic.spec.ts
+++ b/qce-v4-tool/e2e/session-and-schedule-logic.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure logic regression tests. No frontend/mock server needed.
+ *
+ * Issue #649: session lists must never contain duplicated entries, and group
+ * sessions must not leak into the friend collection.
+ * Issue #646: scheduled HTML exports must keep the self-contained option when a
+ * task is created and when it is loaded back into the wizard form.
+ */
+
+import { test, expect } from '@playwright/test';
+import { dedupeFriends, dedupeGroups, dedupeSessionItems } from '@/lib/session-dedupe';
+import { buildSpecialFriends } from '@/lib/special-contacts';
+import { scheduledExportConfigToForm, scheduledExportFormToConfig } from '@/hooks/use-scheduled-exports';
+import type { CreateScheduledExportForm, Friend, Group, RecentContact } from '@/types/api';
+
+test.describe('session deduplication (issue #649)', () => {
+    test('groups and friends keep the first occurrence of every identity', () => {
+        const groups = [
+            { groupCode: '111', groupName: 'A' },
+            { groupCode: '222', groupName: 'B' },
+            { groupCode: '111', groupName: 'A copy' },
+        ] as Group[];
+        expect(dedupeGroups(groups).map((g) => g.groupName)).toEqual(['A', 'B']);
+
+        const friends = [
+            { uid: 'u_a', uin: 1, nick: 'A' },
+            { uid: 'u_a', uin: 1, nick: 'A copy' },
+            { uid: '', uin: 2, nick: 'B' },
+        ] as Friend[];
+        expect(dedupeFriends(friends).map((f) => f.nick)).toEqual(['A', 'B']);
+    });
+
+    test('same id in different session types stays separate', () => {
+        const items = [
+            { id: '123', type: 'group' as const },
+            { id: '123', type: 'friend' as const },
+            { id: '123', type: 'group' as const },
+        ];
+        expect(dedupeSessionItems(items)).toHaveLength(2);
+    });
+
+    test('special contacts exclude groups and already known sessions', () => {
+        const contacts = [
+            { chatType: 2, peerUid: '111', peerUin: '111', classification: 'special' },
+            { chatType: 1, peerUid: 'u_known', peerUin: '900', classification: 'special' },
+            { chatType: 1, peerUid: 'u_bot', peerUin: '901', classification: 'special' },
+            { chatType: 1, peerUid: 'u_friend', peerUin: '902', classification: 'friend' },
+        ] as RecentContact[];
+
+        const specials = buildSpecialFriends(contacts, new Set(['u_known']));
+
+        expect(specials.map((f) => f.uid)).toEqual(['u_bot']);
+    });
+});
+
+test.describe('scheduled self-contained HTML (issue #646)', () => {
+    const baseForm: CreateScheduledExportForm = {
+        name: 'nightly',
+        chatType: 2,
+        peerUid: '111',
+        sessionName: '测试群',
+        format: 'HTML',
+        scheduleType: 'daily',
+        executeTime: '02:00',
+        timeRangeType: 'yesterday',
+        enabled: true,
+        embedResourcesAsDataUri: true,
+    };
+
+    test('form option is persisted into the task options and read back', () => {
+        const config = scheduledExportFormToConfig(baseForm);
+        expect(config.options.embedResourcesAsDataUri).toBe(true);
+
+        const form = scheduledExportConfigToForm(config);
+        expect(form.embedResourcesAsDataUri).toBe(true);
+    });
+
+    test('option defaults to disabled when the form does not set it', () => {
+        const config = scheduledExportFormToConfig({ ...baseForm, embedResourcesAsDataUri: undefined });
+        expect(config.options.embedResourcesAsDataUri).toBe(false);
+    });
+});

--- a/qce-v4-tool/hooks/use-chat-data.ts
+++ b/qce-v4-tool/hooks/use-chat-data.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from "react"
 import type { Group, Friend, GroupsResponse, FriendsResponse, RecentContactsResponse } from "@/types/api"
 import { useApi } from "./use-api"
 import { buildSpecialFriends } from "@/lib/special-contacts"
+import { dedupeFriends, dedupeGroups } from "@/lib/session-dedupe"
 
 export interface AvatarExportResult {
   success: boolean
@@ -55,7 +56,7 @@ export function useChatData() {
 
           if (hasMore) {
             currentPage++
-            setGroups([...allGroups])
+            setGroups(dedupeGroups(allGroups))
           } else {
             break
           }
@@ -64,7 +65,8 @@ export function useChatData() {
         }
       }
 
-      setGroups(allGroups)
+      // Issue #649：分页结果可能重复包含同一个群，去重后再进入 UI。
+      setGroups(dedupeGroups(allGroups))
       setLoadProgress(null)
       console.log(`[QCE] 已加载 ${allGroups.length} 个群组`)
 
@@ -102,7 +104,7 @@ export function useChatData() {
 
           if (hasMore) {
             currentPage++
-            setFriends([...allFriends])
+            setFriends(dedupeFriends(allFriends))
           } else {
             break
           }
@@ -128,7 +130,11 @@ export function useChatData() {
           }
           setRecentActivityMap(activityMap)
 
-          const existingUids = new Set(allFriends.map((f) => f.uid))
+          // Issue #649：同时用 uid 和 uin 判断是否已存在，避免同一会话被特殊会话
+          // 合并逻辑再插一遍。
+          const existingUids = new Set(
+            allFriends.flatMap((f) => [f.uid, f.uin ? String(f.uin) : ""]).filter(Boolean),
+          )
           const specialFriends = buildSpecialFriends(recentResp.data.contacts, existingUids)
 
           if (specialFriends.length > 0) {
@@ -140,7 +146,7 @@ export function useChatData() {
         console.warn("[QCE] 加载最近联系人失败，跳过特殊会话合并:", recentErr)
       }
 
-      setFriends(allFriends)
+      setFriends(dedupeFriends(allFriends))
       setLoadProgress(null)
       console.log(`[QCE] 已加载 ${allFriends.length} 个好友`)
 

--- a/qce-v4-tool/hooks/use-export-task-plans.ts
+++ b/qce-v4-tool/hooks/use-export-task-plans.ts
@@ -5,13 +5,14 @@
  *
  * - 任务（导出任务计划）、群标签、运行记录的本地持久化（localStorage）。
  * - 执行引擎：解析群集合 → 自动拆分批次的顺序执行，实时回写进度。
- *   当前环境无后端任务接口时以本地模拟执行完成闭环；接入服务端后
- *   只需将 executeBatch 替换为对 /api/export-task-plans/:id/run 的调用。
+ *   每个群调用 `POST /api/messages/export` 创建真实导出任务，再轮询
+ *   `GET /api/tasks/:taskId` 等待结果，失败原因写入运行记录。
  * - 失败恢复：runPlan({ onlyGroupCodes }) 仅重跑指定群。
  */
 
 import { useState, useEffect, useCallback, useMemo, useRef } from "react"
-import type { Group } from "@/types/api"
+import type { ExportTask, Group } from "@/types/api"
+import { useApi } from "./use-api"
 import {
   DEFAULT_BATCH_SIZE,
   ExportTaskPlan,
@@ -31,6 +32,31 @@ const LS_RUNS = "qce-export-task-runs-v1"
 const LS_KNOWN_GROUPS = "qce-known-groups-v1"
 const MAX_RUNS_PER_PLAN = 30
 const MAX_KNOWN_GROUPS = 500
+/** 单群导出轮询间隔（毫秒）。 */
+const TASK_POLL_INTERVAL_MS = 2_000
+/** 单群导出等待上限（毫秒），超时当作失败并进入失败列表。 */
+const TASK_WAIT_TIMEOUT_MS = 6 * 60 * 60 * 1_000
+const DAY_SECONDS = 86_400
+
+/**
+ * Issue #641：旧版本提供过「载入示例数据」，写入的示例任务与虚构群会一直占着
+ * 任务列表和群组选择器，用户看不到也选不了自己的群。示例数据已经移除，
+ * 这里只负责把本地残留的示例记录清掉（真实任务的 ID 不使用这些前缀）。
+ */
+const DEMO_PLAN_IDS = new Set(["plan_demo_school", "plan_demo_games", "plan_demo_txt"])
+const DEMO_RUN_ID_PREFIX = "run_demo_"
+
+function demoGroupCodes(): Set<string> {
+  const codes = new Set<string>()
+  for (const [prefix, count] of [
+    ["81", 8],
+    ["82", 6],
+    ["83", 6],
+  ] as Array<[string, number]>) {
+    for (let i = 0; i < count; i += 1) codes.add(`${prefix}${100_000 + i * 137}`)
+  }
+  return codes
+}
 
 function readLS<T>(key: string, fallback: T): T {
   if (typeof window === "undefined") return fallback
@@ -67,13 +93,34 @@ export function useExportTaskPlans(liveGroups: Group[] = []) {
   /** 正在运行的计划 ID -> run ID */
   const [activeRuns, setActiveRuns] = useState<Record<string, string>>({})
   const cancelRef = useRef<Set<string>>(new Set())
+  const { apiCall } = useApi()
 
   // ---------------- hydration ----------------
   useEffect(() => {
-    setPlans(readLS<ExportTaskPlan[]>(LS_PLANS, []))
-    setGroupTags(readLS<GroupTagMap>(LS_TAGS, {}))
-    setRuns(readLS<ExportTaskRun[]>(LS_RUNS, []))
-    setKnownGroups(readLS<Group[]>(LS_KNOWN_GROUPS, []))
+    const storedPlans = readLS<ExportTaskPlan[]>(LS_PLANS, [])
+    const storedTags = readLS<GroupTagMap>(LS_TAGS, {})
+    const storedRuns = readLS<ExportTaskRun[]>(LS_RUNS, [])
+    const storedGroups = readLS<Group[]>(LS_KNOWN_GROUPS, [])
+
+    const demoCodes = demoGroupCodes()
+    const cleanPlans = storedPlans.filter((p) => !DEMO_PLAN_IDS.has(p.id))
+    const cleanRuns = storedRuns.filter(
+      (r) => !r.id.startsWith(DEMO_RUN_ID_PREFIX) && !DEMO_PLAN_IDS.has(r.planId),
+    )
+    const cleanGroups = storedGroups.filter((g) => !demoCodes.has(g.groupCode))
+    const cleanTags = Object.fromEntries(
+      Object.entries(storedTags).filter(([code]) => !demoCodes.has(code)),
+    )
+
+    if (cleanPlans.length !== storedPlans.length) writeLS(LS_PLANS, cleanPlans)
+    if (cleanRuns.length !== storedRuns.length) writeLS(LS_RUNS, cleanRuns)
+    if (cleanGroups.length !== storedGroups.length) writeLS(LS_KNOWN_GROUPS, cleanGroups)
+    if (Object.keys(cleanTags).length !== Object.keys(storedTags).length) writeLS(LS_TAGS, cleanTags)
+
+    setPlans(cleanPlans)
+    setGroupTags(cleanTags)
+    setRuns(cleanRuns)
+    setKnownGroups(cleanGroups)
     setHydrated(true)
   }, [])
 
@@ -195,19 +242,101 @@ export function useExportTaskPlans(liveGroups: Group[] = []) {
     [],
   )
 
-  /**
-   * 执行单个批次。
-   * TODO(backend): 替换为对服务端批量导出接口的调用，并按返回结果构造失败列表。
-   * 本地模式下批次内全部成功。
-   */
-  const executeBatch = useCallback(
-    async (_plan: ExportTaskPlan, batch: ExportTaskRunBatch): Promise<ExportTaskRunFailure[]> => {
-      // 模拟批次执行耗时，驱动 UI 进度动画
-      const cost = 420 + Math.min(batch.groupCodes.length, 20) * 36 + Math.random() * 240
-      await new Promise((r) => setTimeout(r, cost))
-      return []
+  /** 轮询导出任务直到结束，返回失败原因；成功返回 null。 */
+  const waitForTask = useCallback(
+    async (taskId: string, runId: string): Promise<string | null> => {
+      const deadline = Date.now() + TASK_WAIT_TIMEOUT_MS
+      while (Date.now() < deadline) {
+        if (cancelRef.current.has(runId)) return "任务已取消"
+        await new Promise((resolve) => setTimeout(resolve, TASK_POLL_INTERVAL_MS))
+        const resp = await apiCall<ExportTask>(`/api/tasks/${encodeURIComponent(taskId)}`)
+        if (!resp.success || !resp.data) continue
+        const task = resp.data
+        if (task.status === "completed") return null
+        if (task.status === "failed") return task.error || "导出失败"
+        if (task.status === "cancelled") return "导出任务被取消"
+      }
+      return "等待导出结果超时"
     },
-    [],
+    [apiCall],
+  )
+
+  /** 导出单个群，返回失败原因；成功返回 null。 */
+  const exportGroup = useCallback(
+    async (plan: ExportTaskPlan, group: { groupCode: string; groupName: string }, runId: string) => {
+      const nowSeconds = Math.floor(Date.now() / 1000)
+      // 增量导出：从该群上次导出到的位置继续；否则按任务的时间范围类型。
+      const incrementalFrom = plan.incremental ? plan.progress?.[group.groupCode] : undefined
+      let startTime = incrementalFrom
+      let endTime: number | undefined
+      if (startTime === undefined) {
+        if (plan.timeRangeType === "last-7-days") startTime = nowSeconds - 7 * DAY_SECONDS
+        else if (plan.timeRangeType === "last-30-days") startTime = nowSeconds - 30 * DAY_SECONDS
+        else if (plan.timeRangeType === "custom" && plan.customTimeRange) {
+          startTime = plan.customTimeRange.startTime
+          endTime = plan.customTimeRange.endTime
+        }
+      }
+
+      const outputDir = plan.outputDir?.trim()
+      const body = {
+        peer: { chatType: 2, peerUid: group.groupCode, guildId: "" },
+        sessionName: group.groupName || group.groupCode,
+        format: plan.format,
+        filter: {
+          ...(startTime !== undefined && { startTime }),
+          ...(endTime !== undefined && { endTime }),
+          includeRecalled: false,
+        },
+        options: {
+          batchSize: 5000,
+          prettyFormat: true,
+          useFriendlyFileName: true,
+          includeResourceLinks: plan.options.includeResourceLinks,
+          includeSystemMessages: plan.options.includeSystemMessages,
+          filterPureImageMessages: plan.options.filterPureImageMessages,
+          preferGroupMemberName: plan.options.preferGroupMemberName,
+          ...(outputDir && { outputDir }),
+        },
+      }
+
+      try {
+        const resp = await apiCall<{ taskId?: string }>("/api/messages/export", {
+          method: "POST",
+          body: JSON.stringify(body),
+        })
+        if (!resp.success) return resp.error?.message || "创建导出任务失败"
+        const taskId = resp.data?.taskId
+        // 没有 taskId 说明服务端同步完成，无需轮询。
+        if (!taskId) return null
+        return await waitForTask(taskId, runId)
+      } catch (err) {
+        return err instanceof Error ? err.message : "创建导出任务失败"
+      }
+    },
+    [apiCall, waitForTask],
+  )
+
+  /** 顺序执行单个批次内的每个群，返回失败列表。 */
+  const executeBatch = useCallback(
+    async (
+      plan: ExportTaskPlan,
+      batch: ExportTaskRunBatch,
+      runId: string,
+    ): Promise<ExportTaskRunFailure[]> => {
+      const failures: ExportTaskRunFailure[] = []
+      for (const [index, groupCode] of batch.groupCodes.entries()) {
+        const groupName = batch.groupNames[index] || groupCode
+        if (cancelRef.current.has(runId)) {
+          failures.push({ groupCode, groupName, reason: "任务已取消" })
+          continue
+        }
+        const reason = await exportGroup(plan, { groupCode, groupName }, runId)
+        if (reason) failures.push({ groupCode, groupName, reason })
+      }
+      return failures
+    },
+    [exportGroup],
   )
 
   const runPlan = useCallback(
@@ -276,7 +405,7 @@ export function useExportTaskPlans(liveGroups: Group[] = []) {
           batches: r.batches.map((b) => (b.index === batch.index ? { ...b, status: "running" } : b)),
         }))
 
-        const batchFailures = await executeBatch(plan, batch)
+        const batchFailures = await executeBatch(plan, batch, run.id)
 
         const batchFailed = batchFailures.length
         const batchSuccess = batch.groupCodes.length - batchFailed
@@ -398,25 +527,6 @@ export function useExportTaskPlans(liveGroups: Group[] = []) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hydrated, runs.length])
 
-  // ---------------- 示例数据 ----------------
-
-  /** 载入示例任务（空状态下的一键体验数据） */
-  const seedDemoData = useCallback(() => {
-    if (plans.length > 0) return false
-    const demo = buildDemoPayload()
-    persistPlans(demo.plans)
-    persistTags(demo.groupTags)
-    persistRuns(demo.runs)
-    setKnownGroups((prev) => {
-      const map = new Map(prev.map((g) => [g.groupCode, g]))
-      for (const g of demo.groups) if (!map.has(g.groupCode)) map.set(g.groupCode, g)
-      const merged = Array.from(map.values())
-      writeLS(LS_KNOWN_GROUPS, merged)
-      return merged
-    })
-    return true
-  }, [plans.length, persistPlans, persistTags, persistRuns])
-
   return {
     hydrated,
     plans,
@@ -437,248 +547,5 @@ export function useExportTaskPlans(liveGroups: Group[] = []) {
     setGroupTagList,
     toggleGroupTag,
     deleteTag,
-    seedDemoData,
-  }
-}
-
-// ---------------------------------------------------------------------------
-// 示例数据
-// ---------------------------------------------------------------------------
-
-function buildDemoPayload(): {
-  plans: ExportTaskPlan[]
-  runs: ExportTaskRun[]
-  groupTags: GroupTagMap
-  groups: Group[]
-} {
-  const now = Date.now()
-  const day = 86_400_000
-  const iso = (t: number) => new Date(t).toISOString()
-
-  const school = [
-    "高三（2）班家长群",
-    "高三年级通知群",
-    "班级家委会",
-    "数学竞赛兴趣小组",
-    "英语角交流群",
-    "校学生会大群",
-    "社团联合会",
-    "图书馆志愿者",
-  ]
-  const games = ["原神锄地大队", "王者开黑群", "Steam 拼车群", "Switch 同好会", "独立游戏品鉴", "电竞赛事讨论"]
-  const interests = ["摄影扫街小分队", "周末骑行俱乐部", "手冲咖啡研究所", "二次元同好会", "读书会·周六场", "城市徒步联盟"]
-
-  const groups: Group[] = []
-  const groupTags: GroupTagMap = {}
-  const push = (name: string, tag: string, i: number, prefix: string) => {
-    const groupCode = `${prefix}${(100000 + i * 137).toString()}`
-    groups.push({
-      groupCode,
-      groupName: name,
-      memberCount: 48 + ((i * 37) % 450),
-      maxMember: 500,
-    })
-    groupTags[groupCode] = [tag]
-  }
-  school.forEach((n, i) => push(n, "学校", i, "81"))
-  games.forEach((n, i) => push(n, "游戏", i, "82"))
-  interests.forEach((n, i) => push(n, "兴趣", i, "83"))
-
-  const tagGroups = (tag: string) => groups.filter((g) => (groupTags[g.groupCode] || []).includes(tag))
-
-  const schoolRefs = tagGroups("学校").map((g) => ({
-    groupCode: g.groupCode,
-    groupName: g.groupName,
-    memberCount: g.memberCount,
-  }))
-
-  // 任务一：标签关联，最近一次部分失败
-  const planA: ExportTaskPlan = {
-    id: "plan_demo_school",
-    name: "学校交流群备份",
-    description: "每周备份班级群与社团群文字消息，用于期末整理归档",
-    sourceMode: "tags",
-    fixedGroups: [],
-    tags: ["学校"],
-    format: "JSON",
-    options: {
-      includeResourceLinks: false,
-      includeSystemMessages: true,
-      filterPureImageMessages: true,
-      preferGroupMemberName: true,
-    },
-    outputDir: "backups/school",
-    incremental: true,
-    timeRangeType: "all",
-    batchSize: 5,
-    createdAt: iso(now - 32 * day),
-    updatedAt: iso(now - 1 * day),
-    progress: Object.fromEntries(schoolRefs.map((r) => [r.groupCode, Math.floor((now - day) / 1000)])),
-  }
-
-  // 任务一的最近一次运行：8 群，6 成功 2 失败
-  const failedA = schoolRefs.slice(5, 7)
-  const runA: ExportTaskRun = {
-    id: "run_demo_school_1",
-    planId: planA.id,
-    planName: planA.name,
-    trigger: "manual",
-    status: "partial",
-    startedAt: iso(now - day - 3_600_000),
-    finishedAt: iso(now - day - 3_540_000),
-    durationMs: 60_000,
-    total: schoolRefs.length,
-    success: schoolRefs.length - failedA.length,
-    failed: failedA.length,
-    batches: [
-      {
-        index: 0,
-        groupCodes: schoolRefs.slice(0, 5).map((r) => r.groupCode),
-        groupNames: schoolRefs.slice(0, 5).map((r) => r.groupName),
-        status: "success",
-      },
-      {
-        index: 1,
-        groupCodes: schoolRefs.slice(5).map((r) => r.groupCode),
-        groupNames: schoolRefs.slice(5).map((r) => r.groupName),
-        status: "partial",
-        failedGroupCodes: failedA.map((r) => r.groupCode),
-        error: "批次内部分群导出失败",
-      },
-    ],
-    failures: [
-      { groupCode: failedA[0].groupCode, groupName: failedA[0].groupName, reason: "消息拉取超时（单群消息量过大）" },
-      { groupCode: failedA[1].groupCode, groupName: failedA[1].groupName, reason: "账号被临时风控，群消息接口受限" },
-    ],
-  }
-  planA.lastRun = {
-    runId: runA.id,
-    at: runA.finishedAt!,
-    status: "partial",
-    total: runA.total,
-    success: runA.success,
-    failed: runA.failed,
-  }
-
-  // 任务一更早的一次成功运行
-  const runA0: ExportTaskRun = {
-    id: "run_demo_school_0",
-    planId: planA.id,
-    planName: planA.name,
-    trigger: "manual",
-    status: "success",
-    startedAt: iso(now - 8 * day),
-    finishedAt: iso(now - 8 * day + 54_000),
-    durationMs: 54_000,
-    total: schoolRefs.length,
-    success: schoolRefs.length,
-    failed: 0,
-    batches: [
-      {
-        index: 0,
-        groupCodes: schoolRefs.slice(0, 5).map((r) => r.groupCode),
-        groupNames: schoolRefs.slice(0, 5).map((r) => r.groupName),
-        status: "success",
-      },
-      {
-        index: 1,
-        groupCodes: schoolRefs.slice(5).map((r) => r.groupCode),
-        groupNames: schoolRefs.slice(5).map((r) => r.groupName),
-        status: "success",
-      },
-    ],
-    failures: [],
-  }
-
-  // 任务二：混合来源，从未运行
-  const fixedB = tagGroups("游戏").slice(0, 3).map((g) => ({
-    groupCode: g.groupCode,
-    groupName: g.groupName,
-    memberCount: g.memberCount,
-  }))
-  const planB: ExportTaskPlan = {
-    id: "plan_demo_games",
-    name: "游戏群精华存档",
-    description: "固定三个开黑群 + 所有 #兴趣 标签群",
-    sourceMode: "mixed",
-    fixedGroups: fixedB,
-    tags: ["兴趣"],
-    format: "HTML",
-    options: {
-      includeResourceLinks: true,
-      includeSystemMessages: false,
-      filterPureImageMessages: false,
-      preferGroupMemberName: true,
-    },
-    outputDir: "",
-    incremental: false,
-    timeRangeType: "last-30-days",
-    batchSize: 5,
-    createdAt: iso(now - 6 * day),
-    updatedAt: iso(now - 6 * day),
-  }
-
-  // 任务三：固定群，上次全部成功
-  const fixedC = tagGroups("游戏").map((g) => ({
-    groupCode: g.groupCode,
-    groupName: g.groupName,
-    memberCount: g.memberCount,
-  }))
-  const planC: ExportTaskPlan = {
-    id: "plan_demo_txt",
-    name: "游戏群文字记录（TXT）",
-    sourceMode: "fixed",
-    fixedGroups: fixedC,
-    tags: [],
-    format: "TXT",
-    options: {
-      includeResourceLinks: false,
-      includeSystemMessages: false,
-      filterPureImageMessages: true,
-      preferGroupMemberName: false,
-    },
-    incremental: true,
-    timeRangeType: "all",
-    batchSize: 10,
-    createdAt: iso(now - 20 * day),
-    updatedAt: iso(now - 2 * day),
-    progress: Object.fromEntries(fixedC.map((r) => [r.groupCode, Math.floor((now - 2 * day) / 1000)])),
-  }
-  const runC: ExportTaskRun = {
-    id: "run_demo_txt_1",
-    planId: planC.id,
-    planName: planC.name,
-    trigger: "manual",
-    status: "success",
-    startedAt: iso(now - 2 * day - 40_000),
-    finishedAt: iso(now - 2 * day),
-    durationMs: 40_000,
-    total: fixedC.length,
-    success: fixedC.length,
-    failed: 0,
-    batches: [
-      {
-        index: 0,
-        groupCodes: fixedC.map((r) => r.groupCode),
-        groupNames: fixedC.map((r) => r.groupName),
-        status: "success",
-      },
-    ],
-    failures: [],
-  }
-  planC.lastRun = {
-    runId: runC.id,
-    at: runC.finishedAt!,
-    status: "success",
-    total: runC.total,
-    success: runC.success,
-    failed: 0,
-  }
-
-  return {
-    plans: [planA, planB, planC],
-    runs: [runA, runA0, runC],
-    groupTags,
-    groups,
   }
 }

--- a/qce-v4-tool/hooks/use-scheduled-exports.ts
+++ b/qce-v4-tool/hooks/use-scheduled-exports.ts
@@ -30,6 +30,8 @@ export interface ScheduledExportConfig {
         preferGroupMemberName?: boolean;
         debugExport?: boolean;
         skipDownloadResourceTypes?: Array<'image' | 'video' | 'audio' | 'file'>;
+        /** Issue #646: 定时 HTML 导出把资源 base64 内联，生成自包含单文件。 */
+        embedResourcesAsDataUri?: boolean;
     };
     outputDir?: string;
     enabled: boolean;
@@ -61,6 +63,7 @@ export function scheduledExportFormToConfig(formData: CreateScheduledExportForm)
             prettyFormat: true,
             preferGroupMemberName: formData.preferGroupMemberName ?? true,
             debugExport: formData.debugExport ?? false,
+            embedResourcesAsDataUri: formData.embedResourcesAsDataUri ?? false,
             ...(Array.isArray(formData.skipDownloadResourceTypes) && formData.skipDownloadResourceTypes.length > 0 && {
                 skipDownloadResourceTypes: formData.skipDownloadResourceTypes,
             }),
@@ -91,6 +94,7 @@ export function scheduledExportConfigToForm(task: ScheduledExportConfig): Create
         preferGroupMemberName: task.options.preferGroupMemberName ?? true,
         debugExport: task.options.debugExport ?? false,
         skipDownloadResourceTypes: task.options.skipDownloadResourceTypes,
+        embedResourcesAsDataUri: task.options.embedResourcesAsDataUri ?? false,
     };
 }
 

--- a/qce-v4-tool/hooks/use-session-filter.ts
+++ b/qce-v4-tool/hooks/use-session-filter.ts
@@ -8,6 +8,7 @@ import {
   type SortField,
   type SortOrder,
 } from "@/lib/session-sort"
+import { dedupeSessionItems } from "@/lib/session-dedupe"
 
 export type SessionType = 'all' | 'group' | 'friend'
 export type { SortField, SortOrder }
@@ -156,7 +157,8 @@ export function useSessionFilter(
       }
     })
 
-    return [...groupItems, ...friendItems]
+    // Issue #649：任何上游数据源重复都不应让会话列表出现两条相同记录。
+    return dedupeSessionItems([...groupItems, ...friendItems])
   }, [groups, friends, recentActivityMap, taskStatsMap])
 
   const sortedItems = useMemo<SessionItem[]>(() => {

--- a/qce-v4-tool/lib/session-dedupe.ts
+++ b/qce-v4-tool/lib/session-dedupe.ts
@@ -1,0 +1,38 @@
+import type { Friend, Group } from "@/types/api"
+
+/**
+ * 会话去重工具（Issue #649）。
+ *
+ * 群列表 / 好友列表来自多个来源：分页拉取（可能重复追加同一页）、NapCat 缓存与
+ * 实时列表合并、最近联系人补充的特殊会话。任何一处重复都会让会话列表出现两条
+ * 完全一样的记录，因此在进入 UI 之前按稳定身份键统一去重，保留首次出现的条目。
+ */
+
+function dedupeBy<T>(items: T[], key: (item: T) => string): T[] {
+  const seen = new Set<string>()
+  const result: T[] = []
+  for (const item of items) {
+    const id = key(item)
+    if (id && seen.has(id)) continue
+    if (id) seen.add(id)
+    result.push(item)
+  }
+  return result
+}
+
+/** 按群号去重。 */
+export function dedupeGroups(groups: Group[]): Group[] {
+  return dedupeBy(groups, (g) => g.groupCode ?? "")
+}
+
+/** 按 uid 去重；uid 缺失时退回 uin。 */
+export function dedupeFriends(friends: Friend[]): Friend[] {
+  return dedupeBy(friends, (f) => f.uid || (f.uin ? String(f.uin) : ""))
+}
+
+/** 按「会话类型 + 会话 ID」去重，群与好友即使 ID 相同也互不影响。 */
+export function dedupeSessionItems<T extends { id: string; type: "group" | "friend" }>(
+  items: T[],
+): T[] {
+  return dedupeBy(items, (item) => `${item.type}:${item.id}`)
+}

--- a/qce-v4-tool/lib/special-contacts.ts
+++ b/qce-v4-tool/lib/special-contacts.ts
@@ -65,7 +65,14 @@ export function buildSpecialFriends(
   existingUids: Set<string>,
 ): Friend[] {
   return contacts
-    .filter((c) => c.classification === "special" && !existingUids.has(c.peerUid))
+    .filter(
+      (c) =>
+        c.classification === "special" &&
+        // Issue #649：群会话属于群列表，不能被当成好友再插一遍。
+        c.chatType !== 2 &&
+        !existingUids.has(c.peerUid) &&
+        !(c.peerUin && existingUids.has(String(c.peerUin))),
+    )
     .map((c) => {
       const specialKind = classifySpecialChatType(c.chatType)
       const isDevice = specialKind === "device"

--- a/qce-v4-tool/types/api.ts
+++ b/qce-v4-tool/types/api.ts
@@ -439,6 +439,8 @@ export interface CreateScheduledExportForm {
   debugExport?: boolean
   /** Issue #341: 仅保留元数据、跳过下载的资源类型 */
   skipDownloadResourceTypes?: Array<'image' | 'video' | 'audio' | 'file'>
+  /** Issue #646: 定时 HTML 导出把图片等资源 base64 内联，生成自包含单文件。 */
+  embedResourcesAsDataUri?: boolean
 }
 
 export interface ScheduledExportsResponse {

--- a/qq-chat-export-server/src/api/routes/friends.rs
+++ b/qq-chat-export-server/src/api/routes/friends.rs
@@ -317,6 +317,29 @@ fn map_friend(friend: &Value, category_id: &Value) -> Value {
     })
 }
 
+/// 把 NapCat 的分组好友结构展开成扁平列表。
+///
+/// Issue #649：同一个好友可以同时出现在多个分组里，按 uid 去重，避免会话列表出现
+/// 重复条目。
+fn flatten_friend_categories(categories: &[Value]) -> Vec<Value> {
+    let mut seen_uids: HashSet<String> = HashSet::new();
+    let mut friends: Vec<Value> = Vec::new();
+    for cat in categories {
+        let category_id = cat.get("categoryId").cloned().unwrap_or(Value::Null);
+        if let Some(list) = cat.get("buddyList").and_then(Value::as_array) {
+            for friend in list {
+                let mapped = map_friend(friend, &category_id);
+                let uid = str_of(&mapped, "uid");
+                if !uid.is_empty() && !seen_uids.insert(uid) {
+                    continue;
+                }
+                friends.push(mapped);
+            }
+        }
+    }
+    friends
+}
+
 /// `GET /api/friends` — 好友列表（分页）。
 pub async fn list_friends(
     State(state): State<SharedState>,
@@ -336,15 +359,7 @@ pub async fn list_friends(
 
     let empty: Vec<Value> = Vec::new();
     let cats = categories.as_array().unwrap_or(&empty);
-    let mut friends: Vec<Value> = Vec::new();
-    for cat in cats {
-        let category_id = cat.get("categoryId").cloned().unwrap_or(Value::Null);
-        if let Some(list) = cat.get("buddyList").and_then(Value::as_array) {
-            for friend in list {
-                friends.push(map_friend(friend, &category_id));
-            }
-        }
-    }
+    let friends = flatten_friend_categories(cats);
 
     let total = friends.len();
     let start_index = (page - 1).saturating_mul(limit);
@@ -532,6 +547,34 @@ mod tests {
             recent_contact_limit(&HashMap::from([("limit".to_string(), "9000".to_string())])),
             2_000
         );
+    }
+
+    #[test]
+    fn flattened_friends_are_deduplicated_across_categories() {
+        let categories = vec![
+            json!({
+                "categoryId": 0,
+                "buddyList": [
+                    {"coreInfo": {"uid": "u_a", "uin": "1001", "nick": "A"}},
+                    {"coreInfo": {"uid": "u_b", "uin": "1002", "nick": "B"}},
+                ],
+            }),
+            json!({
+                "categoryId": 1,
+                "buddyList": [
+                    {"coreInfo": {"uid": "u_a", "uin": "1001", "nick": "A"}},
+                    {"coreInfo": {"uid": "u_c", "uin": "1003", "nick": "C"}},
+                ],
+            }),
+        ];
+
+        let friends = flatten_friend_categories(&categories);
+
+        assert_eq!(friends.len(), 3);
+        assert_eq!(friends[0]["uid"], "u_a");
+        assert_eq!(friends[0]["categoryId"], 0);
+        assert_eq!(friends[1]["uid"], "u_b");
+        assert_eq!(friends[2]["uid"], "u_c");
     }
 
     #[test]

--- a/qq-chat-export-server/src/api/routes/groups.rs
+++ b/qq-chat-export-server/src/api/routes/groups.rs
@@ -178,8 +178,17 @@ pub async fn list_groups(
     let empty: Vec<Value> = Vec::new();
     let list = groups.as_array().unwrap_or(&empty);
 
+    // Issue #649：NapCat 缓存与实时列表合并后可能出现同一个群，按群号去重。
+    let mut seen_codes: HashSet<String> = HashSet::new();
     let groups_with_avatars: Vec<Value> = list
         .iter()
+        .filter(|group| {
+            let code = group
+                .get("groupCode")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            code.is_empty() || seen_codes.insert(code.to_string())
+        })
         .map(|group| {
             let code = group
                 .get("groupCode")

--- a/qq-chat-export-server/src/paths/mod.rs
+++ b/qq-chat-export-server/src/paths/mod.rs
@@ -140,6 +140,31 @@ impl PathManager {
         self.default_export_root_dir().join("scheduled-exports")
     }
 
+    /// 导出目录允许的根集合。
+    ///
+    /// Issue #644：任务级自定义导出目录可以位于默认导出根之外（例如另一个盘），
+    /// 校验策略与设置页的自定义导出目录一致：必须是绝对路径，且不能落在系统关键
+    /// 目录里。不满足时只返回默认导出根，请求会被上层按越界路径拒绝。
+    pub fn export_output_roots(&self, requested: Option<&str>) -> Vec<PathBuf> {
+        let mut roots = vec![self.exports_dir(), self.scheduled_exports_dir()];
+        if let Some(raw) = requested {
+            let sanitized = Self::sanitize_path(raw);
+            let path = Path::new(&sanitized);
+            let has_parent_component = path
+                .components()
+                .any(|c| matches!(c, std::path::Component::ParentDir))
+                || sanitized.split(['/', '\\']).any(|segment| segment == "..");
+            if !sanitized.is_empty() && path.is_absolute() && !has_parent_component {
+                if let Ok(dir) = Self::validate_path(&sanitized) {
+                    if !roots.contains(&dir) {
+                        roots.push(dir);
+                    }
+                }
+            }
+        }
+        roots
+    }
+
     /// 资源目录。
     pub fn resources_dir(&self) -> PathBuf {
         self.default_base_dir().join("resources")
@@ -299,6 +324,27 @@ mod tests {
             .set_custom_output_dir(Some("C:\\Windows\\System32\\x"))
             .is_err());
         assert!(pm.set_custom_output_dir(Some("/home/user/exports")).is_ok());
+    }
+
+    #[test]
+    fn custom_export_roots_extend_allowed_roots_for_absolute_safe_paths() {
+        let pm = PathManager::new();
+        let defaults = pm.export_output_roots(None);
+        assert_eq!(defaults.len(), 2);
+
+        let custom = if cfg!(windows) {
+            "D:\\stampBOT\\data"
+        } else {
+            "/data/stampbot"
+        };
+        let roots = pm.export_output_roots(Some(custom));
+        assert_eq!(roots.len(), 3);
+        assert_eq!(roots[2], PathBuf::from(custom));
+
+        // 相对路径与系统关键目录不会成为允许的根。
+        assert_eq!(pm.export_output_roots(Some("relative/dir")).len(), 2);
+        assert_eq!(pm.export_output_roots(Some("/etc/cron.d")).len(), 2);
+        assert_eq!(pm.export_output_roots(Some("   ")).len(), 2);
     }
 
     #[test]

--- a/qq-chat-export-server/src/scheduled_executor.rs
+++ b/qq-chat-export-server/src/scheduled_executor.rs
@@ -87,18 +87,12 @@ impl ScheduledExportExecutor for ApiScheduledExportExecutor {
             .unwrap_or("HTML")
             .to_uppercase();
         let options = task.get("options").cloned().unwrap_or(Value::Null);
-        let requested_output_dir = task
-            .get("outputDir")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map_or_else(|| self.path_manager.scheduled_exports_dir(), PathBuf::from);
-        let output_roots = [
-            self.path_manager.exports_dir(),
-            self.path_manager.scheduled_exports_dir(),
-        ];
-        let output_dir = resolve_for_creation_within(&requested_output_dir, &output_roots)
-            .ok_or_else(|| "定时导出目录不在允许的导出目录内".to_string())?;
+        // Issue #644：任务自带的输出目录可以指向默认导出根之外的位置（例如另一个盘），
+        // 由 `PathManager` 统一做安全校验后加入允许的根集合。
+        let output_dir = resolve_scheduled_output_dir(
+            &self.path_manager,
+            task.get("outputDir").and_then(Value::as_str),
+        )?;
         let debug_session = if options.get("debugExport").and_then(Value::as_bool) == Some(true) {
             let export_name = format!(
                 "scheduled-{}-{}",
@@ -580,9 +574,79 @@ fn to_value_resource_map(
         .collect()
 }
 
+/// 解析定时导出的输出目录。
+///
+/// Issue #644：任务自带的输出目录可以指向默认导出根之外的位置（例如另一个盘），
+/// 由 `PathManager` 统一做安全校验后加入允许的根集合；非法路径按越界拒绝。
+fn resolve_scheduled_output_dir(
+    path_manager: &PathManager,
+    raw_output_dir: Option<&str>,
+) -> Result<PathBuf, String> {
+    let configured = raw_output_dir
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(PathManager::sanitize_path)
+        .filter(|s| !s.is_empty());
+    let requested = configured
+        .as_deref()
+        .map_or_else(|| path_manager.scheduled_exports_dir(), PathBuf::from);
+    let roots = path_manager.export_output_roots(configured.as_deref());
+    resolve_for_creation_within(&requested, &roots)
+        .ok_or_else(|| "定时导出目录不在允许的导出目录内".to_string())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{reserve_scheduled_file_name, sanitize_task_name, scheduled_export_file_name};
+    use super::{
+        reserve_scheduled_file_name, resolve_for_creation_within, resolve_scheduled_output_dir,
+        sanitize_task_name, scheduled_export_file_name, PathBuf, PathManager,
+    };
+
+    #[test]
+    fn scheduled_output_dir_accepts_configured_dirs_outside_default_roots() {
+        let path_manager = PathManager::new();
+
+        // 默认导出根在 Windows 上会被 canonicalize 成 \\?\ 前缀形式，期望值同步规范化。
+        let default_dir = resolve_for_creation_within(
+            &path_manager.scheduled_exports_dir(),
+            &path_manager.export_output_roots(None),
+        )
+        .unwrap();
+        assert_eq!(
+            resolve_scheduled_output_dir(&path_manager, None).unwrap(),
+            default_dir
+        );
+        assert_eq!(
+            resolve_scheduled_output_dir(&path_manager, Some("   ")).unwrap(),
+            default_dir
+        );
+
+        let custom = if cfg!(windows) {
+            "D:\\stampBOT\\data"
+        } else {
+            "/data/stampbot"
+        };
+        // 自定义目录若已存在会被 canonicalize，统一按规范化结果比较。
+        let custom_expected = resolve_for_creation_within(
+            &PathBuf::from(custom),
+            &path_manager.export_output_roots(Some(custom)),
+        )
+        .unwrap();
+        assert_eq!(
+            resolve_scheduled_output_dir(&path_manager, Some(custom)).unwrap(),
+            custom_expected
+        );
+        // 引号包裹的粘贴路径同样可用。
+        assert_eq!(
+            resolve_scheduled_output_dir(&path_manager, Some(&format!("\"{custom}\""))).unwrap(),
+            custom_expected
+        );
+
+        // 相对路径、系统关键目录与父目录穿越都不会成为允许的根。
+        for rejected in ["relative/dir", "/etc/cron.d", "/data/../etc"] {
+            assert!(resolve_scheduled_output_dir(&path_manager, Some(rejected)).is_err());
+        }
+    }
 
     #[test]
     fn scheduled_names_are_readable_safe_and_reserved_concurrently() {


### PR DESCRIPTION
Batch of UI and export-setting fixes.

## Changes

- **#649** Session list duplicates: dedupe groups and friends on the server (`friends.rs`, `groups.rs`) and on the client (`lib/session-dedupe.ts`), and stop group chats from being merged into the friend collection via special contacts.
- **#646** Scheduled HTML export has no images: add a self-contained HTML option (`embedResourcesAsDataUri`) that inlines downloaded resources as base64, wired through the wizard, hook, types, and scheduled executor.
- **#643** Date range picker UX: controlled visible month plus year/month dropdown (2005 to current year) so the panel follows the selected date instead of staying on the first-render month.
- **#641** Export task plans: load the real group list on the plans tab, wire plan execution to the real export API with per-group polling, and remove demo/seed data.
- **#644** Custom export path: allow scheduled export directories outside the default roots via `PathManager::export_output_roots` validation.

Closes #649, closes #646, closes #643, closes #641.