### PR TITLE
feat(server): 引入信号量排队机制支持大批量会话导出并补充回归测试

### DIFF
--- a/qq-chat-export-server/src/api/routes/messages.rs
+++ b/qq-chat-export-server/src/api/routes/messages.rs
@@ -423,6 +423,7 @@ fn standalone_guard_with(state: &SharedState, feature: &str) -> Option<ApiError>
 fn broadcast_progress(
     state: &SharedState,
     task_id: &str,
+    status: &str,
     progress: i64,
     message: &str,
     count: usize,
@@ -431,7 +432,7 @@ fn broadcast_progress(
         "type": "export_progress",
         "data": {
             "taskId": task_id,
-            "status": "running",
+            "status": status,
             "progress": progress,
             "message": message,
             "messageCount": count,
@@ -1196,7 +1197,7 @@ async fn run_export_task(
             }),
         )
         .await;
-        broadcast_progress(&state, &task_id, 0, "正在排队中...", 0);
+        broadcast_progress(&state, &task_id, "queued", 0, "正在排队中...", 0);
 
         // 排队：异步获取并发名额，_permit 生命周期覆盖整个导出过程。
         // 当前面的任务结束时自动唤醒队列中排在最前方的任务。
@@ -1219,7 +1220,7 @@ async fn run_export_task(
             Err("导出服务已关闭".to_string())
         }
     };
-    release_export_path(req.output_dir.join(&file_name));
+    release_export_path(&req.output_dir.join(&file_name));
 
     if let Err(error) = result {
         if is_cancelled(&state, &task_id, &cancel_flag).await {
@@ -1666,7 +1667,7 @@ async fn process_export_task(
         json!({ "status": "running", "progress": 0, "message": "开始获取消息..." }),
     )
     .await;
-    broadcast_progress(state, task_id, 0, "开始获取消息...", 0);
+    broadcast_progress(state, task_id, "running", 0, "开始获取消息...", 0);
     let debug_session = if req.options.get("debugExport").and_then(Value::as_bool) == Some(true) {
         let session = ExportDebugSession::start(&req.output_dir, file_name).await?;
         session
@@ -1756,7 +1757,7 @@ async fn process_export_task(
             json!({ "progress": progress, "messageCount": spool.count(), "message": message }),
         )
         .await;
-        broadcast_progress(state, task_id, progress, &message, spool.count());
+        broadcast_progress(state, task_id, "running", progress, &message, spool.count());
         previous = Some(batch);
     }
 
@@ -1795,7 +1796,14 @@ async fn process_export_task(
         json!({ "progress": 55, "message": "正在解析消息...", "messageCount": spool.count() }),
     )
     .await;
-    broadcast_progress(state, task_id, 55, "正在解析消息...", spool.count());
+    broadcast_progress(
+        state,
+        task_id,
+        "running",
+        55,
+        "正在解析消息...",
+        spool.count(),
+    );
 
     let sender_title_resolver = title_map.map(|map| {
         let map = Arc::new(map);
@@ -1945,6 +1953,7 @@ async fn process_export_task(
                     broadcast_progress(
                         &state_cb,
                         &task_id_cb,
+                        "running",
                         percent,
                         &progress.message,
                         count_cb,
@@ -1974,7 +1983,14 @@ async fn process_export_task(
             json!({ "progress": progress_next, "message": message, "messageCount": parsed_count }),
         )
         .await;
-        broadcast_progress(state, task_id, progress_next, &message, parsed_count);
+        broadcast_progress(
+            state,
+            task_id,
+            "running",
+            progress_next,
+            &message,
+            parsed_count,
+        );
     }
     drop(reader);
     drop(spool);
@@ -2015,7 +2031,14 @@ async fn process_export_task(
         json!({ "progress": 85, "message": "正在生成文件...", "messageCount": parsed_count }),
     )
     .await;
-    broadcast_progress(state, task_id, 85, "正在生成文件...", parsed_count);
+    broadcast_progress(
+        state,
+        task_id,
+        "running",
+        85,
+        "正在生成文件...",
+        parsed_count,
+    );
 
     // Issue #30 / #192：确保输出目录存在。
     tokio::fs::create_dir_all(&req.output_dir)
@@ -2171,13 +2194,27 @@ async fn process_export_task(
                             == Some(true),
                         ..JsonFormatOptions::default()
                     };
-                    broadcast_progress(state, task_id, 90, "正在写入JSON文件...", message_count);
+                    broadcast_progress(
+                        state,
+                        task_id,
+                        "running",
+                        90,
+                        "正在写入JSON文件...",
+                        message_count,
+                    );
                     let exporter = JsonExporter::new(export_options, json_options);
                     exporter
                         .export(clean_messages, &chat_info)
                         .await
                         .map_err(|e| e.to_string())?;
-                    broadcast_progress(state, task_id, 95, "JSON文件写入完成", message_count);
+                    broadcast_progress(
+                        state,
+                        task_id,
+                        "running",
+                        95,
+                        "JSON文件写入完成",
+                        message_count,
+                    );
                 }
                 "EXCEL" => {
                     let exporter =
@@ -2232,7 +2269,14 @@ async fn process_export_task(
                     json!({ "progress": 95, "message": "正在打包ZIP文件..." }),
                 )
                 .await;
-                broadcast_progress(state, task_id, 95, "正在打包ZIP文件...", message_count);
+                broadcast_progress(
+                    state,
+                    task_id,
+                    "running",
+                    95,
+                    "正在打包ZIP文件...",
+                    message_count,
+                );
 
                 let base_zip_file_name = if let Some(stripped) = file_name
                     .strip_suffix(".html")
@@ -2339,7 +2383,14 @@ async fn process_export_task(
                 json!({ "progress": 95, "message": "正在打包ZIP文件..." }),
             )
             .await;
-            broadcast_progress(state, task_id, 95, "正在打包ZIP文件...", message_count);
+            broadcast_progress(
+                state,
+                task_id,
+                "running",
+                95,
+                "正在打包ZIP文件...",
+                message_count,
+            );
             create_zip_from_dir(temp_dir.clone(), file_path.clone()).await?;
             let _ = tokio::fs::remove_dir_all(&temp_dir).await;
         }
@@ -2618,5 +2669,244 @@ mod file_name_tests {
         release_export_path(&base.join(concurrent));
         release_export_path(&base.join(concurrent_2));
         std::fs::remove_dir_all(base).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod task_queue_tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    struct DummyExecutor;
+    #[async_trait::async_trait]
+    impl crate::scheduler::manager::ScheduledExportExecutor for DummyExecutor {
+        async fn execute(
+            &self,
+            _task: &Value,
+            _start_time_sec: i64,
+            _end_time_sec: i64,
+        ) -> Result<crate::scheduler::manager::ExecutionOutcome, String> {
+            Ok(crate::scheduler::manager::ExecutionOutcome {
+                message_count: 0,
+                file_path: None,
+                file_size: None,
+                resource_summary: None,
+                note: None,
+            })
+        }
+    }
+
+    async fn create_test_state() -> (crate::api::state::SharedState, std::path::PathBuf) {
+        let temp =
+            std::env::temp_dir().join(format!("qce-test-queue-{}", uuid::Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&temp).expect("create temp dir");
+        let db = Arc::new(crate::storage::DatabaseManager::new(&temp.join("qce.db")));
+        db.initialize().await.expect("init db");
+        let (ws_tx, _) = tokio::sync::broadcast::channel(16);
+        let path_manager = Arc::new(crate::paths::PathManager::new());
+        let napcat =
+            crate::napcat::NapCatBridgeClient::new("http://127.0.0.1:40654", 10_000).unwrap();
+        let resource_handler = Arc::new(
+            crate::resource::ResourceHandler::new(
+                Arc::new(napcat.clone()),
+                None,
+                Arc::clone(&db),
+                crate::resource::ResourceHandlerConfig {
+                    storage_root: temp.join("resources"),
+                    ..crate::resource::ResourceHandlerConfig::default()
+                },
+            )
+            .await,
+        );
+        let progress_tracker = Arc::new(crate::progress::ProgressTracker::new(Arc::clone(&db)));
+        let security_manager = Arc::new(crate::security::SecurityManager::new().unwrap());
+        let scheduled_export_manager = Arc::new(crate::scheduler::ScheduledExportManager::new(
+            Arc::clone(&db),
+            Arc::new(DummyExecutor),
+        ));
+        let state = Arc::new(crate::api::state::AppState {
+            napcat,
+            run_mode: crate::api::state::RunMode::Plugin,
+            db,
+            resource_handler,
+            progress_tracker,
+            scheduled_export_manager,
+            security_manager,
+            path_manager,
+            ws_tx,
+            export_tasks: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            export_semaphore: Arc::new(tokio::sync::Semaphore::new(
+                crate::api::state::MAX_ACTIVE_EXPORT_TASKS,
+            )),
+            cancelled_task_ids: tokio::sync::Mutex::new(std::collections::HashSet::new()),
+            running_export_cancel_flags: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            resource_file_cache: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            message_cache: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            started_at: std::time::Instant::now(),
+            static_dir: temp.clone(),
+            port: 0,
+        });
+        (state, temp)
+    }
+
+    #[tokio::test]
+    async fn queue_handles_hundreds_of_tasks_without_dropping_requests() {
+        let (state, temp) = create_test_state().await;
+
+        // 旧版本上限为 MAX_ACTIVE_EXPORT_TASKS (32)，只要活跃任务达到 32，后续请求就会被忽略。
+        // 新版本上限为 MAX_QUEUED_TASKS (1000)，能够容纳数百个导出任务排队。
+        const BATCH_SIZE: usize = 300;
+        let mut registered_ids = Vec::with_capacity(BATCH_SIZE);
+
+        for i in 0..BATCH_SIZE {
+            let task_id = format!("test-task-{i}");
+            let task = json!({
+                "taskId": task_id,
+                "peer": { "chatType": 1, "peerUid": format!("user_{i}") },
+                "sessionName": format!("会话_{i}"),
+                "status": "queued",
+                "message": "正在排队中...",
+                "progress": 0,
+                "createdAt": now_iso(),
+            });
+            let success = register_task(&state, &task).await;
+            assert!(success, "任务 {i} 应该成功进入队列");
+            registered_ids.push(task_id);
+        }
+
+        // 验证任务总数达到 300 个，全部状态为 queued
+        let tasks = state.export_tasks.lock().await;
+        assert_eq!(tasks.len(), BATCH_SIZE);
+        for id in &registered_ids {
+            assert_eq!(
+                tasks
+                    .get(id)
+                    .and_then(|t| t.get("status"))
+                    .and_then(Value::as_str),
+                Some("queued")
+            );
+        }
+        drop(tasks);
+
+        let _ = std::fs::remove_dir_all(temp);
+    }
+
+    #[tokio::test]
+    async fn semaphore_limits_concurrent_running_tasks_while_draining_queue() {
+        let (state, temp) = create_test_state().await;
+
+        const TOTAL_TASKS: usize = 100;
+        let currently_running = Arc::new(AtomicUsize::new(0));
+        let peak_running = Arc::new(AtomicUsize::new(0));
+        let completed_count = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = Vec::with_capacity(TOTAL_TASKS);
+
+        for _ in 0..TOTAL_TASKS {
+            let state_clone = Arc::clone(&state);
+            let currently_running_clone = Arc::clone(&currently_running);
+            let peak_running_clone = Arc::clone(&peak_running);
+            let completed_count_clone = Arc::clone(&completed_count);
+
+            let handle = tokio::spawn(async move {
+                // 模拟 run_export_task 中的信号量排队获取
+                let _permit = state_clone.export_semaphore.acquire().await.unwrap();
+
+                // 模拟获取到许可，任务开始执行
+                let cur = currently_running_clone.fetch_add(1, Ordering::SeqCst) + 1;
+                peak_running_clone.fetch_max(cur, Ordering::SeqCst);
+
+                // 确保任何时刻并发运行的任务数均不超过 MAX_ACTIVE_EXPORT_TASKS (32)
+                assert!(
+                    cur <= crate::api::state::MAX_ACTIVE_EXPORT_TASKS,
+                    "并发任务数 {cur} 超过了上限 32"
+                );
+
+                // 模拟耗时任务
+                tokio::time::sleep(Duration::from_millis(5)).await;
+
+                currently_running_clone.fetch_sub(1, Ordering::SeqCst);
+                completed_count_clone.fetch_add(1, Ordering::SeqCst);
+            });
+            handles.push(handle);
+        }
+
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        assert_eq!(
+            completed_count.load(Ordering::SeqCst),
+            TOTAL_TASKS,
+            "所有100个任务均应顺利完成"
+        );
+        assert_eq!(
+            currently_running.load(Ordering::SeqCst),
+            0,
+            "全部完成后运行中任务数应为0"
+        );
+        let peak = peak_running.load(Ordering::SeqCst);
+        assert!(
+            peak <= crate::api::state::MAX_ACTIVE_EXPORT_TASKS,
+            "峰值并发 {peak} 不得超出 32"
+        );
+        assert_eq!(
+            state.export_semaphore.available_permits(),
+            crate::api::state::MAX_ACTIVE_EXPORT_TASKS,
+            "全部完成后信号量许可应全数归还"
+        );
+
+        let _ = std::fs::remove_dir_all(temp);
+    }
+
+    #[tokio::test]
+    async fn queued_task_cancelled_before_acquire_does_not_execute() {
+        let (state, temp) = create_test_state().await;
+
+        let task_id = "test-cancel-in-queue";
+        let task = json!({
+            "taskId": task_id,
+            "status": "queued",
+            "progress": 0,
+        });
+        register_task(&state, &task).await;
+
+        let cancel_flag = Arc::new(AtomicBool::new(false));
+        {
+            let mut flags = state.running_export_cancel_flags.lock().await;
+            flags.insert(task_id.to_string(), Arc::clone(&cancel_flag));
+        }
+
+        // 用户在排队期间取消了任务
+        cancel_flag.store(true, Ordering::SeqCst);
+        {
+            let mut cancelled = state.cancelled_task_ids.lock().await;
+            cancelled.insert(task_id.to_string());
+        }
+
+        // 模拟 run_export_task 的许可获取与取消检查逻辑
+        let mut executed_export = false;
+        if let Ok(_permit) = state.export_semaphore.acquire().await {
+            if is_cancelled(&state, task_id, &cancel_flag).await {
+                // 正确识别取消，不执行实际导出
+            } else {
+                executed_export = true;
+            }
+        }
+
+        assert!(
+            !executed_export,
+            "排队中被取消的任务获取到许可后不应执行导出操作"
+        );
+        assert_eq!(
+            state.export_semaphore.available_permits(),
+            crate::api::state::MAX_ACTIVE_EXPORT_TASKS,
+            "许可必须立刻归还"
+        );
+
+        let _ = std::fs::remove_dir_all(temp);
     }
 }

--- a/qq-chat-export-server/src/api/routes/messages.rs
+++ b/qq-chat-export-server/src/api/routes/messages.rs
@@ -27,8 +27,8 @@ use crate::api::response::{self, ApiError, ErrorType, RequestId};
 use crate::api::routes::groups::standalone_guard;
 use crate::api::state::{MessageCacheEntry, RunMode, SharedState, CACHE_EXPIRE_TIME_MS};
 
-const MAX_ACTIVE_EXPORT_TASKS: usize = 32;
 const MAX_MESSAGE_CACHE_ENTRIES: usize = 64;
+const MAX_QUEUED_TASKS: usize = 1000;
 const MAX_CACHED_MESSAGES_PER_ENTRY: usize = 20_000;
 use crate::clean_message_spool::{CleanMessageSpool, SpooledCleanMessageSource};
 use crate::export_debug::ExportDebugSession;
@@ -844,11 +844,11 @@ async fn register_task(state: &SharedState, task: &Value) -> bool {
             .filter(|value| {
                 matches!(
                     value.get("status").and_then(Value::as_str),
-                    Some("pending" | "running")
+                    Some("queued" | "pending" | "running")
                 )
             })
             .count();
-        if active_count >= MAX_ACTIVE_EXPORT_TASKS {
+        if active_count >= MAX_QUEUED_TASKS {
             return false;
         }
         tasks.insert(task_id, task.clone());
@@ -912,7 +912,8 @@ pub async fn export_messages(
         "fileName": file_name,
         "downloadUrl": download_url,
         "messageCount": 0,
-        "status": "running",
+        "status": "queued",             // 初始状态设为 queued
+        "message": "正在排队中...",      // 初始消息设为 正在排队中...
         "progress": 0,
         "createdAt": now_iso(),
         "format": format,
@@ -922,7 +923,7 @@ pub async fn export_messages(
     if !register_task(&state, &task).await {
         let err = ApiError::new(
             ErrorType::Api,
-            "运行中的导出任务已达到上限",
+            "排队中的导出任务已达到上限",
             "EXPORT_TASK_LIMIT_REACHED",
         )
         .with_status(axum::http::StatusCode::TOO_MANY_REQUESTS);
@@ -936,7 +937,7 @@ pub async fn export_messages(
         "downloadUrl": download_url,
         "filePath": file_path.to_string_lossy(),
         "messageCount": 0,
-        "status": "running",
+        "status": "queued",
         "startTime": req.filter.get("startTime").cloned().unwrap_or(Value::Null),
         "endTime": req.filter.get("endTime").cloned().unwrap_or(Value::Null),
     });
@@ -1008,7 +1009,8 @@ pub async fn export_streaming_zip(
         "fileName": file_name,
         "downloadUrl": download_url,
         "messageCount": 0,
-        "status": "running",
+        "status": "queued",             // 初始状态设为 queued
+        "message": "正在排队中...",      // 初始消息设为 正在排队中...
         "progress": 0,
         "createdAt": now_iso(),
         "format": "STREAMING_ZIP",
@@ -1018,7 +1020,7 @@ pub async fn export_streaming_zip(
     if !register_task(&state, &task).await {
         let err = ApiError::new(
             ErrorType::Api,
-            "运行中的导出任务已达到上限",
+            "排队中的导出任务已达到上限",
             "EXPORT_TASK_LIMIT_REACHED",
         )
         .with_status(axum::http::StatusCode::TOO_MANY_REQUESTS);
@@ -1032,7 +1034,7 @@ pub async fn export_streaming_zip(
         "downloadUrl": download_url,
         "filePath": file_path.to_string_lossy(),
         "messageCount": 0,
-        "status": "running",
+        "status": "queued",
         "startTime": req.filter.get("startTime").cloned().unwrap_or(Value::Null),
         "endTime": req.filter.get("endTime").cloned().unwrap_or(Value::Null),
         "streamingMode": true,
@@ -1100,7 +1102,8 @@ pub async fn export_streaming_jsonl(
         "fileName": dir_name,
         "downloadUrl": download_url,
         "messageCount": 0,
-        "status": "running",
+        "status": "queued",             // 初始状态设为 queued
+        "message": "正在排队中...",      // 初始消息设为 正在排队中...
         "progress": 0,
         "createdAt": now_iso(),
         "format": "STREAMING_JSONL",
@@ -1110,7 +1113,7 @@ pub async fn export_streaming_jsonl(
     if !register_task(&state, &task).await {
         let err = ApiError::new(
             ErrorType::Api,
-            "运行中的导出任务已达到上限",
+            "排队中的导出任务已达到上限",
             "EXPORT_TASK_LIMIT_REACHED",
         )
         .with_status(axum::http::StatusCode::TOO_MANY_REQUESTS);
@@ -1124,7 +1127,7 @@ pub async fn export_streaming_jsonl(
         "downloadUrl": download_url,
         "filePath": dir_path.to_string_lossy(),
         "messageCount": 0,
-        "status": "running",
+        "status": "queued",
         "startTime": req.filter.get("startTime").cloned().unwrap_or(Value::Null),
         "endTime": req.filter.get("endTime").cloned().unwrap_or(Value::Null),
         "streamingMode": true,
@@ -1157,7 +1160,7 @@ enum ExportMode {
     StreamingJsonl,
 }
 
-/// 后台导出主流程包装：负责取消 / 失败态与清理。
+/// 后台导出主流程包装：负责获取排队许可 / 取消 / 失败态与清理。
 async fn run_export_task(
     state: SharedState,
     task_id: String,
@@ -1177,28 +1180,49 @@ async fn run_export_task(
         flags.insert(task_id.clone(), Arc::clone(&cancel_flag));
     }
 
-    let result = if cancelled_before_registration {
+    // 收敛所有执行分支的结果：末尾统一释放路径、下发终态、清理跟踪状态。
+    // 排队前 / 排队中 / 执行中的「取消」统一交给末尾的 is_cancelled 判定。
+    let result: Result<(), String> = if cancelled_before_registration {
         Err("任务已被用户停止".to_string())
     } else {
-        process_export_task(
+        // 广播当前任务已进入排队状态
+        update_task(
             &state,
             &task_id,
-            &req,
-            &format,
-            &file_name,
-            mode,
-            &cancel_flag,
+            json!({
+                "status": "queued",
+                "progress": 0,
+                "message": "正在排队中..."
+            }),
         )
-        .await
+        .await;
+        broadcast_progress(&state, &task_id, 0, "正在排队中...", 0);
+
+        // 排队：异步获取并发名额，_permit 生命周期覆盖整个导出过程。
+        // 当前面的任务结束时自动唤醒队列中排在最前方的任务。
+        if let Ok(_permit) = state.export_semaphore.acquire().await {
+            if is_cancelled(&state, &task_id, &cancel_flag).await {
+                Err("任务已被用户停止".to_string())
+            } else {
+                process_export_task(
+                    &state,
+                    &task_id,
+                    &req,
+                    &format,
+                    &file_name,
+                    mode,
+                    &cancel_flag,
+                )
+                .await
+            }
+        } else {
+            Err("导出服务已关闭".to_string())
+        }
     };
-    release_export_path(&req.output_dir.join(&file_name));
+    release_export_path(req.output_dir.join(&file_name));
 
     if let Err(error) = result {
-        let was_cancelled = {
-            let cancelled = state.cancelled_task_ids.lock().await;
-            cancelled.contains(&task_id) || cancel_flag.load(Ordering::SeqCst)
-        };
-        if was_cancelled {
+        if is_cancelled(&state, &task_id, &cancel_flag).await {
             tracing::info!("[ApiServer] 导出任务已被用户停止: {task_id}");
             update_task(
                 &state,

--- a/qq-chat-export-server/src/api/state.rs
+++ b/qq-chat-export-server/src/api/state.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use serde_json::Value;
-use tokio::sync::{broadcast, Mutex};
+use tokio::sync::{broadcast, Mutex, Semaphore};
 
 use crate::api::response::{ApiError, ErrorType};
 use crate::napcat::NapCatBridgeClient;
@@ -32,6 +32,8 @@ pub const CACHE_EXPIRE_TIME_MS: i64 = 10 * 60 * 1000;
 
 /// WebSocket 广播消息。
 pub type WsMessage = String;
+
+pub const MAX_ACTIVE_EXPORT_TASKS: usize = 32;
 
 /// 服务器运行模式：`plugin`（NapCat 内启动，bridge 可用）或
 /// `standalone`（start-standalone 脚本直接拉起，没有 bridge，issue #668）。
@@ -95,6 +97,8 @@ pub struct AppState {
     pub ws_tx: broadcast::Sender<WsMessage>,
     /// 导出任务表（taskId → 任务 JSON）。
     pub export_tasks: Mutex<HashMap<String, Value>>,
+    /// 导出任务信号量（限制同时运行的导出任务数）。
+    pub export_semaphore: Arc<Semaphore>,
     /// issue #446：被用户主动停止的任务 ID。
     pub cancelled_task_ids: Mutex<std::collections::HashSet<String>>,
     /// issue #446：运行中任务的取消信号（taskId → 取消 flag）。

--- a/qq-chat-export-server/src/main.rs
+++ b/qq-chat-export-server/src/main.rs
@@ -162,6 +162,7 @@ async fn run() -> Result<(), String> {
         path_manager: Arc::clone(&path_manager),
         ws_tx,
         export_tasks: Mutex::new(export_tasks),
+        export_semaphore: Arc::new(tokio::sync::Semaphore::new(qce_server::api::state::MAX_ACTIVE_EXPORT_TASKS)),
         cancelled_task_ids: Mutex::new(std::collections::HashSet::new()),
         running_export_cancel_flags: Mutex::new(HashMap::new()),
         resource_file_cache: Mutex::new(HashMap::new()),


### PR DESCRIPTION
## 背景

当用户在前端勾选数百个聊天会话（例如 100~500 个群聊/好友）进行批量导出时，前端会连续向 `/api/messages/export` 发送导出请求。

在原先的实现中：
1. **任务并发数量过少**：`register_task` 限制 `active_count >= MAX_ACTIVE_EXPORT_TASKS (32)`，且新任务入表时直接赋予 `"running"` 状态。
2. **请求直接被丢弃**：当活跃任务数达到 32 后，第 33 个及后续请求全部在 `register_task` 返回 `false`，接口响应 `429 Too Many Requests (EXPORT_TASK_LIMIT_REACHED)`，导致前端发送的导出请求直接被服务端拒绝并丢弃。

---

## 解决方案

1. **允许请求先排队**：
   - 将任务入队容量提升为 `MAX_QUEUED_TASKS = 1000`，使数百个导出请求能够正常被系统接收并进入等待队列。
   - 任务初始状态设为 `"queued"`（进度 0%，提示 `正在排队中...`）。
2. **限制最多 32 个任务同时执行**：
   - 在 `AppState` 中引入 `export_semaphore: Arc<Semaphore>`（许可数保持为 32）。
   - 后台任务 `run_export_task` 在排队期间异步等待信号量许可（`acquire().await`），确保**任意时刻最多只有 32 个任务处于执行态（`process_export_task`）**。
   - 当正在运行的任务完成、失败或取消时，自动释放许可并按 FIFO 顺序唤醒下一个排队任务。
3. **完善排队中的取消与进度状态**：
   - 若排队中的任务被用户取消，在获得许可时能直接识别取消状态并立即让出许可，不执行无意义的导出流程。
   - 修复 `broadcast_progress` 在排队阶段被硬编码为 `"running"` 的问题，正确下发 `"queued"` 状态。

---

## 测试与验证

在 `qq-chat-export-server/src/api/routes/messages.rs` 中新增独立测试套件 `task_queue_tests`：

1. **`queue_handles_hundreds_of_tasks_without_dropping_requests`**：
   - 验证 300 个任务批量入队，无任何任务被抛弃且状态统一为 `queued`。
2. **`semaphore_limits_concurrent_running_tasks_while_draining_queue`**：
   - 验证 100 个任务并发等待并流转消费时，全生命周期内最高并发执行数严格 `<= 32`，全部完成且许可全数回收。
3. **`queued_task_cancelled_before_acquire_does_not_execute`**：
   - 验证排队中被取消的任务出队后立即跳过导出并释放许可。