### PR TITLE
feat: 完善可复用导出任务配置并修复分页遮挡

### DIFF
--- a/qce-v4-tool/components/export-plans/plan-wizard.tsx
+++ b/qce-v4-tool/components/export-plans/plan-wizard.tsx
@@ -17,10 +17,13 @@ import { Switch } from "@/components/ui/switch"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Slider } from "@/components/ui/slider"
+import { DateRangePicker } from "@/components/ui/date-range-picker"
 import { toast } from "@/components/ui/use-toast"
 import type { useExportTaskPlans } from "@/hooks/use-export-task-plans"
+import { toggleSkipResourceType } from "@/lib/skip-resource-types"
 import {
   DEFAULT_BATCH_SIZE,
+  DEFAULT_EXPORT_TASK_PLAN_OPTIONS,
   MAX_BATCH_SIZE,
   MIN_BATCH_SIZE,
   ExportTaskPlan,
@@ -59,10 +62,31 @@ interface DraftState {
   includeSystemMessages: boolean
   filterPureImageMessages: boolean
   preferGroupMemberName: boolean
+  includeRecalled: boolean
+  debugExport: boolean
+  streamingZipMode: boolean
+  exportAsZip: boolean
+  embedAvatarsAsBase64: boolean
+  embedResourcesAsDataUri: boolean
+  skipDownloadResourceTypes?: Array<"image" | "video" | "audio" | "file">
+  useNameInFileName: boolean
+  useFriendlyFileName: boolean
+  keywords: string
+  excludeUserUins: string
+  includeUserUins: string
   outputDir: string
   incremental: boolean
   timeRangeType: ExportTaskPlanTimeRangeType
+  customStartTime: string
+  customEndTime: string
   batchSize: number
+}
+
+function toDateTimeLocal(seconds?: number): string {
+  if (seconds === undefined) return ""
+  const date = new Date(seconds * 1000)
+  const pad = (value: number) => String(value).padStart(2, "0")
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`
 }
 
 function draftFromPlan(plan: ExportTaskPlan | null): DraftState {
@@ -75,13 +99,15 @@ function draftFromPlan(plan: ExportTaskPlan | null): DraftState {
       fixedSnapshots: {},
       tags: [],
       format: "JSON",
-      includeResourceLinks: false,
-      includeSystemMessages: true,
-      filterPureImageMessages: true,
-      preferGroupMemberName: true,
+      ...DEFAULT_EXPORT_TASK_PLAN_OPTIONS,
+      keywords: "",
+      excludeUserUins: "",
+      includeUserUins: "",
       outputDir: "",
       incremental: true,
       timeRangeType: "all",
+      customStartTime: "",
+      customEndTime: "",
       batchSize: DEFAULT_BATCH_SIZE,
     }
   }
@@ -102,18 +128,36 @@ function draftFromPlan(plan: ExportTaskPlan | null): DraftState {
     includeSystemMessages: plan.options.includeSystemMessages,
     filterPureImageMessages: plan.options.filterPureImageMessages,
     preferGroupMemberName: plan.options.preferGroupMemberName,
+    includeRecalled: plan.options.includeRecalled,
+    debugExport: plan.options.debugExport,
+    streamingZipMode: plan.options.streamingZipMode,
+    exportAsZip: plan.options.exportAsZip,
+    embedAvatarsAsBase64: plan.options.embedAvatarsAsBase64,
+    embedResourcesAsDataUri: plan.options.embedResourcesAsDataUri,
+    skipDownloadResourceTypes: plan.options.skipDownloadResourceTypes,
+    useNameInFileName: plan.options.useNameInFileName,
+    useFriendlyFileName: plan.options.useFriendlyFileName,
+    keywords: plan.options.keywords || "",
+    excludeUserUins: plan.options.excludeUserUins || "",
+    includeUserUins: plan.options.includeUserUins || "",
     outputDir: plan.outputDir || "",
     incremental: plan.incremental,
     timeRangeType: plan.timeRangeType,
+    customStartTime: toDateTimeLocal(plan.customTimeRange?.startTime),
+    customEndTime: toDateTimeLocal(plan.customTimeRange?.endTime),
     batchSize: plan.batchSize || DEFAULT_BATCH_SIZE,
   }
 }
 
 export function ExportTaskPlanWizard({ open, mode, initialPlan, store, onClose }: WizardProps) {
   const [draft, setDraft] = useState<DraftState>(() => draftFromPlan(initialPlan))
+  const [filtersOpen, setFiltersOpen] = useState(false)
 
   useEffect(() => {
-    if (open) setDraft(draftFromPlan(initialPlan))
+    if (open) {
+      setDraft(draftFromPlan(initialPlan))
+      setFiltersOpen(false)
+    }
   }, [open, initialPlan])
 
   const patch = (updates: Partial<DraftState>) => setDraft((d) => ({ ...d, ...updates }))
@@ -143,7 +187,12 @@ export function ExportTaskPlanWizard({ open, mode, initialPlan, store, onClose }
 
   const nameValid = draft.name.trim().length > 0
   const groupsValid = resolved.length > 0
-  const canSubmit = nameValid && groupsValid
+  const customRangeValid =
+    draft.timeRangeType !== "custom" ||
+    (Boolean(draft.customStartTime) &&
+      Boolean(draft.customEndTime) &&
+      new Date(draft.customEndTime).getTime() >= new Date(draft.customStartTime).getTime())
+  const canSubmit = nameValid && groupsValid && customRangeValid
   const progressed = initialPlan?.progress ? Object.keys(initialPlan.progress).length : 0
   const batches = splitIntoBatches(Array.from({ length: resolved.length }, (_, i) => i + 1), draft.batchSize)
 
@@ -154,6 +203,10 @@ export function ExportTaskPlanWizard({ open, mode, initialPlan, store, onClose }
     }
     if (!groupsValid) {
       toast({ title: "群聊集合为空", description: "请选择固定群或关联至少一个标签", variant: "destructive" })
+      return
+    }
+    if (!customRangeValid) {
+      toast({ title: "自定义时间范围无效", description: "请选择完整时间，并确保结束时间不早于开始时间", variant: "destructive" })
       return
     }
     const payload = {
@@ -176,10 +229,31 @@ export function ExportTaskPlanWizard({ open, mode, initialPlan, store, onClose }
         includeSystemMessages: draft.includeSystemMessages,
         filterPureImageMessages: draft.filterPureImageMessages,
         preferGroupMemberName: draft.preferGroupMemberName,
+        includeRecalled: draft.includeRecalled,
+        debugExport: draft.debugExport,
+        streamingZipMode: draft.streamingZipMode,
+        exportAsZip: draft.exportAsZip,
+        embedAvatarsAsBase64: draft.embedAvatarsAsBase64,
+        embedResourcesAsDataUri: draft.embedResourcesAsDataUri,
+        skipDownloadResourceTypes: draft.filterPureImageMessages
+          ? undefined
+          : draft.skipDownloadResourceTypes,
+        useNameInFileName: draft.useNameInFileName,
+        useFriendlyFileName: draft.useFriendlyFileName,
+        keywords: draft.keywords.trim() || undefined,
+        excludeUserUins: draft.excludeUserUins.trim() || undefined,
+        includeUserUins: draft.includeUserUins.trim() || undefined,
       },
       outputDir: draft.outputDir.trim() || undefined,
       incremental: draft.incremental,
       timeRangeType: draft.timeRangeType,
+      customTimeRange:
+        draft.timeRangeType === "custom"
+          ? {
+              startTime: Math.floor(new Date(draft.customStartTime).getTime() / 1000),
+              endTime: Math.floor(new Date(draft.customEndTime).getTime() / 1000),
+            }
+          : undefined,
       batchSize: draft.batchSize,
     }
     if (mode === "edit" && initialPlan) {
@@ -318,6 +392,13 @@ export function ExportTaskPlanWizard({ open, mode, initialPlan, store, onClose }
                               patch({
                                 format: fmt,
                                 filterPureImageMessages: fmt === "JSON" || fmt === "TXT",
+                                streamingZipMode:
+                                  fmt === "JSON" || fmt === "HTML" ? draft.streamingZipMode : false,
+                                exportAsZip: fmt === "HTML" ? draft.exportAsZip : false,
+                                embedAvatarsAsBase64:
+                                  fmt === "JSON" ? draft.embedAvatarsAsBase64 : false,
+                                embedResourcesAsDataUri:
+                                  fmt === "HTML" ? draft.embedResourcesAsDataUri : false,
                               })
                             }
                           >
@@ -334,9 +415,11 @@ export function ExportTaskPlanWizard({ open, mode, initialPlan, store, onClose }
                       <div className="inline-flex items-center flex-wrap gap-1 p-1 rounded-[20px] bg-black/[0.04] dark:bg-white/[0.06] w-fit max-w-full">
                         {(
                           [
-                            { id: "all", label: "全部历史" },
+                            { id: "all", label: "全部消息" },
+                            { id: "recent-3-months", label: "最近 3 个月" },
                             { id: "last-7-days", label: "最近 7 天" },
                             { id: "last-30-days", label: "最近 30 天" },
+                            { id: "custom", label: "自定义" },
                           ] as const
                         ).map((t) => {
                           const active = draft.timeRangeType === t.id
@@ -357,9 +440,74 @@ export function ExportTaskPlanWizard({ open, mode, initialPlan, store, onClose }
                           )
                         })}
                       </div>
+                      {draft.timeRangeType === "custom" && (
+                        <div className="space-y-2">
+                          <DateRangePicker
+                            startTime={draft.customStartTime}
+                            endTime={draft.customEndTime}
+                            onChange={(start, end) => patch({ customStartTime: start, customEndTime: end })}
+                          />
+                          {!customRangeValid && (draft.customStartTime || draft.customEndTime) && (
+                            <div className="text-[12px] text-red-600 dark:text-red-400">
+                              请选择完整时间，并确保结束时间不早于开始时间
+                            </div>
+                          )}
+                        </div>
+                      )}
                     </div>
                   )}
                 </div>
+              </section>
+
+              {/* 过滤条件 */}
+              <section>
+                <button
+                  type="button"
+                  aria-expanded={filtersOpen}
+                  onClick={() => setFiltersOpen((value) => !value)}
+                  className={["inline-flex items-center gap-2 text-left", filtersOpen ? "mb-5" : ""].join(" ")}
+                >
+                  <span className="text-[14px] font-medium text-foreground">过滤条件</span>
+                  {[draft.keywords, draft.excludeUserUins, draft.includeUserUins].filter((value) => value.trim()).length > 0 && (
+                    <span className="rounded-full bg-[#317CFF]/10 px-2 py-0.5 text-[10px] font-medium text-[#317CFF]">
+                      已配置 {[draft.keywords, draft.excludeUserUins, draft.includeUserUins].filter((value) => value.trim()).length} 项
+                    </span>
+                  )}
+                  <ChevronDown
+                    className={["h-4 w-4 text-muted-foreground transition-transform", filtersOpen ? "rotate-180" : ""].join(" ")}
+                  />
+                </button>
+                {filtersOpen && (
+                  <div className="space-y-4">
+                    <div className="space-y-2">
+                      <label className={FIELD_LABEL}>关键词过滤</label>
+                      <Input
+                        placeholder="用逗号分隔多个关键词，如：重要,会议,通知"
+                        value={draft.keywords}
+                        onChange={(event) => patch({ keywords: event.target.value })}
+                        className={PILL_INPUT + " w-full"}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <label className={FIELD_LABEL}>屏蔽用户</label>
+                      <Input
+                        placeholder="用逗号分隔多个 QQ 号"
+                        value={draft.excludeUserUins}
+                        onChange={(event) => patch({ excludeUserUins: event.target.value })}
+                        className={PILL_INPUT + " w-full"}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <label className={FIELD_LABEL}>仅保留用户</label>
+                      <Input
+                        placeholder="用逗号分隔多个 QQ 号，留空表示不限制"
+                        value={draft.includeUserUins}
+                        onChange={(event) => patch({ includeUserUins: event.target.value })}
+                        className={PILL_INPUT + " w-full"}
+                      />
+                    </div>
+                  </div>
+                )}
               </section>
 
               <hr className="border-black/[0.06] dark:border-white/[0.08]" />
@@ -367,52 +515,47 @@ export function ExportTaskPlanWizard({ open, mode, initialPlan, store, onClose }
               {/* 高级选项 */}
               <section>
                 <h2 className={SECTION_TITLE}>高级选项</h2>
-                <div className="space-y-2.5">
-                  <h3 className="text-[12px] font-medium text-muted-foreground pl-1">导出内容</h3>
-                  <div className="bg-neutral-50/50 dark:bg-white/[0.03] rounded-2xl border border-neutral-100/80 dark:border-white/[0.06] overflow-hidden divide-y divide-neutral-100/80 dark:divide-white/[0.06]">
-                    {(
-                      [
-                        {
-                          id: "includeResourceLinks",
-                          checked: draft.includeResourceLinks,
-                          set: (v: boolean) => patch({ includeResourceLinks: v }),
-                          title: "包含资源链接",
-                          desc: "在导出中包含图片、文件等资源的下载链接",
-                        },
-                        {
-                          id: "includeSystemMessages",
-                          checked: draft.includeSystemMessages,
-                          set: (v: boolean) => patch({ includeSystemMessages: v }),
-                          title: "包含系统消息",
-                          desc: "包含入群通知、撤回提示等系统提示消息",
-                        },
-                        {
-                          id: "filterPureImageMessages",
-                          checked: draft.filterPureImageMessages,
-                          set: (v: boolean) => patch({ filterPureImageMessages: v }),
-                          title: "过滤纯图片消息",
-                          desc: "只要文字内容时可开启，进一步减小导出体积",
-                        },
-                        {
-                          id: "preferGroupMemberName",
-                          checked: draft.preferGroupMemberName,
-                          set: (v: boolean) => patch({ preferGroupMemberName: v }),
-                          title: "优先使用群成员名称",
-                          desc: "群聊导出时优先使用群名片或群内名称",
-                        },
-                      ] as const
-                    ).map((opt) => (
-                      <div key={opt.id} className="flex items-center justify-between gap-6 group p-4 transition-colors">
-                        <div className="flex flex-col gap-0.5 flex-1 pr-4">
-                          <div className="text-[13px] font-medium text-foreground">{opt.title}</div>
-                          <div className="text-[12px] text-muted-foreground leading-snug mt-0.5">{opt.desc}</div>
+                <div className="space-y-6">
+                  {(() => {
+                    const options = [
+                      { id: "includeResourceLinks", checked: draft.includeResourceLinks, set: (v: boolean) => patch({ includeResourceLinks: v }), title: "包含资源链接", desc: "在导出中包含图片、文件等资源的下载链接", visible: true, group: "导出内容" },
+                      { id: "includeSystemMessages", checked: draft.includeSystemMessages, set: (v: boolean) => patch({ includeSystemMessages: v }), title: "包含系统消息", desc: "包含入群通知、撤回提示等系统提示消息", visible: true, group: "导出内容" },
+                      { id: "includeRecalled", checked: draft.includeRecalled, set: (v: boolean) => patch({ includeRecalled: v }), title: "包含撤回消息", desc: "在可获取时保留已撤回消息", visible: true, group: "导出内容" },
+                      { id: "filterPureImageMessages", checked: draft.filterPureImageMessages, set: (v: boolean) => patch({ filterPureImageMessages: v }), title: "快速导出（跳过资源下载）", desc: "保留消息记录，但不下载图片、视频、语音等资源", visible: true, group: "导出内容" },
+                      { id: "skipFileDownload", checked: !!draft.skipDownloadResourceTypes?.includes("file"), set: (v: boolean) => patch({ skipDownloadResourceTypes: toggleSkipResourceType(draft.skipDownloadResourceTypes, "file", v) }), title: "仅保留文件元数据，不下载文件", desc: "群文件和聊天文档仅保留文件名、大小、MD5 等信息", visible: !draft.filterPureImageMessages, group: "导出内容" },
+                      { id: "skipImageDownload", checked: !!draft.skipDownloadResourceTypes?.includes("image"), set: (v: boolean) => patch({ skipDownloadResourceTypes: toggleSkipResourceType(draft.skipDownloadResourceTypes, "image", v) }), title: "不下载图片", desc: "跳过图片资源下载，HTML 中以占位形式显示", visible: !draft.filterPureImageMessages, group: "导出内容" },
+                      { id: "skipVideoDownload", checked: !!draft.skipDownloadResourceTypes?.includes("video"), set: (v: boolean) => patch({ skipDownloadResourceTypes: toggleSkipResourceType(draft.skipDownloadResourceTypes, "video", v) }), title: "不下载视频", desc: "避免视频占用大量带宽和磁盘空间", visible: !draft.filterPureImageMessages, group: "导出内容" },
+                      { id: "skipAudioDownload", checked: !!draft.skipDownloadResourceTypes?.includes("audio"), set: (v: boolean) => patch({ skipDownloadResourceTypes: toggleSkipResourceType(draft.skipDownloadResourceTypes, "audio", v) }), title: "不下载语音", desc: "跳过 SILK、AMR 等语音资源下载", visible: !draft.filterPureImageMessages, group: "导出内容" },
+                      { id: "preferGroupMemberName", checked: draft.preferGroupMemberName, set: (v: boolean) => patch({ preferGroupMemberName: v }), title: "优先使用群成员名称", desc: "优先使用群名片或群内名称", visible: true, group: "导出内容" },
+                      { id: "embedAvatarsAsBase64", checked: draft.embedAvatarsAsBase64, set: (v: boolean) => patch({ embedAvatarsAsBase64: v }), title: "嵌入头像为 Base64", desc: "将发送者头像嵌入 JSON 文件", visible: draft.format === "JSON" && !draft.streamingZipMode, group: "导出内容" },
+                      { id: "embedResourcesAsDataUri", checked: draft.embedResourcesAsDataUri, set: (v: boolean) => patch({ embedResourcesAsDataUri: v, exportAsZip: v ? false : draft.exportAsZip }), title: "生成自包含 HTML", desc: "把资源内联到单个 HTML，不再生成 resources 目录", visible: draft.format === "HTML" && !draft.exportAsZip && !draft.streamingZipMode, group: "导出内容" },
+                      { id: "useNameInFileName", checked: draft.useNameInFileName, set: (v: boolean) => patch({ useNameInFileName: v }), title: "文件名包含会话名称", desc: "保留旧客户端的名称文件名兼容设置", visible: true, group: "文件命名" },
+                      { id: "useFriendlyFileName", checked: draft.useFriendlyFileName, set: (v: boolean) => patch({ useFriendlyFileName: v }), title: "使用友好文件名", desc: "使用名称、群号和时间生成可读文件名", visible: true, group: "文件命名" },
+                      { id: "streamingZipMode", checked: draft.streamingZipMode, set: (v: boolean) => patch({ streamingZipMode: v, exportAsZip: v ? false : draft.exportAsZip, embedResourcesAsDataUri: v ? false : draft.embedResourcesAsDataUri }), title: "流式导出（超大消息量专用）", desc: draft.format === "HTML" ? "输出流式 ZIP，适合 50 万条以上记录" : "输出分块 JSONL，适合 50 万条以上记录", visible: draft.format === "HTML" || draft.format === "JSON", group: "性能与处理" },
+                      { id: "exportAsZip", checked: draft.exportAsZip, set: (v: boolean) => patch({ exportAsZip: v, embedResourcesAsDataUri: v ? false : draft.embedResourcesAsDataUri }), title: "导出为 ZIP 压缩包", desc: "将 HTML 和资源文件打包为 ZIP", visible: draft.format === "HTML" && !draft.streamingZipMode, group: "性能与处理" },
+                      { id: "debugExport", checked: draft.debugExport, set: (v: boolean) => patch({ debugExport: v }), title: "调试导出", desc: "额外保存原始消息、解析结果与资源调用错误", visible: true, group: "性能与处理" },
+                    ].filter((option) => option.visible)
+
+                    return ["导出内容", "文件命名", "性能与处理"]
+                      .map((groupName) => ({ groupName, items: options.filter((option) => option.group === groupName) }))
+                      .filter(({ items }) => items.length > 0)
+                      .map(({ groupName, items }) => (
+                        <div key={groupName} className="space-y-2.5">
+                          <h3 className="text-[12px] font-medium text-muted-foreground pl-1">{groupName}</h3>
+                          <div className="bg-neutral-50/50 dark:bg-white/[0.03] rounded-2xl border border-neutral-100/80 dark:border-white/[0.06] overflow-hidden divide-y divide-neutral-100/80 dark:divide-white/[0.06]">
+                            {items.map((option) => (
+                              <div key={option.id} className="flex items-center justify-between gap-6 p-4 transition-colors">
+                                <div className="flex flex-col gap-0.5 flex-1 pr-4">
+                                  <div className="text-[13px] font-medium text-foreground">{option.title}</div>
+                                  <div className="text-[12px] text-muted-foreground leading-snug mt-0.5">{option.desc}</div>
+                                </div>
+                                <Switch checked={option.checked} onCheckedChange={option.set} />
+                              </div>
+                            ))}
+                          </div>
                         </div>
-                        <div className="flex-shrink-0">
-                          <Switch checked={opt.checked} onCheckedChange={(v) => opt.set(v)} />
-                        </div>
-                      </div>
-                    ))}
-                  </div>
+                      ))
+                  })()}
                 </div>
 
                 {/* 自定义存储路径（对齐 TaskWizard 的位置与样式） */}
@@ -481,7 +624,13 @@ export function ExportTaskPlanWizard({ open, mode, initialPlan, store, onClose }
                 配置就绪，{resolved.length} 个群将分为 {batches.length} 批执行
               </span>
             ) : (
-              <span>{!nameValid ? "请填写任务名称" : "请选择固定群或关联标签"}</span>
+              <span>
+                {!nameValid
+                  ? "请填写任务名称"
+                  : !groupsValid
+                    ? "请选择固定群或关联标签"
+                    : "请填写有效的自定义时间范围"}
+              </span>
             )}
           </div>
 

--- a/qce-v4-tool/components/ui/session-list.tsx
+++ b/qce-v4-tool/components/ui/session-list.tsx
@@ -543,9 +543,13 @@ function SessionListComponent({
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0.94 }}
             transition={{ type: "spring", stiffness: 400, damping: 35, mass: 0.8 }}
-            className="fixed bottom-8 left-1/2 -translate-x-1/2 z-50"
+            data-testid="batch-selection-toolbar"
+            className={[
+              "sticky z-50 mx-auto mt-3 w-max max-w-[calc(100vw-2rem)]",
+              totalPages > 1 ? "bottom-16 mb-2" : "bottom-8",
+            ].join(" ")}
           >
-            <div className="flex items-center gap-1 rounded-full bg-white/80 dark:bg-neutral-900/80 backdrop-blur-xl shadow-[0_8px_32px_rgba(0,0,0,0.08)] border border-black/[0.06] dark:border-white/[0.08] px-2 py-1.5">
+            <div className="flex max-w-full flex-wrap items-center justify-center gap-1 rounded-[24px] bg-white/80 dark:bg-neutral-900/80 backdrop-blur-xl shadow-[0_8px_32px_rgba(0,0,0,0.08)] border border-black/[0.06] dark:border-white/[0.08] px-2 py-1.5">
               <span className="text-[13px] font-medium text-foreground px-3 tabular-nums">
                 已选择 {selectedItems.size} 项
               </span>
@@ -621,7 +625,7 @@ function SessionListComponent({
 
       {/* Pagination */}
       {totalPages > 1 && (
-        <div className="flex items-center justify-between pt-3">
+        <div data-testid="session-pagination" className="flex flex-wrap items-center justify-between gap-2 pt-3">
           <div className="flex items-center gap-1.5">
             <span className="text-sm text-muted-foreground/60">每页</span>
             <PillDropdown
@@ -637,6 +641,7 @@ function SessionListComponent({
 
           <div className="flex items-center gap-0.5">
             <Button
+              aria-label="第一页"
               variant="ghost"
               size="icon"
               className="h-8 w-8 rounded-full"
@@ -646,6 +651,7 @@ function SessionListComponent({
               <ChevronsLeft className="w-3.5 h-3.5" />
             </Button>
             <Button
+              aria-label="上一页"
               variant="ghost"
               size="icon"
               className="h-8 w-8 rounded-full"
@@ -662,6 +668,7 @@ function SessionListComponent({
             </div>
 
             <Button
+              aria-label="下一页"
               variant="ghost"
               size="icon"
               className="h-8 w-8 rounded-full"
@@ -671,6 +678,7 @@ function SessionListComponent({
               <ChevronRight className="w-3.5 h-3.5" />
             </Button>
             <Button
+              aria-label="最后一页"
               variant="ghost"
               size="icon"
               className="h-8 w-8 rounded-full"

--- a/qce-v4-tool/e2e/export-task-plan-config.spec.ts
+++ b/qce-v4-tool/e2e/export-task-plan-config.spec.ts
@@ -1,0 +1,182 @@
+import { expect, test } from "@playwright/test"
+
+import { buildExportRequest, exportTaskPlanToForm } from "@/lib/export-request"
+import {
+  normalizeExportTaskPlan,
+  type ExportTaskPlan,
+} from "@/types/export-task-plans"
+
+function makePlan(overrides: Partial<ExportTaskPlan> = {}): ExportTaskPlan {
+  return normalizeExportTaskPlan({
+    id: "plan_1",
+    name: "学校群备份",
+    sourceMode: "fixed",
+    fixedGroups: [{ groupCode: "123", groupName: "测试群" }],
+    tags: [],
+    format: "JSON",
+    options: {
+      includeResourceLinks: true,
+      includeSystemMessages: true,
+      filterPureImageMessages: false,
+      preferGroupMemberName: true,
+      includeRecalled: true,
+      debugExport: true,
+      streamingZipMode: false,
+      exportAsZip: false,
+      embedAvatarsAsBase64: true,
+      embedResourcesAsDataUri: false,
+      skipDownloadResourceTypes: ["video", "audio"],
+      useNameInFileName: true,
+      useFriendlyFileName: true,
+      keywords: "通知, 会议",
+      excludeUserUins: "10001",
+      includeUserUins: "10002, 10003",
+    },
+    outputDir: "D:\\exports",
+    incremental: false,
+    timeRangeType: "all",
+    batchSize: 20,
+    createdAt: "2026-08-19T00:00:00.000Z",
+    updatedAt: "2026-08-19T00:00:00.000Z",
+    ...overrides,
+  })
+}
+
+test.describe("shared export request builder", () => {
+  test("keeps filters and advanced options for reusable task plans", () => {
+    const plan = makePlan()
+    const form = exportTaskPlanToForm(plan, { groupCode: "123", groupName: "测试群" }, 1_700_000_000)
+    const request = buildExportRequest(form)
+
+    expect(request.endpoint).toBe("/api/messages/export")
+    expect(request.body.filter).toMatchObject({
+      keywords: ["通知", "会议"],
+      excludeUserUins: ["10001"],
+      includeUserUins: ["10002", "10003"],
+      includeRecalled: true,
+    })
+    expect(request.body.options).toMatchObject({
+      includeResourceLinks: true,
+      includeSystemMessages: true,
+      filterPureImageMessages: false,
+      embedAvatarsAsBase64: true,
+      preferGroupMemberName: true,
+      debugExport: true,
+      outputDir: "D:\\exports",
+      useNameInFileName: true,
+      useFriendlyFileName: true,
+      skipDownloadResourceTypes: ["video", "audio"],
+    })
+  })
+
+  test("selects the matching streaming endpoint", () => {
+    const json = buildExportRequest({
+      ...exportTaskPlanToForm(makePlan(), { groupCode: "123", groupName: "测试群" }),
+      streamingZipMode: true,
+    })
+    expect(json.endpoint).toBe("/api/messages/export-streaming-jsonl")
+    expect(json.body.format).toBe("STREAMING_JSONL")
+    expect(json.body.options.batchSize).toBe(3000)
+
+    const html = buildExportRequest({
+      ...exportTaskPlanToForm(makePlan({ format: "HTML" }), { groupCode: "123", groupName: "测试群" }),
+      streamingZipMode: true,
+    })
+    expect(html.endpoint).toBe("/api/messages/export-streaming-zip")
+    expect(html.body.format).toBe("STREAMING_ZIP")
+  })
+
+  test("keeps every regular export format on the standard endpoint", () => {
+    for (const format of ["JSON", "HTML", "TXT", "EXCEL"] as const) {
+      const request = buildExportRequest(
+        exportTaskPlanToForm(makePlan({ format }), { groupCode: "123", groupName: "测试群" }),
+      )
+      expect(request.endpoint).toBe("/api/messages/export")
+      expect(request.body.format).toBe(format)
+    }
+  })
+})
+
+test.describe("reusable task time ranges and compatibility", () => {
+  test("normalizes old localStorage plans without losing progress", () => {
+    const legacy = {
+      ...makePlan(),
+      options: {
+        includeResourceLinks: false,
+        includeSystemMessages: false,
+        filterPureImageMessages: true,
+        preferGroupMemberName: false,
+      },
+      progress: { "123": 1_690_000_000 },
+    } as unknown as ExportTaskPlan
+
+    const normalized = normalizeExportTaskPlan(legacy)
+    expect(normalized.progress).toEqual({ "123": 1_690_000_000 })
+    expect(normalized.options.includeResourceLinks).toBe(false)
+    expect(normalized.options.includeRecalled).toBe(false)
+    expect(normalized.options.streamingZipMode).toBe(false)
+    expect(normalized.options.useFriendlyFileName).toBe(false)
+  })
+
+  test("uses the saved cursor for subsequent incremental runs", () => {
+    const plan = makePlan({
+      incremental: true,
+      progress: { "123": 1_690_000_000 },
+    })
+    const request = buildExportRequest(
+      exportTaskPlanToForm(plan, { groupCode: "123", groupName: "测试群" }, 1_700_000_000),
+    )
+    expect(request.body.filter.startTime).toBe(1_690_000_000)
+    expect(request.body.filter.endTime).toBeUndefined()
+  })
+
+  test("exports full history on the first incremental run", () => {
+    const request = buildExportRequest(
+      exportTaskPlanToForm(
+        makePlan({ incremental: true, progress: undefined }),
+        { groupCode: "123", groupName: "测试群" },
+        1_700_000_000,
+      ),
+    )
+    expect(request.body.filter.startTime).toBeUndefined()
+    expect(request.body.filter.endTime).toBeUndefined()
+  })
+
+  test("supports recent three months and custom ranges", () => {
+    const now = Math.floor(new Date("2026-08-19T12:00:00.000Z").getTime() / 1000)
+    const recent = buildExportRequest(
+      exportTaskPlanToForm(
+        makePlan({ timeRangeType: "recent-3-months" }),
+        { groupCode: "123", groupName: "测试群" },
+        now,
+      ),
+    )
+    expect(recent.body.filter.endTime).toBe(now)
+    expect(new Date(recent.body.filter.startTime! * 1000).toISOString()).toBe("2026-05-19T12:00:00.000Z")
+
+    const custom = buildExportRequest(
+      exportTaskPlanToForm(
+        makePlan({
+          timeRangeType: "custom",
+          customTimeRange: { startTime: 1_650_000_000, endTime: 1_660_000_000 },
+        }),
+        { groupCode: "123", groupName: "测试群" },
+        now,
+      ),
+    )
+    expect(custom.body.filter.startTime).toBe(1_650_000_000)
+    expect(custom.body.filter.endTime).toBe(1_660_000_000)
+
+    for (const [timeRangeType, seconds] of [["last-7-days", 7 * 86_400], ["last-30-days", 30 * 86_400]] as const) {
+      const legacyRange = buildExportRequest(
+        exportTaskPlanToForm(
+          makePlan({ timeRangeType }),
+          { groupCode: "123", groupName: "测试群" },
+          now,
+        ),
+      )
+      expect(legacyRange.body.filter.startTime).toBe(now - seconds)
+      expect(legacyRange.body.filter.endTime).toBe(now)
+    }
+  })
+})

--- a/qce-v4-tool/e2e/ui-smoke.spec.ts
+++ b/qce-v4-tool/e2e/ui-smoke.spec.ts
@@ -20,8 +20,9 @@ import { isNewerVersion } from '../lib/version';
 const TOKEN = process.env.QCE_MOCK_TOKEN ?? 'qce_mock_token_for_tests';
 const FRONTEND_BASE = process.env.E2E_FRONTEND_URL ?? 'http://localhost:40653';
 // Production URL has the frontend living under `/qce/`.
-const AUTH_PATH = `/qce/auth`;
-const SHELL_PATH = `/qce`;
+const BASE_PATH = process.env.QCE_E2E_BASE_PATH ?? '/qce';
+const AUTH_PATH = `${BASE_PATH}/auth`;
+const SHELL_PATH = BASE_PATH || '/';
 
 async function clearLocalStorage(page: import('@playwright/test').Page) {
     // We can't use addInitScript here – that runs on EVERY navigation in the
@@ -215,6 +216,137 @@ async function openSessionsTab(page: import('@playwright/test').Page) {
     await expect(searchBox).toBeVisible({ timeout: 15_000 });
     return searchBox;
 }
+
+test.describe('Session list — batch toolbar and pagination', () => {
+    test('keeps the selected sessions while pagination remains visible and clickable', async ({ page }) => {
+        await clearLocalStorage(page);
+        await page.evaluate((value) => {
+            localStorage.setItem('qce_access_token', value);
+        }, TOKEN);
+
+        const groups = Array.from({ length: 313 }, (_, index) => ({
+            groupCode: String(900000000 + index),
+            groupName: `分页测试群 ${String(index + 1).padStart(3, '0')}`,
+            memberCount: 10 + index,
+            maxMember: 2000,
+        }));
+
+        await page.route('**/auth', async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ success: true }),
+            });
+        });
+        await page.route('**/api/**', async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ success: true, data: {} }),
+            });
+        });
+        await page.route('**/api/tasks**', async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ success: true, data: { tasks: [] } }),
+            });
+        });
+
+        await page.route('**/api/system/info**', async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    success: true,
+                    data: {
+                        name: 'QQ Chat Exporter',
+                        version: '5.5.80',
+                        mode: 'plugin',
+                        napcat: {
+                            version: 'mock',
+                            online: true,
+                            selfInfo: { uid: 'mock-user', uin: '10001', nick: '分页测试账号' },
+                        },
+                        runtime: { nodeVersion: 'mock', platform: 'win32', uptime: 1 },
+                    },
+                }),
+            });
+        });
+
+        await page.route('**/api/security/ip-whitelist**', async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    success: true,
+                    data: { allowedIPs: ['127.0.0.1'], disabled: false, isDocker: false, currentClientIP: '127.0.0.1' },
+                }),
+            });
+        });
+
+        await page.route('**/api/groups?**', async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    success: true,
+                    data: {
+                        groups,
+                        totalCount: groups.length,
+                        currentPage: 1,
+                        totalPages: 1,
+                        hasNext: false,
+                        hasPrev: false,
+                    },
+                }),
+            });
+        });
+        await page.route('**/api/friends?**', async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    success: true,
+                    data: { friends: [], totalCount: 0, currentPage: 1, totalPages: 1, hasNext: false, hasPrev: false },
+                }),
+            });
+        });
+        await page.route('**/api/recent-contacts?**', async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ success: true, data: { contacts: [] } }),
+            });
+        });
+        const response = await page.goto(`${FRONTEND_BASE}${SHELL_PATH}`).catch(() => null);
+        test.skip(!response || response.status() >= 500, `frontend not reachable at ${FRONTEND_BASE}`);
+
+        await openSessionsTab(page);
+        await expect(page.getByText('分页测试群 001', { exact: true })).toBeVisible({ timeout: 15_000 });
+
+        const batchButton = page.getByRole('button', { name: '批量选择', exact: true }).filter({ visible: true }).first();
+        await batchButton.click();
+        await page.getByRole('checkbox', { name: '选择会话 分页测试群 001' }).click();
+
+        const toolbar = page.getByTestId('batch-selection-toolbar');
+        const pagination = page.getByTestId('session-pagination');
+        await expect(toolbar).toContainText('已选择 1 项');
+        await pagination.scrollIntoViewIfNeeded();
+
+        const [toolbarBox, paginationBox] = await Promise.all([
+            toolbar.boundingBox(),
+            pagination.boundingBox(),
+        ]);
+        expect(toolbarBox).not.toBeNull();
+        expect(paginationBox).not.toBeNull();
+        expect(toolbarBox!.y + toolbarBox!.height).toBeLessThanOrEqual(paginationBox!.y);
+
+        await page.getByRole('button', { name: '下一页' }).click();
+        await expect(pagination).toContainText(/2\s*\/\s*7/);
+        await expect(toolbar).toContainText('已选择 1 项');
+    });
+});
 
 test.describe('Session list — QQ lookup (issue #204)', () => {
     test('searching by deactivated QQ number reveals the lookup card', async ({ page }) => {

--- a/qce-v4-tool/hooks/use-export-task-plans.ts
+++ b/qce-v4-tool/hooks/use-export-task-plans.ts
@@ -13,6 +13,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react"
 import type { ExportTask, Group } from "@/types/api"
 import { useApi } from "./use-api"
+import { buildExportRequest, exportTaskPlanToForm } from "@/lib/export-request"
 import {
   DEFAULT_BATCH_SIZE,
   ExportTaskPlan,
@@ -22,6 +23,7 @@ import {
   GroupTagMap,
   collectTags,
   genId,
+  normalizeExportTaskPlan,
   resolvePlanGroups,
   splitIntoBatches,
 } from "@/types/export-task-plans"
@@ -36,7 +38,6 @@ const MAX_KNOWN_GROUPS = 500
 const TASK_POLL_INTERVAL_MS = 2_000
 /** 单群导出等待上限（毫秒），超时当作失败并进入失败列表。 */
 const TASK_WAIT_TIMEOUT_MS = 6 * 60 * 60 * 1_000
-const DAY_SECONDS = 86_400
 
 /**
  * Issue #641：旧版本提供过「载入示例数据」，写入的示例任务与虚构群会一直占着
@@ -103,7 +104,9 @@ export function useExportTaskPlans(liveGroups: Group[] = []) {
     const storedGroups = readLS<Group[]>(LS_KNOWN_GROUPS, [])
 
     const demoCodes = demoGroupCodes()
-    const cleanPlans = storedPlans.filter((p) => !DEMO_PLAN_IDS.has(p.id))
+    const cleanPlans = storedPlans
+      .filter((p) => !DEMO_PLAN_IDS.has(p.id))
+      .map(normalizeExportTaskPlan)
     const cleanRuns = storedRuns.filter(
       (r) => !r.id.startsWith(DEMO_RUN_ID_PREFIX) && !DEMO_PLAN_IDS.has(r.planId),
     )
@@ -112,7 +115,7 @@ export function useExportTaskPlans(liveGroups: Group[] = []) {
       Object.entries(storedTags).filter(([code]) => !demoCodes.has(code)),
     )
 
-    if (cleanPlans.length !== storedPlans.length) writeLS(LS_PLANS, cleanPlans)
+    if (JSON.stringify(cleanPlans) !== JSON.stringify(storedPlans)) writeLS(LS_PLANS, cleanPlans)
     if (cleanRuns.length !== storedRuns.length) writeLS(LS_RUNS, cleanRuns)
     if (cleanGroups.length !== storedGroups.length) writeLS(LS_KNOWN_GROUPS, cleanGroups)
     if (Object.keys(cleanTags).length !== Object.keys(storedTags).length) writeLS(LS_TAGS, cleanTags)
@@ -198,7 +201,7 @@ export function useExportTaskPlans(liveGroups: Group[] = []) {
   const createPlan = useCallback(
     (input: Omit<ExportTaskPlan, "id" | "createdAt" | "updatedAt">) => {
       const now = new Date().toISOString()
-      const plan: ExportTaskPlan = { ...input, id: genId("plan"), createdAt: now, updatedAt: now }
+      const plan = normalizeExportTaskPlan({ ...input, id: genId("plan"), createdAt: now, updatedAt: now })
       persistPlans([plan, ...plans])
       return plan
     },
@@ -208,7 +211,11 @@ export function useExportTaskPlans(liveGroups: Group[] = []) {
   const updatePlan = useCallback(
     (id: string, updates: Partial<Omit<ExportTaskPlan, "id" | "createdAt">>) => {
       persistPlans(
-        plans.map((p) => (p.id === id ? { ...p, ...updates, updatedAt: new Date().toISOString() } : p)),
+        plans.map((p) =>
+          p.id === id
+            ? normalizeExportTaskPlan({ ...p, ...updates, updatedAt: new Date().toISOString() })
+            : p,
+        ),
       )
     },
     [plans, persistPlans],
@@ -264,44 +271,11 @@ export function useExportTaskPlans(liveGroups: Group[] = []) {
   /** 导出单个群，返回失败原因；成功返回 null。 */
   const exportGroup = useCallback(
     async (plan: ExportTaskPlan, group: { groupCode: string; groupName: string }, runId: string) => {
-      const nowSeconds = Math.floor(Date.now() / 1000)
-      // 增量导出：从该群上次导出到的位置继续；否则按任务的时间范围类型。
-      const incrementalFrom = plan.incremental ? plan.progress?.[group.groupCode] : undefined
-      let startTime = incrementalFrom
-      let endTime: number | undefined
-      if (startTime === undefined) {
-        if (plan.timeRangeType === "last-7-days") startTime = nowSeconds - 7 * DAY_SECONDS
-        else if (plan.timeRangeType === "last-30-days") startTime = nowSeconds - 30 * DAY_SECONDS
-        else if (plan.timeRangeType === "custom" && plan.customTimeRange) {
-          startTime = plan.customTimeRange.startTime
-          endTime = plan.customTimeRange.endTime
-        }
-      }
-
-      const outputDir = plan.outputDir?.trim()
-      const body = {
-        peer: { chatType: 2, peerUid: group.groupCode, guildId: "" },
-        sessionName: group.groupName || group.groupCode,
-        format: plan.format,
-        filter: {
-          ...(startTime !== undefined && { startTime }),
-          ...(endTime !== undefined && { endTime }),
-          includeRecalled: false,
-        },
-        options: {
-          batchSize: 5000,
-          prettyFormat: true,
-          useFriendlyFileName: true,
-          includeResourceLinks: plan.options.includeResourceLinks,
-          includeSystemMessages: plan.options.includeSystemMessages,
-          filterPureImageMessages: plan.options.filterPureImageMessages,
-          preferGroupMemberName: plan.options.preferGroupMemberName,
-          ...(outputDir && { outputDir }),
-        },
-      }
+      const form = exportTaskPlanToForm(plan, group)
+      const { endpoint, body } = buildExportRequest(form)
 
       try {
-        const resp = await apiCall<{ taskId?: string }>("/api/messages/export", {
+        const resp = await apiCall<{ taskId?: string }>(endpoint, {
           method: "POST",
           body: JSON.stringify(body),
         })

--- a/qce-v4-tool/hooks/use-export-tasks.ts
+++ b/qce-v4-tool/hooks/use-export-tasks.ts
@@ -2,7 +2,6 @@ import { Fragment, createElement, useCallback, useEffect, useMemo, useRef, useSt
 import type {
   APIResponse,
   CreateTaskForm,
-  CreateTaskRequest,
   CreateTaskResponse,
   ExportTask,
   TasksResponse,
@@ -14,6 +13,7 @@ import {
   type ExportTaskUpdate,
 } from "@/lib/export-task-state"
 import { useApi } from "./use-api"
+import { buildExportRequest } from "@/lib/export-request"
 
 const GITHUB_URL = "https://github.com/shuakami/qq-chat-exporter"
 
@@ -463,61 +463,7 @@ export function useExportTasks(_props?: UseExportTasksProps) {
       setLoading(true)
       setError(null)
 
-      const useStreamingMode = form.streamingZipMode === true
-      const isJsonFormat = form.format === "JSON"
-
-      const requestBody: CreateTaskRequest = {
-        peer: {
-          chatType: form.chatType,
-          peerUid: form.peerUid,
-          ...(form.peerUin && { peerUin: form.peerUin }),
-          guildId: "",
-        },
-        sessionName: form.sessionName,
-        format: useStreamingMode
-          ? (isJsonFormat ? "STREAMING_JSONL" : "STREAMING_ZIP")
-          : form.format,
-        filter: {
-          ...(form.startTime && { startTime: Math.floor(new Date(form.startTime).getTime() / 1000) }),
-          ...(form.endTime && { endTime: Math.floor(new Date(form.endTime).getTime() / 1000) }),
-          ...(form.keywords && { keywords: form.keywords.split(",").map((keyword) => keyword.trim()) }),
-          ...(form.excludeUserUins && {
-            excludeUserUins: form.excludeUserUins.split(",").map((uin) => uin.trim()).filter(Boolean),
-          }),
-          // Issue #369：仅导出指定 QQ 的消息。
-          ...(form.includeUserUins && {
-            includeUserUins: form.includeUserUins.split(",").map((uin) => uin.trim()).filter(Boolean),
-          }),
-          includeRecalled: form.includeRecalled,
-        },
-        options: {
-          batchSize: useStreamingMode ? 3000 : 5000,
-          includeResourceLinks: true,
-          includeSystemMessages: form.includeSystemMessages,
-          filterPureImageMessages: form.filterPureImageMessages,
-          prettyFormat: true,
-          exportAsZip: form.exportAsZip,
-          embedAvatarsAsBase64: form.embedAvatarsAsBase64,
-          // Issue #311: 自包含 HTML（资源 base64 内联）。
-          embedResourcesAsDataUri: form.embedResourcesAsDataUri,
-          preferGroupMemberName: form.preferGroupMemberName ?? true,
-          debugExport: form.debugExport ?? false,
-          ...(form.outputDir?.trim() && { outputDir: form.outputDir.trim() }),
-          ...(form.useNameInFileName && { useNameInFileName: true }),
-          // Issue #134: 友好文件名格式 `<名称>(<QQ号>).<扩展名>`
-          ...(form.useFriendlyFileName && { useFriendlyFileName: true }),
-          ...(Array.isArray(form.skipDownloadResourceTypes) && form.skipDownloadResourceTypes.length > 0 && {
-            skipDownloadResourceTypes: form.skipDownloadResourceTypes,
-          }),
-        },
-      }
-
-      let apiEndpoint = "/api/messages/export"
-      if (useStreamingMode) {
-        apiEndpoint = isJsonFormat
-          ? "/api/messages/export-streaming-jsonl"
-          : "/api/messages/export-streaming-zip"
-      }
+      const { endpoint: apiEndpoint, body: requestBody } = buildExportRequest(form)
 
       const response = await apiCall(apiEndpoint, {
         method: "POST",

--- a/qce-v4-tool/lib/export-request.ts
+++ b/qce-v4-tool/lib/export-request.ts
@@ -1,0 +1,126 @@
+import type { CreateTaskForm, CreateTaskRequest } from "@/types/api"
+import type { ExportTaskPlan } from "@/types/export-task-plans"
+
+export interface BuiltExportRequest {
+  endpoint: string
+  body: CreateTaskRequest
+}
+
+function splitCsv(value?: string): string[] | undefined {
+  if (!value) return undefined
+  const items = value.split(",").map((item) => item.trim()).filter(Boolean)
+  return items.length > 0 ? items : undefined
+}
+
+/** 单次、批量和可复用导出任务共用的请求构造。 */
+export function buildExportRequest(form: CreateTaskForm): BuiltExportRequest {
+  const useStreamingMode = form.streamingZipMode === true
+  const isJsonFormat = form.format === "JSON"
+  const keywords = splitCsv(form.keywords)
+  const excludeUserUins = splitCsv(form.excludeUserUins)
+  const includeUserUins = splitCsv(form.includeUserUins)
+
+  const body: CreateTaskRequest = {
+    peer: {
+      chatType: form.chatType,
+      peerUid: form.peerUid,
+      ...(form.peerUin && { peerUin: form.peerUin }),
+      guildId: "",
+    },
+    sessionName: form.sessionName,
+    format: useStreamingMode
+      ? (isJsonFormat ? "STREAMING_JSONL" : "STREAMING_ZIP")
+      : form.format,
+    filter: {
+      ...(form.startTime && { startTime: Math.floor(new Date(form.startTime).getTime() / 1000) }),
+      ...(form.endTime && { endTime: Math.floor(new Date(form.endTime).getTime() / 1000) }),
+      ...(keywords && { keywords }),
+      ...(excludeUserUins && { excludeUserUins }),
+      ...(includeUserUins && { includeUserUins }),
+      includeRecalled: form.includeRecalled,
+    },
+    options: {
+      batchSize: useStreamingMode ? 3000 : 5000,
+      includeResourceLinks: form.includeResourceLinks ?? true,
+      includeSystemMessages: form.includeSystemMessages,
+      filterPureImageMessages: form.filterPureImageMessages,
+      prettyFormat: true,
+      exportAsZip: form.exportAsZip,
+      embedAvatarsAsBase64: form.embedAvatarsAsBase64,
+      embedResourcesAsDataUri: form.embedResourcesAsDataUri,
+      preferGroupMemberName: form.preferGroupMemberName ?? true,
+      debugExport: form.debugExport ?? false,
+      ...(form.outputDir?.trim() && { outputDir: form.outputDir.trim() }),
+      ...(form.useNameInFileName && { useNameInFileName: true }),
+      ...(form.useFriendlyFileName && { useFriendlyFileName: true }),
+      ...(Array.isArray(form.skipDownloadResourceTypes) && form.skipDownloadResourceTypes.length > 0 && {
+        skipDownloadResourceTypes: form.skipDownloadResourceTypes,
+      }),
+    },
+  }
+
+  const endpoint = useStreamingMode
+    ? (isJsonFormat ? "/api/messages/export-streaming-jsonl" : "/api/messages/export-streaming-zip")
+    : "/api/messages/export"
+
+  return { endpoint, body }
+}
+
+function secondsToIso(seconds?: number): string | undefined {
+  return seconds === undefined ? undefined : new Date(seconds * 1000).toISOString()
+}
+
+export function exportTaskPlanToForm(
+  plan: ExportTaskPlan,
+  group: { groupCode: string; groupName: string },
+  nowSeconds = Math.floor(Date.now() / 1000),
+): CreateTaskForm {
+  const incrementalFrom = plan.incremental ? plan.progress?.[group.groupCode] : undefined
+  let startTime = incrementalFrom
+  let endTime: number | undefined
+
+  if (startTime === undefined && !plan.incremental) {
+    if (plan.timeRangeType === "recent-3-months") {
+      const start = new Date(nowSeconds * 1000)
+      start.setMonth(start.getMonth() - 3)
+      startTime = Math.floor(start.getTime() / 1000)
+      endTime = nowSeconds
+    } else if (plan.timeRangeType === "last-7-days") {
+      startTime = nowSeconds - 7 * 86_400
+      endTime = nowSeconds
+    } else if (plan.timeRangeType === "last-30-days") {
+      startTime = nowSeconds - 30 * 86_400
+      endTime = nowSeconds
+    } else if (plan.timeRangeType === "custom" && plan.customTimeRange) {
+      startTime = plan.customTimeRange.startTime
+      endTime = plan.customTimeRange.endTime
+    }
+  }
+
+  return {
+    chatType: 2,
+    peerUid: group.groupCode,
+    peerUin: group.groupCode,
+    sessionName: group.groupName || group.groupCode,
+    format: plan.format,
+    startTime: secondsToIso(startTime),
+    endTime: secondsToIso(endTime),
+    keywords: plan.options.keywords,
+    excludeUserUins: plan.options.excludeUserUins,
+    includeUserUins: plan.options.includeUserUins,
+    includeRecalled: plan.options.includeRecalled,
+    includeResourceLinks: plan.options.includeResourceLinks,
+    includeSystemMessages: plan.options.includeSystemMessages,
+    filterPureImageMessages: plan.options.filterPureImageMessages,
+    exportAsZip: plan.options.exportAsZip,
+    embedAvatarsAsBase64: plan.options.embedAvatarsAsBase64,
+    embedResourcesAsDataUri: plan.options.embedResourcesAsDataUri,
+    streamingZipMode: plan.options.streamingZipMode,
+    outputDir: plan.outputDir,
+    useNameInFileName: plan.options.useNameInFileName,
+    useFriendlyFileName: plan.options.useFriendlyFileName,
+    preferGroupMemberName: plan.options.preferGroupMemberName,
+    debugExport: plan.options.debugExport,
+    skipDownloadResourceTypes: plan.options.skipDownloadResourceTypes,
+  }
+}

--- a/qce-v4-tool/types/api.ts
+++ b/qce-v4-tool/types/api.ts
@@ -212,6 +212,8 @@ export interface CreateTaskForm {
   endTime?: string
   keywords?: string
   includeRecalled: boolean
+  /** 是否在导出内容中保留资源下载链接；旧调用方未传时默认开启。 */
+  includeResourceLinks?: boolean
   includeSystemMessages: boolean
   filterPureImageMessages: boolean
   exportAsZip?: boolean
@@ -256,6 +258,8 @@ export interface CreateTaskRequest {
     startTime?: number
     endTime?: number
     keywords?: string[]
+    excludeUserUins?: string[]
+    includeUserUins?: string[]
     includeRecalled: boolean
   }
   options: {

--- a/qce-v4-tool/types/export-task-plans.ts
+++ b/qce-v4-tool/types/export-task-plans.ts
@@ -35,9 +35,26 @@ export interface ExportTaskPlanOptions {
   includeSystemMessages: boolean
   filterPureImageMessages: boolean
   preferGroupMemberName: boolean
+  includeRecalled: boolean
+  debugExport: boolean
+  streamingZipMode: boolean
+  exportAsZip: boolean
+  embedAvatarsAsBase64: boolean
+  embedResourcesAsDataUri: boolean
+  skipDownloadResourceTypes?: Array<"image" | "video" | "audio" | "file">
+  useNameInFileName: boolean
+  useFriendlyFileName: boolean
+  keywords?: string
+  excludeUserUins?: string
+  includeUserUins?: string
 }
 
-export type ExportTaskPlanTimeRangeType = "all" | "last-7-days" | "last-30-days" | "custom"
+export type ExportTaskPlanTimeRangeType =
+  | "all"
+  | "recent-3-months"
+  | "last-7-days"
+  | "last-30-days"
+  | "custom"
 
 export interface ExportTaskPlanLastRun {
   runId: string
@@ -134,6 +151,47 @@ export type GroupTagMap = Record<string, string[]>
 export const DEFAULT_BATCH_SIZE = 20
 export const MIN_BATCH_SIZE = 5
 export const MAX_BATCH_SIZE = 50
+
+export const DEFAULT_EXPORT_TASK_PLAN_OPTIONS: ExportTaskPlanOptions = {
+  includeResourceLinks: true,
+  includeSystemMessages: true,
+  filterPureImageMessages: true,
+  preferGroupMemberName: true,
+  includeRecalled: false,
+  debugExport: false,
+  streamingZipMode: false,
+  exportAsZip: false,
+  embedAvatarsAsBase64: false,
+  embedResourcesAsDataUri: false,
+  useNameInFileName: false,
+  useFriendlyFileName: false,
+}
+
+/**
+ * 补齐旧版 localStorage 中不存在的导出选项，同时保留任务、进度和运行信息。
+ * 不改存储 key，避免一次性破坏用户已有任务。
+ */
+export function normalizeExportTaskPlan(plan: ExportTaskPlan): ExportTaskPlan {
+  const skipDownloadResourceTypes = Array.isArray(plan.options?.skipDownloadResourceTypes)
+    ? plan.options.skipDownloadResourceTypes.filter(
+        (value): value is "image" | "video" | "audio" | "file" =>
+          value === "image" || value === "video" || value === "audio" || value === "file",
+      )
+    : undefined
+
+  return {
+    ...plan,
+    options: {
+      ...DEFAULT_EXPORT_TASK_PLAN_OPTIONS,
+      ...(plan.options || {}),
+      ...(skipDownloadResourceTypes && skipDownloadResourceTypes.length > 0
+        ? { skipDownloadResourceTypes }
+        : { skipDownloadResourceTypes: undefined }),
+    },
+    timeRangeType: plan.timeRangeType || "all",
+    batchSize: plan.batchSize || DEFAULT_BATCH_SIZE,
+  }
+}
 
 let idCounter = 0
 export function genId(prefix: string): string {


### PR DESCRIPTION
## 背景

「导出任务」(可复用导出计划)此前使用了一套精简的持久化与请求模型,只保存 4 个开关,执行时还硬编码了部分参数(如 `includeRecalled=false`),导致它和普通/批量导出的能力不一致。此外会话列表的多选操作条用 `fixed bottom-8`,分页栏也在底部,二者没有预留安全区,会互相遮挡。
修改前：
<img width="416" height="59" alt="PixPin_2026-08-19_22-09-48" src="https://github.com/user-attachments/assets/0dcd2779-c2a2-4ac1-8deb-1e388265c9d4" />

修改后：
<img width="908" height="148" alt="PixPin_2026-08-19_21-08-34" src="https://github.com/user-attachments/assets/c226afc2-b917-4c51-979c-c221425dcf3d" />

关联 issue: #641

## 主要改动

- **抽取共享请求构造** `lib/export-request.ts`:单次导出、批量导出、可复用导出任务三处统一字段与默认值,避免新增选项时再次出现两边不一致;顺带修复批量任务硬编码 `includeRecalled=false`、不传 `peerUin`、丢失关键词/成员过滤等问题
- **扩展 `ExportTaskPlanOptions`**:完整保存系统消息 / 快速导出 / 按资源类型跳过下载 / 群成员名称 / 调试 / 流式 / ZIP / 自包含 HTML / 头像 Base64 / 文件名规则 / 关键词 / 排除成员 / 仅包含成员 / 撤回消息等
- **时间范围**:保留增量导出开关;关闭增量后提供"全部消息 / 最近 3 个月 / 自定义",并兼容已有任务中的"最近 7 天 / 30 天";自定义起止时间保存、回显并校验结束时间不早于开始时间
- **旧数据兼容**:`normalizeExportTaskPlan` 补齐 localStorage 旧任务缺失字段,不删除已有任务、群集合、进度与历史
- **修复分页遮挡**:多选操作条改 `sticky`,有分页时上移;小屏收缩换行;跨页保留选择,分页按钮保持可点击

## 行为变化(请评审重点关注)

增量导出首次运行(该群无进度游标)时,改为导出**全部历史**(此前按时间范围起导)。对"群备份"场景更合理,已加测试断言。如维护者认为应保持旧行为,我可以调整。

## 测试

- 新增 `e2e/export-task-plan-config.spec.ts`:请求构造、流式端点选择、旧数据归一化、增量游标续传、时间范围边界
- 扩展 `e2e/ui-smoke.spec.ts`:313 会话分页无遮挡回归
- 本地已跑通 `pnpm build` 与上述 Playwright 用例

## 范围

仅改动 `qce-v4-tool` 前端;现有 Rust 导出 API 已支持相关请求字段,不涉及服务端改动。导出任务仍只管理群聊集合,不扩展到好友会话。
