### PR TITLE
fix: 修复批量导出时进度显示异常的问题，增加回归测试；调整了一些零散的配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ NapCat-QCE-Windows-x64/
 NapCatQQ-clean/
 .ciallo/
 .kiro/
+
+# Frontend static artifacts
+static/

--- a/qce-v4-tool/app/page.tsx
+++ b/qce-v4-tool/app/page.tsx
@@ -1081,7 +1081,10 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
   }
 
   // 批量导出处理函数
-  const handleBatchExport = async (config: BatchExportConfig) => {
+  const handleBatchExport = async (
+    config: BatchExportConfig,
+    onProgress?: (index: number, status: 'success' | 'failed', error?: string) => void
+  ) => {
     const items = getBatchExportItems()
     const results: Array<{ name: string; status: 'success' | 'failed'; error?: string }> = []
 
@@ -1145,15 +1148,19 @@ export default function QCEDashboard({ initialTab }: { initialTab?: string } = {
         const success = await createTask(form)
         
         if (success) {
+          onProgress?.(i, 'success')
           results.push({ name: item.name, status: 'success' })
         } else {
+          onProgress?.(i, 'failed', '导出失败')
           results.push({ name: item.name, status: 'failed', error: '导出失败' })
         }
       } catch (error) {
+        const message = error instanceof Error ? error.message : '未知错误'
+        onProgress?.(i, 'failed', message)
         results.push({ 
           name: item.name, 
           status: 'failed', 
-          error: error instanceof Error ? error.message : '未知错误' 
+          error: message 
         })
       }
 

--- a/qce-v4-tool/components/ui/batch-export-dialog.tsx
+++ b/qce-v4-tool/components/ui/batch-export-dialog.tsx
@@ -32,11 +32,17 @@ export interface BatchExportItem {
   avatarUrl?: string
 }
 
+export type ExportProgressCallback = (
+  index: number,
+  status: 'success' | 'failed',
+  error?: string
+) => void
+
 interface BatchExportDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   items: BatchExportItem[]
-  onExport: (config: BatchExportConfig) => Promise<void>
+  onExport: (config: BatchExportConfig, onProgress?: ExportProgressCallback) => Promise<void>
 }
 
 export interface BatchExportConfig {
@@ -240,7 +246,14 @@ export function BatchExportDialog({ open, onOpenChange, items, onExport }: Batch
     }
 
     try {
-      await onExport(config)
+      await onExport(config, (index, status, error) => {
+        setProgress(prev => {
+          const nextResults = [...prev.results]
+          nextResults[index] = { name: items[index]?.name || '', status, error }
+          const next = Math.min(index + 1, items.length - 1)
+          return { ...prev, current: next, currentItem: items[next]?.name || '', results: nextResults }
+        })
+      })
       setProgress(prev => ({ ...prev, status: 'completed' }))
     } catch (error) {
       setProgress(prev => ({ ...prev, status: 'failed' }))

--- a/qce-v4-tool/e2e/batch-export-progress.spec.ts
+++ b/qce-v4-tool/e2e/batch-export-progress.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test'
+
+const TOKEN = process.env.QCE_MOCK_TOKEN ?? 'qce_mock_token_for_tests'
+const FRONTEND_BASE = process.env.E2E_FRONTEND_URL ?? 'http://localhost:40653'
+const SHELL_PATH = '/qce'
+
+async function clearLocalStorage(page: import('@playwright/test').Page) {
+    await page.goto(`${FRONTEND_BASE}${SHELL_PATH}`).catch(() => null)
+    await page.evaluate(() => localStorage.clear()).catch(() => null)
+}
+
+test.describe('Batch export progress', () => {
+    /**
+     * 回归测试：page.tsx 的 handleBatchExport 会接收 dialog 传入的 onProgress
+     * 回调，并在每个 createTask 完成后回调一次。dialog 依据回调逐会话推进
+     * 进度（当前会话数和绿色成功勾均需满足）。
+     * 断言进度严格按 1/3 → 2/3 → 3/3 推进、成功勾逐个出现。
+     */
+    test('page.tsx onProgress callback advances progress per session', async ({ page }) => {
+        await clearLocalStorage(page)
+        await page.evaluate((value) => {
+            localStorage.setItem('qce_access_token', value)
+        }, TOKEN)
+
+        const response = await page.goto(`${FRONTEND_BASE}${SHELL_PATH}`).catch(() => null)
+        test.skip(
+            !response || response.status() >= 500,
+            `frontend not reachable at ${FRONTEND_BASE}`
+        )
+
+        // 关掉欢迎弹窗（如有），切到会话标签页。
+        const skipBtn = page.getByRole('button', { name: '跳过' }).first()
+        if (await skipBtn.isVisible({ timeout: 1500 }).catch(() => false)) {
+            await skipBtn.click().catch(() => null)
+        }
+        const sessionsTab = page.getByRole('button', { name: '会话', exact: true })
+        await expect(sessionsTab).toBeVisible({ timeout: 15_000 })
+        await sessionsTab.click()
+
+        // 进入批量选择模式。
+        await page.getByRole('button', { name: '批量选择' }).click()
+
+        // 逐个搜索并勾选三个会话。
+        const searchBox = page.locator('input[placeholder*="搜索会话"]').first()
+        await expect(searchBox).toBeVisible({ timeout: 15_000 })
+        const sessions = ['Alice', 'Bob', 'QCE Testing Group']
+        for (const name of sessions) {
+            await searchBox.fill(name)
+            await page.getByRole('checkbox', { name: `选择会话 ${name}` }).click()
+        }
+
+        // 打开批量导出对话框。
+        await page.getByRole('button', { name: '设置并导出' }).click()
+        const dialog = page.getByRole('dialog', { name: '批量导出聊天记录' })
+        await expect(dialog).toBeVisible()
+        await expect(dialog.getByText('已选择 3 个会话进行批量导出。')).toBeVisible()
+
+        // 捕获每个导出请求，手动逐个放行，让每个进度中间态可观测。
+        const exportRequests: Array<() => void> = []
+        await page.route('**/api/messages/export', async (route) => {
+            await new Promise<void>((resolve) => exportRequests.push(resolve))
+            await route.continue()
+        })
+
+        await dialog.getByRole('button', { name: '开始批量导出' }).click()
+
+        // 第 1 个请求发出：进度停在 1/3，尚无成功勾。
+        await expect.poll(() => exportRequests.length, 'first export request sent').toBe(1)
+        await expect(dialog.getByText('1 / 3 个会话')).toBeVisible()
+        await expect(dialog.locator('svg.text-green-500')).toHaveCount(0)
+
+        // 放行第 1 个：page.tsx 回传 success，进度推进到 2/3，出现 1 个成功勾。
+        exportRequests[0]()
+        await expect.poll(() => exportRequests.length, 'second export request sent').toBe(2)
+        await expect(dialog.getByText('2 / 3 个会话')).toBeVisible()
+        await expect(dialog.locator('svg.text-green-500')).toHaveCount(1)
+
+        // 放行第 2 个：进度推进到 3/3，出现 2 个成功勾。
+        exportRequests[1]()
+        await expect.poll(() => exportRequests.length, 'third export request sent').toBe(3)
+        await expect(dialog.getByText('3 / 3 个会话')).toBeVisible()
+        await expect(dialog.locator('svg.text-green-500')).toHaveCount(2)
+
+        // 放行第 3 个：全部完成，对话框自动关闭，弹出通知。
+        exportRequests[2]()
+        await expect(dialog).toBeHidden({ timeout: 15_000 })
+        await expect(page.getByText('成功创建 3 个导出任务')).toBeVisible({ timeout: 15_000 })
+    })
+})

--- a/qce-v4-tool/package.json
+++ b/qce-v4-tool/package.json
@@ -12,12 +12,6 @@
     "test:e2e:install": "playwright install chromium",
     "test:e2e:ui": "playwright test --ui"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@tailwindcss/oxide",
-      "sharp"
-    ]
-  },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-accordion": "1.2.18",

--- a/qce-v4-tool/pnpm-workspace.yaml
+++ b/qce-v4-tool/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - '.'
+
+allowBuilds:
+  sharp: true
+  "@tailwindcss/oxide": true

--- a/qce-v4-tool/proxy.ts
+++ b/qce-v4-tool/proxy.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   // Intercept POST /auth for token validation (mock: always succeed)
   if (request.nextUrl.pathname === "/auth" && request.method === "POST") {
     return NextResponse.json({ success: true, data: { token: "mock" } })


### PR DESCRIPTION
## 问题

批量导出多个会话时，进度始终卡在 `正在导出1 / N个会话`，不会随每个会话完成而推进；左侧列表的绿色成功勾选进度也不更新。原因是 `page.tsx` 中 `BatchExportDialog` 的 `handleExport` 调用 `onExport(config)` 后，进度只在 `finally` 里被设为固定值，缺少逐聊天会话的回调更新。

## 修复

`BatchExportDialog` 新增 `ExportProgressCallback` 类型，`onExport` 签名改为 `(config, onProgress?) => Promise<void>`。`handleExport` 在调用时传入回调，每完成一个会话就更新 `progress.current`、`currentItem` 和 `results[index]` 的状态。

`page.tsx` 的 `handleBatchExport` 接收 `onProgress` 参数，在每个 `createTask` 成功或失败后调用回调。

## 测试

新增 `batch-export-progress.spec.ts`，逐次放行 3 个导出请求，断言进度严格按 `1/3 → 2/3 → 3/3` 推进、绿色成功勾逐个出现（`0 → 1 → 2`），验证 page.tsx 的回调确实使进度更新。

## 额外修复

1. 添加前端构建产物 `/static` 文件夹至根目录的 `.gitignore` 文件
2. 文件 `qce-v4-tool\package.json` 的 `onlyBuiltDependencies` 写法过时，用 `qce-v4-tool\pnpm-workspace.yaml` 代替
3. 文件`qce-v4-tool\middleware.ts` 的命名过时，更改为 `qce-v4-tool\proxy.ts` 