### PR TITLE
fix(ui): 修复批量导出聊天记录时对话框配置会自动重置的问题

### DIFF
--- a/qce-v4-tool/components/ui/batch-export-dialog.tsx
+++ b/qce-v4-tool/components/ui/batch-export-dialog.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -78,6 +78,7 @@ export interface BatchExportProgress {
 
 
 export function BatchExportDialog({ open, onOpenChange, items, onExport }: BatchExportDialogProps) {
+  const didInitRef = useRef(false)
   const [format, setFormat] = useState<'HTML' | 'TXT' | 'JSON' | 'EXCEL'>('HTML')
   const [timeRange, setTimeRange] = useState<'all' | 'recent' | 'custom'>('all')
   const [customStartDate, setCustomStartDate] = useState('')
@@ -114,6 +115,7 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
 
   // 对话框打开时重置所有状态
   useEffect(() => {
+    if (didInitRef.current) return
     if (open) {
       setFormat('HTML')
       setTimeRange('all')
@@ -141,8 +143,15 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
         status: 'idle',
         results: items.map(item => ({ name: item.name, status: 'pending' }))
       })
+      didInitRef.current = true
     }
   }, [open, items])
+
+  useEffect(() => {
+    if (!open) {
+      didInitRef.current = false
+    }
+  }, [open])
 
   // 格式改变时自动调整filterPureImageMessages默认值，并重置格式专有选项
   useEffect(() => {


### PR DESCRIPTION
## 问题

`BatchExportDialog` 组件里的 `useEffect` 监听了 `[open, items]`（batch-export-dialog.tsx:116）。弹窗打开期间，只要 `items` 引用发生变化（比如父组件重渲染）：
- 用户改好的导出格式、时间范围、高级选项等会被全部还原成默认值；
- 正在进行中的导出进度（`progress`）也会被清空。

## 修复

增加 `didInitRef` 记录初始化状态：
- 仅在打开弹窗时执行一次重置，并将 `didInitRef.current` 设为 `true`；
- 弹窗打开期间，`items` 变化不会再触发重置，保留配置和进度；
- 弹窗关闭时将 `didInitRef.current` 重置为 `false`，确保下次打开时能重新初始化。

## 效果演示

| 修复前 | 修复后（是循环GIF） |
| :---: | :---: |
| <img width="300" height="300" alt="修复前" src="https://github.com/user-attachments/assets/5fa13468-1f65-4e5d-82b1-ad1279dfeffb" /> |<img width="300" height="300" alt="修复后" src="https://github.com/user-attachments/assets/9f02c839-23df-4c5e-a9a5-fcabbc44f973" /> |

## 触发条件

与后端通信时会发生重置。如下方GIF所示：
<img width="1240" height="1010" alt="QQ20260818-172136" src="https://github.com/user-attachments/assets/c741dc9d-94ee-4166-8c61-9a370fc3c7fd" />
