### PR TITLE
fix(plugin): pass through non-function API props and stop overwriting NapCat core.apis

### DIFF
--- a/plugins/qq-chat-exporter/__tests__/unit/apiAdapter.test.ts
+++ b/plugins/qq-chat-exporter/__tests__/unit/apiAdapter.test.ts
@@ -1,0 +1,107 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { __apiAdapterDebug, createApiAdapter, plugin_cleanup, plugin_init } from '../../index.mjs';
+
+describe('createApiAdapter', () => {
+    it('passes through non-function properties like groupMemberCache (issue #654)', () => {
+        const groupMemberCache = new Map([['g1_u1', { uid: 'u1' }]]);
+        const apis = { GroupApi: { groupMemberCache } };
+        const adapter = createApiAdapter(apis);
+
+        const exposed = adapter.GroupApi.groupMemberCache;
+        assert.equal(exposed, groupMemberCache);
+        assert.equal(exposed.get('g1_u1').uid, 'u1');
+    });
+
+    it('passes through non-function PacketApi.pkt so pkt.operation.* resolves', () => {
+        const GetGroupFileUrl = async () => ({ url: 'https://example.invalid/file' });
+        const apis = { PacketApi: { pkt: { operation: { GetGroupFileUrl } } } };
+        const adapter = createApiAdapter(apis);
+
+        const pkt = adapter.PacketApi.pkt;
+        assert.equal(typeof pkt, 'object');
+        assert.equal(pkt.operation.GetGroupFileUrl, GetGroupFileUrl);
+    });
+
+    it('keeps stub fallbacks for truly unknown methods', async () => {
+        const adapter = createApiAdapter({ GroupApi: {} });
+
+        const missing = adapter.GroupApi.someUnknownMethod;
+        assert.equal(typeof missing, 'function');
+        assert.deepEqual(await missing(), { result: 0, errMsg: '' });
+
+        const missingNs = adapter.UnknownApi.whatever;
+        assert.equal(typeof missingNs, 'function');
+        assert.deepEqual(await missingNs(), { result: 0, errMsg: '' });
+    });
+
+    it('keeps known-method stubs when the real method is absent', async () => {
+        const adapter = createApiAdapter({ GroupApi: {} });
+        assert.deepEqual(await adapter.GroupApi.getGroups(), []);
+    });
+
+    it('binds real functions to their API object', async () => {
+        const calls: unknown[][] = [];
+        const apis = {
+            GroupApi: {
+                getGroups(this: object, ...args: unknown[]) {
+                    assert.equal(this, apis.GroupApi);
+                    calls.push(args);
+                    return ['g1'];
+                }
+            }
+        };
+        const adapter = createApiAdapter(apis);
+
+        assert.deepEqual(await adapter.GroupApi.getGroups('x'), ['g1']);
+        assert.deepEqual(calls, [['x']]);
+    });
+
+    it('passes through non-function properties of known namespaces instead of stubbing them', () => {
+        const apis = { GroupApi: { getGroups: null } };
+        const adapter = createApiAdapter(apis);
+        assert.equal(adapter.GroupApi.getGroups, null);
+    });
+});
+
+describe('plugin_init core isolation', () => {
+    it('does not overwrite NapCat core.apis with the adapter proxy (issue #654)', async () => {
+        const groupMemberCache = new Map([['g1_u1', { uid: 'u1' }]]);
+        const getGroups = async () => [{ groupCode: '1' }];
+        const core = {
+            context: {
+                logger: {
+                    log() {},
+                    logError() {},
+                    logWarn() {},
+                    logDebug() {},
+                },
+            },
+            apis: {
+                GroupApi: {
+                    groupMemberCache,
+                    getGroups,
+                },
+            },
+        };
+
+        try {
+            // plugin_init catches startup failures internally (no qce-server in tests),
+            // but the core wrapping happens before the launcher starts.
+            await plugin_init(core);
+
+            // NapCat's own core.apis must be untouched.
+            assert.equal(core.apis.GroupApi.groupMemberCache, groupMemberCache);
+            assert.equal(core.apis.GroupApi.groupMemberCache.get('g1_u1').uid, 'u1');
+            assert.equal(core.apis.GroupApi.getGroups, getGroups);
+
+            // The QCE runtime adapter exposes the same data safely.
+            const adapter = __apiAdapterDebug.lastApis;
+            assert.ok(adapter, 'adapter created');
+            assert.equal(adapter.GroupApi.groupMemberCache, groupMemberCache);
+            assert.equal(typeof adapter.GroupApi.getGroups, 'function');
+        } finally {
+            await plugin_cleanup();
+        }
+    });
+});

--- a/plugins/qq-chat-exporter/index.mjs
+++ b/plugins/qq-chat-exporter/index.mjs
@@ -55,13 +55,22 @@ export function createFallbackCore(rawCore) {
 }
 
 /**
+ * Test-only introspection for the last adapter produced by createApiAdapter.
+ * Tracks at most the most recent adapter.
+ */
+export const __apiAdapterDebug = {
+  lastApis: undefined,
+};
+
+/**
  * API adapter that wraps the real NapCat apis and provides fallback implementations
  * for methods that are missing or have different signatures in NapCat 4.18.6.
  * 
  * This adapter receives the REAL NapCat APIs (from the bridge), not the stub Proxy.
  * It provides stub fallbacks for methods that don't exist or return wrong types.
+ * Non-function properties of the real APIs are passed through untouched.
  */
-function createApiAdapter(apis) {
+export function createApiAdapter(apis) {
   // Known methods that QCE expects, organized by API namespace
   const knownMethods = {
     GroupApi: ['getGroups', 'fetchGroupDetail', 'getGroupMemberAll', 'getGroupFileCount'],
@@ -86,7 +95,7 @@ function createApiAdapter(apis) {
     },
   };
 
-  return new Proxy({}, {
+  const adapter = new Proxy({}, {
     get(target, apiName) {
       if (!(apiName in target)) {
         target[apiName] = new Proxy({}, {
@@ -102,6 +111,10 @@ function createApiAdapter(apis) {
               if (typeof realMethod === 'function') {
                 return realMethod.bind(realApi);
               }
+              // Pass through non-function properties (Maps, objects) untouched
+              if (realApi && methodName in realApi) {
+                return realMethod;
+              }
               // Fall back to stub
               return methodStubs?.[methodName] || (async () => []);
             }
@@ -112,6 +125,10 @@ function createApiAdapter(apis) {
             if (typeof realMethod === 'function') {
               return realMethod.bind(realApi);
             }
+            // Pass through non-function properties (Maps, objects) untouched
+            if (realApi && methodName in realApi) {
+              return realMethod;
+            }
             return async () => ({ result: 0, errMsg: '' });
           }
         });
@@ -119,6 +136,9 @@ function createApiAdapter(apis) {
       return target[apiName];
     }
   });
+
+  __apiAdapterDebug.lastApis = adapter;
+  return adapter;
 }
 
 function pickFirstDefined(...values) {
@@ -249,13 +269,22 @@ export async function plugin_init(arg0, arg1, arg2, arg3) {
 
     const runtimeCore = createFallbackCore(core);
     const realApis = globalThis.__NAPCAT_BRIDGE__?.core?.apis || runtimeCore.apis;
-    runtimeCore.apis = createApiAdapter(realApis);
+    const adapter = createApiAdapter(realApis);
+    // Keep NapCat's core.apis untouched: the adapter proxy is QCE-only.
+    // createFallbackCore returns the same object when given a real core, so
+    // copy-on-write is needed to avoid polluting NapCat's runtime state.
+    const qceCore = runtimeCore === core
+      ? Object.assign(Object.create(Object.getPrototypeOf(core)), core, { apis: adapter })
+      : runtimeCore;
+    if (qceCore === runtimeCore) {
+      runtimeCore.apis = adapter;
+    }
 
     if (apiLauncher) {
       await apiLauncher.stopApiServer();
       apiLauncher = null;
     }
-    apiLauncher = new QQChatExporterApiLauncher(runtimeCore);
+    apiLauncher = new QQChatExporterApiLauncher(qceCore);
     await apiLauncher.startApiServer();
   } catch (error) {
     console.error('[QCE] Initialization failed:', error);


### PR DESCRIPTION
## Summary

Fixes #654.

`createApiAdapter`'s Proxy replaced every unknown property with a stub `async` function, and `plugin_init` assigned that adapter directly onto the live NapCat `core` object (`createFallbackCore` returns the same reference). From then on, every NapCat-internal access to `core.apis.*` went through the function-only Proxy:

- `core.apis.GroupApi.groupMemberCache` (a `Map`) became a stub function → `TypeError: this.core.apis.GroupApi.groupMemberCache.get is not a function` on every group system message.
- `core.apis.PacketApi.pkt` (an object) became a stub function → `pkt.operation` is `undefined` → `Cannot read properties of undefined (reading 'FetchRkey')` on every image parse.

## Changes

- **`createApiAdapter`**: before falling back to a stub, pass through real non-function properties (`if (realApi && methodName in realApi) return realMethod;`) in both the known-method and unknown-method branches.
- **`plugin_init`**: stop mutating NapCat's `core.apis`. The QCE runtime core now gets a copy-on-write wrapper (same prototype, own properties copied) whose own `apis` is the adapter, leaving the original NapCat core untouched.
- Export `createApiAdapter` and add `__tests__/unit/apiAdapter.test.ts` with regression tests covering property pass-through (`groupMemberCache`, `PacketApi.pkt`), stub behavior for genuinely missing methods, and `plugin_init` core isolation.

## Verification

- `npm run typecheck` — clean
- `npm test` — 58 pass, 0 fail (22 pre-existing POSIX-only skips on Windows)
- `npm run test:entrypoint` / `npm run test:context` — pass

Note for the reporter's environment: `FetchRkey` may still fail on QQ `3.2.32-52194` because NapCat v4.18.19's built-in Linux offset table only covers up to `3.2.30-50969` — but after this fix that surfaces as the real PacketBackend error instead of the Proxy-induced `undefined` crash. The `groupMemberCache` error is fully resolved by this patch.