### PR TITLE
fix(macos): patch the QQ runtime copy's main field without sed -i

### DIFF
--- a/scripts/napcat-launcher/launcher-user.sh
+++ b/scripts/napcat-launcher/launcher-user.sh
@@ -497,7 +497,38 @@ if (process.env.QCE_NAPCAT_ENTRY === '1') {
 LOADER_EOF
 
         # In-place edit of the "main" field only, in the private copy.
-        sed -i '' -E 's/"main": *"[^"]*"/"main": ".\/loadNapCat-qce.js"/' "$QQ_RUNTIME_PKG_JSON"
+        #
+        # Deliberately NOT `sed -i ''`: that is BSD-only syntax. GNU sed and
+        # toybox sed treat the following '' as a separate operand (a filename)
+        # instead of the backup suffix for -i, so the substitution never runs
+        # — sed prints `s/.../.../: No such file or directory`, exits non-zero,
+        # and nothing checked it. The copy then boots its original "main"
+        # (application.asar/app_launcher/index.js), NapCat is never imported,
+        # and the launcher sits there waiting on a QR code that will never be
+        # generated, with no error pointing at the real cause. Hit in practice
+        # with the toybox sed some shims put ahead of /usr/bin/sed on PATH.
+        #
+        # Redirect + mv does the same in-place edit portably: it needs no -i
+        # at all, so every sed flavour parses the arguments identically.
+        local patched_json
+        patched_json="$(mktemp "${TMPDIR:-/tmp}/qce-pkg-json.XXXXXX")"
+        if ! sed -E 's/"main": *"[^"]*"/"main": ".\/loadNapCat-qce.js"/' \
+                "$QQ_RUNTIME_PKG_JSON" > "$patched_json"; then
+            rm -f "$patched_json"
+            echo "[Error] Failed to rewrite \"main\" in $QQ_RUNTIME_PKG_JSON."
+            exit 1
+        fi
+        mv "$patched_json" "$QQ_RUNTIME_PKG_JSON"
+
+        # Fail loudly instead of booting an unpatched copy. Without this the
+        # user gets the same silent "no QR code" hang on every run.
+        if ! grep -q '"main": *"\./loadNapCat-qce\.js"' "$QQ_RUNTIME_PKG_JSON" 2>/dev/null; then
+            echo "[Error] $QQ_RUNTIME_PKG_JSON does not carry the patched \"main\"."
+            echo "        The runtime copy would boot QQ's own entry point and"
+            echo "        NapCat would never load. Delete the copy and re-run:"
+            echo "          rm -rf \"$QQ_RUNTIME_APP_DIR\""
+            exit 1
+        fi
 
         macos_resign_qq_runtime
         qq_source_version_marker > "$QQ_RUNTIME_SOURCE_MARKER"

--- a/scripts/napcat-launcher/test-main-patch.sh
+++ b/scripts/napcat-launcher/test-main-patch.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# Regression test for the macOS runtime copy's package.json patch.
+#
+# launcher-user.sh rewrites "main" to ./loadNapCat-qce.js in its private copy
+# of QQ.app so NapCat's napcat.mjs loads inside QQ's own Electron runtime.
+# That used to be done with `sed -i ''`, which silently no-ops under GNU sed
+# and toybox sed: they parse the following '' as a filename rather than as the
+# backup suffix, so nothing is substituted and sed exits non-zero unnoticed.
+# The copy then boots QQ's own entry point, NapCat never loads, and the
+# launcher waits forever on a QR code that is never generated — with no error
+# pointing at the real cause.
+#
+# Usage: sh scripts/napcat-launcher/test-main-patch.sh
+# Exits non-zero on failure. Needs only a POSIX shell and sed.
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+LAUNCHER="$SCRIPT_DIR/launcher-user.sh"
+
+fail() {
+    printf 'FAIL: %s\n' "$1"
+    exit 1
+}
+
+pass() {
+    printf 'ok:   %s\n' "$1"
+}
+
+[ -f "$LAUNCHER" ] || fail "launcher not found at $LAUNCHER"
+
+# 1. No in-place sed anywhere in executable code.
+#    sed -i is exactly the portability trap this test exists for: BSD requires
+#    a suffix argument, GNU sed and toybox sed treat it as a filename. Comment
+#    lines are stripped first so that explaining the trap in launcher-user.sh
+#    does not itself trip the check.
+if sed 's/[[:space:]]*#.*$//' "$LAUNCHER" | grep -qE 'sed[[:space:]]+-i'; then
+    fail "launcher-user.sh uses 'sed -i'; use redirect + mv instead"
+fi
+pass "no in-place sed in launcher-user.sh"
+
+# 2. The substitution actually rewrites the field.
+#    The expression is read out of launcher-user.sh rather than duplicated
+#    here, so the test cannot silently drift from the shipped one.
+EXPR=$(grep -oE "sed -E '[^']*loadNapCat-qce[^']*'" "$LAUNCHER" | head -1 |
+    sed -E "s/^sed -E '//; s/'\$//")
+[ -n "$EXPR" ] || fail "could not extract the main-field substitution from launcher-user.sh"
+printf 'info: expression under test: %s\n' "$EXPR"
+printf 'info: sed under test:        %s\n' "$(command -v sed)"
+
+FIXTURE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/qce-main-patch.XXXXXX")
+trap 'rm -rf "$FIXTURE_DIR"' EXIT INT TERM
+
+FIXTURE="$FIXTURE_DIR/package.json"
+printf '{"name":"qq","main":"./application.asar/app_launcher/index.js","version":"6.9.95-48517"}\n' >"$FIXTURE"
+
+sed -E "$EXPR" "$FIXTURE" >"$FIXTURE_DIR/patched" || fail "sed exited non-zero for: $EXPR"
+mv "$FIXTURE_DIR/patched" "$FIXTURE"
+
+if ! grep -q '"main": *"\.\/loadNapCat-qce\.js"' "$FIXTURE"; then
+    printf 'info: produced %s\n' "$(cat "$FIXTURE")"
+    fail "main field was not rewritten"
+fi
+pass "main field rewritten"
+
+# 3. The substitution must not touch anything else in the manifest.
+grep -q '"version": *"6.9.95-48517"' "$FIXTURE" || fail "substitution clobbered other fields"
+grep -q '"name": *"qq"' "$FIXTURE" || fail "substitution clobbered other fields"
+pass "other fields untouched"
+
+printf '\nall checks passed\n'


### PR DESCRIPTION
## Problem

On macOS, `launcher-user.sh` rewrites the `"main"` field of its private copy of
QQ.app so that NapCat's `napcat.mjs` loads inside QQ's own Electron runtime.
It did that with:

```sh
sed -i '' -E 's/"main": *"[^"]*"/"main": ".\/loadNapCat-qce.js"/' "$QQ_RUNTIME_PKG_JSON"
```

`sed -i ''` is BSD-only. GNU sed and toybox sed parse the following `''` as a
separate operand (a filename) rather than as the backup suffix, so **the
substitution never runs**. sed prints

```
sed: s/"main": *"[^"]*"/"main": ".\/loadNapCat-qce.js"/: No such file or directory
```

exits non-zero, and the script — which is `set -u` but not `set -e` — keeps
going. The copy is then re-signed and launched with its original `"main"`
(`./application.asar/app_launcher/index.js`), so:

- NapCat is never imported
- no QR code is ever generated
- no port is ever opened
- **nothing in the output points at the cause**

QQ appears to start normally, which makes this look like a hang rather than a
failure. It is reachable whenever a non-BSD `sed` sits ahead of `/usr/bin/sed`
on `PATH` — I hit it with the toybox sed a CLI shim installs.

## Fix

- **Redirect + `mv` instead of `sed -i`.** No `-i` means no flavour-dependent
  argument parsing. A failing `sed` now aborts the launcher instead of falling
  through.
- **Verify the patched `"main"` before re-signing.** The idempotency check at
  the top of `macos_prepare_qq_runtime` keys off this exact string, so a no-op
  patch used to loop the user through the same silent hang on every run. Now it
  exits with a message naming the file and the remedy.

## Regression test

`scripts/napcat-launcher/test-main-patch.sh` (POSIX sh, no dependencies):

1. strips comments, then fails on any real `sed -i`;
2. replays the substitution **extracted from `launcher-user.sh`** — not a copy —
   against a fixture manifest, so the test cannot drift from what ships;
3. asserts unrelated manifest fields survive.

Verified:

| check | result |
| --- | --- |
| `sh test-main-patch.sh` under toybox sed | pass |
| `sh test-main-patch.sh` under BSD sed | pass |
| same test against pre-fix `launcher-user.sh` | **fail** (`uses 'sed -i'`) |
| `bash -n` / `sh -n` / `git diff --check` | clean |

Not run: shellcheck (not installed here) and the macOS end-to-end launch, which
needs a QR scan. `scripts/` has no test harness or CI job, so the new test is
not wired into CI — happy to add a workflow if you want one.

## Scope

Two files. No behavior change on the happy path: the copy still gets the same
`"main"`, the same loader, and the same ad-hoc re-signature.
